### PR TITLE
Possibility to set type of params manually

### DIFF
--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -301,6 +301,7 @@ ruleMain = parse
 
   | "?" { PARAM { label=None; pos = pos lexbuf } }
   | [':' '@'] (ident as str) { PARAM { label = Some str; pos = pos lexbuf } }
+  | "::" { TWO_TIMES_COLON }
 
   | '"' { keep_lexeme_start lexbuf (fun () -> ident (ruleInQuotes "" lexbuf)) }
   | "'" { keep_lexeme_start lexbuf (fun () -> TEXT (ruleInSingleQuotes "" lexbuf)) }


### PR DESCRIPTION
Now we can specify parameters with the type with the following syntax:
`(@param_name :: Type)` or `(@param_name :: Type Null)` if param is nullable.

Example:

Schema:
```sql
CREATE TABLE test (x INT NULL DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8
```
And query
```sql
SELECT * FROM test WHERE x = (@x_arg :: Int)
```