### PR TITLE
sql: support full select syntax in subqueries

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -216,7 +216,7 @@ type col_name = {
 }
 and limit = (param_id * Type.t) list * bool
 and nested = source * (source * join_cond) list
-and source1 = [ `Select of select | `Table of string | `Nested of nested ]
+and source1 = [ `Select of select_full | `Table of string | `Nested of nested ]
 and source = source1 * string option
 and join_cond = [ `Cross | `Search of expr | `Default | `Natural | `Using of string list ]
 and select = {

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -191,7 +191,7 @@ join_cond: ON e=expr { `Search e }
          | (* *) { `Default }
 
 source1: IDENT { `Table $1 }
-       | LPAREN s=select_core RPAREN { `Select s }
+       | LPAREN s=select_stmt RPAREN { `Select s }
        | LPAREN s=table_list RPAREN { `Nested s }
 
 source: src=source1 alias=maybe_as { src, alias }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -292,7 +292,7 @@ and eval_select env { columns; from; where; group; having; } =
 and resolve_source env (x,alias) =
   match x with
   | `Select select ->
-    let (s,p,_,_) = eval_select env select in
+    let (s,p,_) = eval_select_full env select in
     s, p, (match alias with None -> [] | Some name -> [name,s])
   | `Nested s ->
     let (env,p) = eval_nested env (Some s) in

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -16,4 +16,25 @@
    <value name="d_id" type="Int"/>
   </out>
  </stmt>
+ <stmt name="select_3" sql="SELECT x.* FROM (&#x0A;  SELECT 1, 'foo', NULL&#x0A;) x" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="_0" type="Int"/>
+   <value name="_1" type="Text"/>
+   <value name="_2" type="Any"/>
+  </out>
+ </stmt>
+ <stmt name="select_4" sql="SELECT x.* FROM (&#x0A;  SELECT 1, 2 UNION&#x0A;  SELECT 3, 4&#x0A;) x" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="_0" type="Int"/>
+   <value name="_1" type="Int"/>
+  </out>
+ </stmt>
+ <stmt name="select_5" sql="SELECT x.* FROM (&#x0A;  SELECT 'foo' UNION ALL&#x0A;  SELECT 'foo'&#x0A;) x" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="_0" type="Text"/>
+  </out>
+ </stmt>
 </sqlgg>

--- a/test/subquery.sql
+++ b/test/subquery.sql
@@ -17,3 +17,17 @@ LEFT JOIN `detail` d ON d.`id` = (
   ORDER BY dd.`id` DESC
   LIMIT 1
 );
+
+SELECT x.* FROM (
+  SELECT 1, 'foo', NULL
+) x;
+
+SELECT x.* FROM (
+  SELECT 1, 2 UNION
+  SELECT 3, 4
+) x;
+
+SELECT x.* FROM (
+  SELECT 'foo' UNION ALL
+  SELECT 'foo'
+) x;


### PR DESCRIPTION
The following worked:
```
$ sqlgg -
select 1 union select 2;
```
The following did not work because subqueries were limited to select_core grammar:
```
$ sqlgg -
select * from (select 1 union select 2);
==> select * from (select 1 union select 2)
Position 1:29 Tokens: union select 2)
Error: Sqlgg.Sql_parser.MenhirBasics.Error
Errors encountered, no code generated
```