### PR TITLE
Reuse inferred param_types in the usage below the body

### DIFF
--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -7,13 +7,13 @@
  </stmt>
  <stmt name="insert1" sql="INSERT INTO `test` SET&#x0A;  `nullable` = CASE @maybe WHEN 0 THEN NULL ELSE @maybe END&#x0A;" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="maybe" type="Int"/>
+   <value name="maybe" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert2" sql="INSERT INTO `test` SET `nullable` = NULLIF(@maybe, 0)" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="maybe" type="Int"/>
+   <value name="maybe" type="Int" nullable="true"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/null.xml
+++ b/test/out/null.xml
@@ -7,13 +7,13 @@
  </stmt>
  <stmt name="insert1" sql="INSERT INTO `test` SET&#x0A;  `nullable` = CASE @maybe WHEN 0 THEN NULL ELSE @maybe END&#x0A;" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="maybe" type="Int" nullable="true"/>
+   <value name="maybe" type="Int"/>
   </in>
   <out/>
  </stmt>
  <stmt name="insert2" sql="INSERT INTO `test` SET `nullable` = NULLIF(@maybe, 0)" category="DML" kind="insert" target="test" cardinality="0">
   <in>
-   <value name="maybe" type="Int" nullable="true"/>
+   <value name="maybe" type="Int"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/use_inferred_type.xml
+++ b/test/out/use_inferred_type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_some_table" sql="CREATE TABLE IF NOT EXISTS `some_table` (&#x0A; `id` INTEGER UNSIGNED PRIMARY KEY AUTO_INCREMENT,&#x0A; `some_field` TEXT NULL,&#x0A; `some_field_2` TEXT NULL DEFAULT NULL&#x0A;)" category="DDL" kind="create" target="some_table" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create" sql="INSERT INTO some_table (&#x0A;  some_field,&#x0A;  some_field_2&#x0A;) VALUES (&#x0A;  @some_field,&#x0A;  case when @some_field = 'TEST' then 'A' else NULL end&#x0A;)" category="DML" kind="insert" target="some_table" cardinality="0">
+  <in>
+   <value name="some_field" type="Text" nullable="true"/>
+  </in>
+  <out/>
+ </stmt>
+ <table name="some_table">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="some_field" type="Text" nullable="true"/>
+   <value name="some_field_2" type="Text" nullable="true"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/use_inferred_type.sql
+++ b/test/use_inferred_type.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `some_table` (
+ `id` INTEGER UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+ `some_field` TEXT NULL,
+ `some_field_2` TEXT NULL DEFAULT NULL
+);
+
+-- @create
+INSERT INTO some_table (
+  some_field,
+  some_field_2
+) VALUES (
+  @some_field,
+  case when @some_field = 'TEST' then 'A' else NULL end
+);


### PR DESCRIPTION
We let users work with a variable as if it has multiple types.

For example:

**Our schema:** 

```sql
-- @create_some_table
CREATE TABLE IF NOT EXISTS `some_table` (
 `id` int NOT NULL,
 `some_field` TEXT NULL,
 `some_field_2` TEXT NULL DEFAULT NULL
) 
```

**Our query**

```sql
-- @create
INSERT INTO some_table (
  some_field,
  some_field_2
) VALUES (
  @some_field,
  case when @some_field = 'TEST' then 'A' else NULL end
);
```

And in this case it generates:

```OCaml
  let create db ~some_field =
    let set_params stmt =
      let p = T.start_params stmt (19) in
      begin match some_field with None -> T.set_param_null p | Some v -> T.set_param_Text p v end;
      T.set_param_Text p some_field; 
      T.finish_params p
    in
    T.execute db ("INSERT INTO some_table (\n\
 some_field,
  some_field_2
) VALUES (
  ?,\n\
  ?,\n\
        case when ? like 'TEST' then 'A' else NULL end,\n\
)") set_params
```
This PR fixes it.