### PR TITLE
Reuse inferred params types

### DIFF
--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -13,3 +13,12 @@ let fail fmt = Printf.ksprintf failwith fmt
 let failed ~at fmt = Printf.ksprintf (fun s -> raise (At (at, Failure s))) fmt
 let printfn fmt = Printf.ksprintf print_endline fmt
 let eprintfn fmt = Printf.ksprintf prerr_endline fmt
+
+module Option = struct
+  include Option
+
+  let bind f o =
+    match o with
+    | None -> None
+    | Some x -> f x
+end

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -155,10 +155,7 @@ and assign_types inferred_param_types expr =
   let rec typeof_ (e:res_expr) = (* FIXME simplify *)
     match e with
     | ResValue t -> e, `Ok t
-    | ResParam p -> 
-      (* print_endline "typeof_"; *)
-      (* e |> Format.asprintf "%a" pp_res_expr |> print_endline; *)
-      e, `Ok p.typ
+    | ResParam p
     | ResInparam p -> e, `Ok p.typ
     | ResInChoice (n, k, e) -> let e, t = typeof e in ResInChoice (n, k, e), t
     | ResChoices (n,l) ->
@@ -643,7 +640,6 @@ let complete_sql kind sql =
   | _ -> (sql,[])
 
 let parse sql =
-  let stmt =  Parser.parse_stmt sql in 
-  let (schema,p1,kind) = eval @@ stmt in
+  let (schema,p1,kind) = eval @@ Parser.parse_stmt sql in
   let (sql,p2) = complete_sql kind sql in
   (sql, schema, unify_params (p1 @ p2), kind)


### PR DESCRIPTION
We let users work with a variable as if it has multiple types.

For example:

**Our schema:** 

```sql
-- @create_some_table
CREATE TABLE IF NOT EXISTS `some_table` (
 `id` int NOT NULL,
 `some_field` TEXT NULL,
 `some_field_2` TEXT NULL DEFAULT NULL
) 
```

**Our query**

```sql
-- @create
INSERT INTO some_table (
  some_field,
  some_field_2
) VALUES (
  @some_field,
  case when @some_field = 'TEST' then 'A' else NULL end
);
```

And in this case it generates:

```OCaml
  let create db ~some_field =
    let set_params stmt =
      let p = T.start_params stmt (19) in
      begin match some_field with None -> T.set_param_null p | Some v -> T.set_param_Text p v end;
      T.set_param_Text p some_field; 
      T.finish_params p
    in
    T.execute db ("INSERT INTO some_table (\n\
 some_field,
  some_field_2
) VALUES (
  ?,\n\
  ?,\n\
        case when ? like 'TEST' then 'A' else NULL end,\n\
)") set_params
```
This PR fixes it.