### PR TITLE
Add a -tracing flag that generates debugging/tracing calls

### DIFF
--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -126,3 +126,31 @@ module type M_io = sig
   val execute : [>`WR] connection -> string -> (statement -> result IO.future) -> int64 IO.future
 
 end
+
+module type M_tracing = sig
+
+  include M
+
+  val tracing_span :
+    ?operation:string ->
+    ?tables:string list ->
+    statement:string ->
+    string (* span-name *) ->
+    (unit -> 'r) ->
+    'r
+
+end
+
+module type M_tracing_io = sig
+
+  include M_io
+
+  val tracing_span :
+    ?operation:string ->
+    ?tables:string list ->
+    statement:string ->
+    string (* span-name *) ->
+    (unit -> 'r IO.future) ->
+    'r IO.future
+
+end

--- a/lib/stmt.ml
+++ b/lib/stmt.ml
@@ -24,6 +24,19 @@ type kind = | Select of cardinality
             | Other
             [@@deriving show {with_path=false}]
 
+let kind_to_operation_name = function
+| Select _ -> Some "SELECT"
+| Insert _ -> Some "INSERT"
+| Create _ -> Some "CREATE TABLE"
+| CreateIndex _ -> Some "CREATE INDEX"
+| Update _ -> Some "UPDATE"
+| Delete _ -> Some "DELETE"
+| Alter _ -> Some "ALTER TABLE"
+| Drop _ -> Some "DROP TABLE"
+| CreateRoutine (_, Some _) -> Some "CREATE FUNCTION"
+| CreateRoutine (_, None) -> Some "CREATE PROCEDURE"
+| Other -> None
+
 type category = DDL | DQL | DML | DCL | TCL | OTHER [@@deriving show {with_path=false}, enum]
 
 let all_categories = List.init (max_category - min_category) (fun i -> Option.get @@ category_of_enum @@ min_category + i)

--- a/lib/stmt.ml
+++ b/lib/stmt.ml
@@ -20,7 +20,7 @@ type kind = | Select of cardinality
             | Delete of Sql.table_name list
             | Alter of Sql.table_name list
             | Drop of Sql.table_name
-            | CreateRoutine of string
+            | CreateRoutine of string * Sql.Type.t option
             | Other
             [@@deriving show {with_path=false}]
 

--- a/lib/stmt.ml
+++ b/lib/stmt.ml
@@ -37,6 +37,19 @@ let kind_to_operation_name = function
 | CreateRoutine (_, None) -> Some "CREATE PROCEDURE"
 | Other -> None
 
+let kind_to_table_names = function
+| Create t -> [t]
+| CreateIndex _ -> [] (* FIXME *)
+| Update (Some t) -> [t]
+| Update None -> []
+| Insert (_,t) -> [t]
+| Delete ts -> ts
+| Alter ts -> ts
+| Drop t -> [t]
+| Select _  ->  [] (* FIXME *)
+| CreateRoutine (_s, _ret) -> []
+| Other -> []
+
 type category = DDL | DQL | DML | DCL | TCL | OTHER [@@deriving show {with_path=false}, enum]
 
 let all_categories = List.init (max_category - min_category) (fun i -> Option.get @@ category_of_enum @@ min_category + i)

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -508,8 +508,8 @@ let eval (stmt:Sql.stmt) =
     let params = update_tables sources ss w in
     [], params, Update None
   | Select select -> eval_select_full empty_env select
-  | CreateRoutine (name,_,_) ->
-    [], [], CreateRoutine name
+  | CreateRoutine (name,ret,_) ->
+    [], [], CreateRoutine (name, ret)
 
 (* FIXME unify each choice separately *)
 let unify_params l =

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -95,6 +95,7 @@ let main () =
     "-gen", Arg.String set_out, "cxx|caml|java|xml|csharp|none Set output language (default: none)";
     "-name", Arg.String (fun x -> name := x), "<identifier> Set output module name (default: sqlgg)";
     "-params", Arg.String set_params_mode, "named|unnamed|oracle|postgresql|none Output query parameters substitution (default: none)";
+    "-tracing", Arg.Unit (fun () -> Sqlgg_config.tracing := true), "invoke a tracing callback on every query (default: false)";
     "-debug", Arg.Int Sqlgg_config.set_debug_level, "<N> set debug level";
     "-no-header", Arg.Unit (fun () -> Sqlgg_config.gen_header := None),
       "do not put version header in generated output";

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -63,7 +63,7 @@ let choose_name props kind index =
   | Alter t -> sprintf "alter_%s_%u" (String.concat "_" @@ List.map fix t) index
   | Drop t -> sprintf "drop_%s" (fix t)
   | Select _  -> sprintf "select_%u" index
-  | CreateRoutine s -> sprintf "create_routine_%s" (fix' s)
+  | CreateRoutine (s, _ret) -> sprintf "create_routine_%s" (fix' s)
   | Other -> sprintf "statement_%u" index
   in
   make_name props name

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -97,19 +97,19 @@ let generate_code (x,_) index stmt =
   let sql = get_sql_string stmt in
   let attrs =
     match stmt.kind with
-    | Select `Nat      -> ["kind", "select"; "cardinality", "n"]
-    | Select `Zero_one -> ["kind", "select"; "cardinality", "0,1"]
-    | Select `One      -> ["kind", "select"; "cardinality", "1"]
-    | Insert (_, t)    -> ["kind", "insert"; "target", Sql.show_table_name t; "cardinality", "0"]
-    | Create t         -> ["kind", "create"; "target", Sql.show_table_name t; "cardinality", "0"]
-    | CreateIndex t    -> ["kind", "create_index"; "target",t;"cardinality","0"]
-    | Update None      -> ["kind", "update"; "cardinality", "0"]
-    | Update (Some t)  -> ["kind", "update"; "target", Sql.show_table_name t; "cardinality", "0"]
-    | Delete t         -> ["kind", "delete"; "target", String.concat "," @@ List.map Sql.show_table_name t; "cardinality", "0"]
-    | Alter t          -> ["kind", "alter"; "target", String.concat "," @@ List.map Sql.show_table_name t; "cardinality", "0"]
-    | Drop t           -> ["kind", "drop"; "target", Sql.show_table_name t; "cardinality", "0"]
-    | CreateRoutine s  -> ["kind", "create_routine"; "target", s]
-    | Other            -> ["kind", "other"]
+    | Select `Nat         -> ["kind", "select"; "cardinality", "n"]
+    | Select `Zero_one    -> ["kind", "select"; "cardinality", "0,1"]
+    | Select `One         -> ["kind", "select"; "cardinality", "1"]
+    | Insert (_, t)       -> ["kind", "insert"; "target", Sql.show_table_name t; "cardinality", "0"]
+    | Create t            -> ["kind", "create"; "target", Sql.show_table_name t; "cardinality", "0"]
+    | CreateIndex t       -> ["kind", "create_index"; "target",t;"cardinality","0"]
+    | Update None         -> ["kind", "update"; "cardinality", "0"]
+    | Update (Some t)     -> ["kind", "update"; "target", Sql.show_table_name t; "cardinality", "0"]
+    | Delete t            -> ["kind", "delete"; "target", String.concat "," @@ List.map Sql.show_table_name t; "cardinality", "0"]
+    | Alter t             -> ["kind", "alter"; "target", String.concat "," @@ List.map Sql.show_table_name t; "cardinality", "0"]
+    | Drop t              -> ["kind", "drop"; "target", Sql.show_table_name t; "cardinality", "0"]
+    | CreateRoutine (s,_) -> ["kind", "create_routine"; "target", s]
+    | Other               -> ["kind", "other"]
   in
   let nodes = [ input; output] in
   x := Node ("stmt", ("name",name)::("sql",sql)::("category",show_category @@ category_of_stmt_kind stmt.kind)::attrs, nodes) :: !x

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -16,3 +16,6 @@ let debug1 () = !debug_level > 0
 let gen_header : [ `Full | `Without_timestamp | `Static ] option ref = ref (Some `Full)
 
 let include_category : [ `All | `None | `Only of Stmt.category list | `Except of Stmt.category list ] ref = ref `All
+
+
+let tracing : bool ref = ref false


### PR DESCRIPTION
The output will generally differ in a call to `T.tracing_span ~operation ~tables ~statement name @@ fun () -> …`, something like this:

```diff
index 661f0dd72f7..506d44aeca3 100644
--- a/db_gen/sth.ml
+++ b/db_gen/sth.ml
@@ -2,7 +2,7 @@
 (*  *)
 (* generated by sqlgg *)
 
-module Make (T : Sqlgg_traits.M_io) = struct
+module Make (T : Sqlgg_traits.M_tracing_io) = struct
 
   module IO = T.IO
 
@@ -20,6 +20,7 @@ WHERE user_id = ?")
       T.set_param_Int p user_id;
       T.finish_params p
     in
+    T.tracing_span ~operation:"SELECT" ~statement:__sqlgg_sql "some_procedure" @@ fun () ->
     T.select db __sqlgg_sql set_params invoke_callback
 
   module Fold = struct
@@ -38,6 +39,7 @@ WHERE user_id = ?")
         T.finish_params p
       in
       let r_acc = ref acc in
+      T.tracing_span ~operation:"SELECT" ~statement:__sqlgg_sql "some_procedure" @@ fun () ->
       IO.(>>=) (T.select db __sqlgg_sql set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
  ...
 ```