### PR TITLE
Batch insert

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -246,6 +246,7 @@ and var =
 | SingleIn of param
 | ChoiceIn of { param: param_id; kind : [`In | `NotIn]; vars: var list }
 | Choice of param_id * ctor list
+| TupleList of param_id * schema
 [@@deriving show]
 type vars = var list [@@deriving show]
 
@@ -323,6 +324,7 @@ type insert_action =
   target : table_name;
   action : [ `Set of assignments option
            | `Values of (string list option * [ `Expr of expr | `Default ] list list option) (* column names * list of value tuples *)
+           | `Param of (string list option * param_id)
            | `Select of (string list option * select_full) ];
   on_duplicate : assignments option;
 }

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -112,6 +112,10 @@ statement: CREATE ioption(temporary) TABLE ioption(if_not_exists) name=table_nam
               {
                 Insert { target; action=`Values (names, values); on_duplicate=ss; }
               }
+         | insert_cmd target=table_name names=sequence(IDENT)? VALUES p=PARAM ss=on_duplicate?
+              {
+                Insert { target; action=`Param (names, p); on_duplicate=ss; }
+              }
          | insert_cmd target=table_name names=sequence(IDENT)? select=maybe_parenth(select_stmt) ss=on_duplicate?
               {
                 Insert { target; action=`Select (names, select); on_duplicate=ss; }

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -239,6 +239,14 @@ let rec inparams_only l =
       | _ -> [])
     l
 
+let tuplelist_params_only l =
+  List.concat @@
+  List.map
+    (function
+      | Sql.TupleList (p, _) -> [Sql.new_param p Any]
+      | _ -> [])
+    l
+
 end
 
 module type Generator = sig

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -239,14 +239,6 @@ let rec inparams_only l =
       | _ -> [])
     l
 
-let tuplelist_params_only l =
-  List.concat @@
-  List.map
-    (function
-      | Sql.TupleList (p, _) -> [Sql.new_param p Any]
-      | _ -> [])
-    l
-
 end
 
 module type Generator = sig

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -73,6 +73,7 @@ type sql =
   | Dynamic of (Sql.param_id * (Sql.param_id * Sql.var list option * sql list) list)
   | SubstIn of Sql.param
   | DynamicIn of Sql.param_id * [`In | `NotIn] * sql list
+  | SubstTuple of Sql.param_id * Sql.schema
 
 let substitute_vars s vars subst_param =
   let rec loop acc i parami vars =
@@ -129,6 +130,12 @@ let substitute_vars s vars subst_param =
       assert (i2 > i1);
       assert (i1 > i);
       let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
+      loop acc i2 parami tl
+    | TupleList (id, schema) :: tl ->
+      let (i1,i2) = id.pos in
+      assert (i2 > i1);
+      assert (i1 > i);
+      let acc = SubstTuple (id, schema) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
       loop acc i2 parami tl
   in
   let (acc,last) = loop [] 0 0 vars in
@@ -203,7 +210,8 @@ let rec find_param_ids l =
     (function
       | Sql.Single p | SingleIn p -> [ p.id ]
       | Choice (id,_) -> [ id ]
-      | ChoiceIn { param; vars; _ } -> find_param_ids vars @ [param])
+      | ChoiceIn { param; vars; _ } -> find_param_ids vars @ [param]
+      | TupleList (id, _) -> [ id ])
     l
 
 let names_of_vars l =
@@ -218,7 +226,8 @@ let rec params_only l =
       | Sql.Single p -> [p]
       | SingleIn _ -> []
       | ChoiceIn { vars; _ } -> params_only vars
-      | Choice _ -> fail "dynamic choices not supported for this host language")
+      | Choice _ -> fail "dynamic choices not supported for this host language"
+      | TupleList _ -> [])
     l
 
 let rec inparams_only l =

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -339,7 +339,7 @@ let gen_tuple_printer _label schema =
        (fun idx { name; domain; _ } ->
           (if idx = 0 then "" else {|Buffer.add_string _sqlgg_b ", "; |}) ^
           sprintf
-            {|Buffer.add_string _sqlgg_b T.Types.%s.to_literal %s;|}
+            {|Buffer.add_string _sqlgg_b (T.Types.%s.to_literal %s);|}
             (in_var_module name domain) name)
        schema)
 

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -64,6 +64,7 @@ let get_sql_string stmt =
   let rec map i = function
   | Static s -> s
   | SubstIn param -> "@@" ^ show_param_name param i (* TODO join text and prepared params earlier for single indexing *)
+  | SubstTuple (id, _) -> "@@" ^ make_param_name i id
   | DynamicIn (_p, _, sqls) -> String.concat "" @@ List.map (map 0 ) sqls
   | Dynamic _ -> fail "dynamic choice not supported for xml output"
   in

--- a/src/test.ml
+++ b/src/test.ml
@@ -26,7 +26,7 @@ let do_test sql ?kind schema params =
   let stmt = parse sql in
   assert_equal ~msg:"schema" ~printer:Sql.Schema.to_string schema stmt.schema;
   assert_equal ~msg:"params" ~cmp:cmp_params ~printer:Sql.show_params params
-    (List.map (function Single p -> p | SingleIn _ | Choice _ | ChoiceIn _ -> assert false) stmt.vars);
+    (List.map (function Single p -> p | SingleIn _ | Choice _ | ChoiceIn _ | TupleList _ -> assert false) stmt.vars);
   match kind with
   | Some k -> assert_equal ~msg:"kind" ~printer:[%derive.show: Stmt.kind] k stmt.kind
   | None -> ()

--- a/test/insert.sql
+++ b/test/insert.sql
@@ -1,3 +1,8 @@
 create table test ( foo integer not null default 12345 );
 insert into test ( foo ) values ( default );
 select * from test where foo != default(foo);
+insert into test VALUES @x;
+insert into test(foo) VALUES @x;
+create table test2 ( foo integer not null default 12345, bar text not null default '');
+insert into test2 VALUES @x;
+insert into test2(foo, bar) VALUES @x ON DUPLICATE KEY UPDATE bar = @on_collision;

--- a/test/out/inargument.xml
+++ b/test/out/inargument.xml
@@ -11,7 +11,7 @@
  </stmt>
  <stmt name="find" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="Int" set="true"/>
+   <value name="ids" type="set(Int)"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -20,7 +20,7 @@
  </stmt>
  <stmt name="get" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="Int" set="true"/>
+   <value name="ids" type="set(Int)"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -29,8 +29,8 @@
  </stmt>
  <stmt name="find2" sql="SELECT * FROM foo&#x0A;WHERE (id IN @@ids) AND foo NOT IN @@foos" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="ids" type="Int" set="true"/>
-   <value name="foos" type="Text" set="true"/>
+   <value name="ids" type="set(Int)"/>
+   <value name="foos" type="set(Text)"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -40,7 +40,7 @@
  <stmt name="find_with_bar" sql="SELECT * FROM foo&#x0A;WHERE CONCAT(foo, @suffix) IN @@foos_with_suffix" category="DQL" kind="select" cardinality="n">
   <in>
    <value name="suffix" type="Text"/>
-   <value name="foos_with_suffix" type="Text" set="true"/>
+   <value name="foos_with_suffix" type="set(Text)"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -49,8 +49,8 @@
  </stmt>
  <stmt name="get2" sql="SELECT * FROM foo&#x0A;WHERE id IN @@ids AND (foo NOT IN @@foos)&#x0A;LIMIT 1" category="DQL" kind="select" cardinality="0,1">
   <in>
-   <value name="ids" type="Int" set="true"/>
-   <value name="foos" type="Text" set="true"/>
+   <value name="ids" type="set(Int)"/>
+   <value name="foos" type="set(Text)"/>
   </in>
   <out>
    <value name="id" type="Int"/>
@@ -59,9 +59,9 @@
  </stmt>
  <stmt name="join" sql="SELECT *&#x0A;FROM foo f JOIN bar b ON f.id = b.foo_id&#x0A;WHERE b.baz IN @@bazz AND b.baz NOT IN @@notbazz AND LENGTH(f.foo) IN @@lengths" category="DQL" kind="select" cardinality="n">
   <in>
-   <value name="bazz" type="Text" set="true"/>
-   <value name="notbazz" type="Text" set="true"/>
-   <value name="lengths" type="Int" set="true"/>
+   <value name="bazz" type="set(Text)"/>
+   <value name="notbazz" type="set(Text)"/>
+   <value name="lengths" type="set(Int)"/>
   </in>
   <out>
    <value name="id" type="Int"/>

--- a/test/out/insert.xml
+++ b/test/out/insert.xml
@@ -15,6 +15,41 @@
    <value name="foo" type="Int"/>
   </out>
  </stmt>
+ <stmt name="insert_test_3" sql="insert into test VALUES @@@x" category="DML" kind="insert" target="test" cardinality="0">
+  <in>
+   <value name="x" type="Any" tuplelist="true"/>
+  </in>
+  <out/>
+ </stmt>
+ <stmt name="insert_test_4" sql="insert into test(foo) VALUES @@@x" category="DML" kind="insert" target="test" cardinality="0">
+  <in>
+   <value name="x" type="Any" tuplelist="true"/>
+  </in>
+  <out/>
+ </stmt>
+ <stmt name="create_test2" sql="create table test2 ( foo integer not null default 12345, bar text not null default '')" category="DDL" kind="create" target="test2" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="insert_test2_6" sql="insert into test2 VALUES @@@x" category="DML" kind="insert" target="test2" cardinality="0">
+  <in>
+   <value name="x" type="Any" tuplelist="true"/>
+  </in>
+  <out/>
+ </stmt>
+ <stmt name="insert_test2_7" sql="insert into test2(foo, bar) VALUES @@@x ON DUPLICATE KEY UPDATE bar = @on_collision" category="DML" kind="insert" target="test2" cardinality="0">
+  <in>
+   <value name="x" type="Any" tuplelist="true"/>
+   <value name="on_collision" type="Text"/>
+  </in>
+  <out/>
+ </stmt>
+ <table name="test2">
+  <schema>
+   <value name="foo" type="Int"/>
+   <value name="bar" type="Text"/>
+  </schema>
+ </table>
  <table name="test">
   <schema>
    <value name="foo" type="Int"/>

--- a/test/out/insert.xml
+++ b/test/out/insert.xml
@@ -17,13 +17,13 @@
  </stmt>
  <stmt name="insert_test_3" sql="insert into test VALUES @@@x" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="x" type="Any" tuplelist="true"/>
+   <value name="x" type="list(Int)"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_test_4" sql="insert into test(foo) VALUES @@@x" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="x" type="Any" tuplelist="true"/>
+   <value name="x" type="list(Int)"/>
   </in>
   <out/>
  </stmt>
@@ -33,13 +33,13 @@
  </stmt>
  <stmt name="insert_test2_6" sql="insert into test2 VALUES @@@x" category="DML" kind="insert" target="test2" cardinality="0">
   <in>
-   <value name="x" type="Any" tuplelist="true"/>
+   <value name="x" type="list(Int, Text)"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert_test2_7" sql="insert into test2(foo, bar) VALUES @@@x ON DUPLICATE KEY UPDATE bar = @on_collision" category="DML" kind="insert" target="test2" cardinality="0">
   <in>
-   <value name="x" type="Any" tuplelist="true"/>
+   <value name="x" type="list(Int, Text)"/>
    <value name="on_collision" type="Text"/>
   </in>
   <out/>


### PR DESCRIPTION
Support batch insert (using a tuple list) with syntax `INSERT INTO foo(x, y) VALUES @foos` or `INSERT INTO foo VALUES @foos`.

Notes
- empty tuple lists are supported
- the generated code performs textual substitution and builds the SQL in linear space/time
- the param is shown as having type `Any` in the XML output

The generated code looks like

```ocaml
  let insert_set db ~foos ~duplicate =
    let set_params stmt =
      let p = T.start_params stmt (1) in
      begin match duplicate with None -> T.set_param_null p | Some v -> T.set_param_Text p v end;
      T.finish_params p
    in
    ( match foos with [] -> T.execute db "-- empty insert" T.no_params | _ :: _ -> T.execute db ("INSERT INTO foo(id, foo) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, foo) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal foo); Buffer.add_char _sqlgg_b ')') foos; Buffer.contents _sqlgg_b) ^ "\n\
ON DUPLICATE KEY UPDATE foo = ?") set_params )
```

given

```sql
CREATE TABLE foo(
    id INTEGER PRIMARY KEY,
    foo TEXT NULL
);

-- @insert_set
INSERT INTO foo(id, foo) VALUES @foos
ON DUPLICATE KEY UPDATE foo = @duplicate;
```