### PR TITLE
Make subqueries nullable and consider count 

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -110,7 +110,9 @@ struct
   type tyvar = Typ of t | Var of int
   let string_of_tyvar = function Typ t -> show t | Var i -> sprintf "'%c" (Char.chr @@ Char.code 'a' + i)
 
-  type agg_fun = Self | Count | Avg (* max, min | count | avg *)
+  type agg_fun = Self (* self means that it returns the same type what aggregated columns have. ie: max, min *) 
+    | Count (* count it's count function which never returns null  *) 
+    | Avg (* avg it's avg function that returns float *)
 
   type func =
   | Agg of agg_fun (* 'a -> 'a | 'a -> t *)

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -116,7 +116,7 @@ struct
   | Multi of tyvar * tyvar (* 'a -> ... -> 'a -> 'b *)
   | Coalesce of tyvar * tyvar
   | Comparison
-  | Ret of kind (* _ -> t *) (* TODO eliminate *)
+  | Ret of t (* _ -> t *) (* TODO eliminate *)
   | F of tyvar * tyvar list
 
   let monomorphic ret args = F (Typ ret, List.map (fun t -> Typ t) args)
@@ -129,7 +129,7 @@ struct
   function
   | Agg -> fprintf pp "|'a| -> 'a"
   | Group ret -> fprintf pp "|_| -> %s" (show ret)
-  | Ret ret -> fprintf pp "_ -> %s" (show_kind ret)
+  | Ret ret -> fprintf pp "_ -> %s" (show ret)
   | F (ret, args) -> fprintf pp "%s -> %s" (String.concat " -> " @@ List.map string_of_tyvar args) (string_of_tyvar ret)
   | Multi (ret, each_arg) | Coalesce (ret, each_arg) -> fprintf pp "{ %s }+ -> %s" (string_of_tyvar each_arg) (string_of_tyvar ret)
   | Comparison -> fprintf pp "'a -> 'a -> %s" (show_kind Bool)

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -167,7 +167,7 @@ statement: CREATE ioption(temporary) TABLE ioption(if_not_exists) name=table_nam
            AS? routine_body
            routine_extra?
               {
-                Function.add (List.length params) (Ret ret) name.tn; (* FIXME store function namespace *)
+                Function.add (List.length params) (Ret (depends ret)) name.tn; (* FIXME store function namespace *)
                 CreateRoutine (name, Some ret, params)
               }
          | CREATE or_replace? PROCEDURE name=table_name params=sequence(proc_parameter)
@@ -175,7 +175,7 @@ statement: CREATE ioption(temporary) TABLE ioption(if_not_exists) name=table_nam
            AS? routine_body
            routine_extra?
               {
-                Function.add (List.length params) (Ret Any) name.tn; (* FIXME void *)
+                Function.add (List.length params) (Ret (depends Any)) name.tn; (* FIXME void *)
                 CreateRoutine (name, None, params)
               }
 
@@ -392,10 +392,10 @@ insert_expr: e=expr { `Expr e }
            | DEFAULT { `Default }
 
 expr:
-      e1=expr numeric_bin_op e2=expr %prec PLUS { Fun ((Ret Any),[e1;e2]) } (* TODO default Int *)
-    | MOD LPAREN e1=expr COMMA e2=expr RPAREN { Fun ((Ret Any),[e1;e2]) } (* mysql special *)
-    | e1=expr NUM_DIV_OP e2=expr %prec PLUS { Fun ((Ret Float),[e1;e2]) }
-    | e1=expr DIV e2=expr %prec PLUS { Fun ((Ret Int),[e1;e2]) }
+      e1=expr numeric_bin_op e2=expr %prec PLUS { Fun ((Ret (depends Any)),[e1;e2]) } (* TODO default Int *)
+    | MOD LPAREN e1=expr COMMA e2=expr RPAREN { Fun ((Ret (depends Any)),[e1;e2]) } (* mysql special *)
+    | e1=expr NUM_DIV_OP e2=expr %prec PLUS { Fun ((Ret (depends Float)),[e1;e2]) }
+    | e1=expr DIV e2=expr %prec PLUS { Fun ((Ret (depends Int)),[e1;e2]) }
     | e1=expr boolean_bin_op e2=expr %prec AND { Fun ((fixed Bool [Bool;Bool]),[e1;e2]) }
     | e1=expr comparison_op anyall? e2=expr %prec EQUAL { Fun (Comparison, [e1; e2]) }
     | e1=expr NOT_DISTINCT_OP anyall? e2=expr %prec EQUAL { poly (depends Bool) [e1;e2]}
@@ -441,7 +441,7 @@ expr:
     | JSON_SET LPAREN j=expr COMMA k=expr COMMA v=expr RPAREN { Fun (Function.lookup "json_set" 3, [j;k;v]) }
     | CONVERT LPAREN e=expr USING IDENT RPAREN { e }
     | CONVERT LPAREN e=expr COMMA t=sql_type RPAREN
-    | CAST LPAREN e=expr AS t=sql_type RPAREN { Fun (Ret t, [e]) }
+    | CAST LPAREN e=expr AS t=sql_type RPAREN { Fun (Ret (depends t), [e]) }
     | f=table_name LPAREN p=func_params RPAREN { Fun (Function.lookup f.tn (List.length p), p) } (* FIXME lookup functions with namespace *)
     | e=expr IS NOT? NULL { poly (strict Bool) [e] }
     | e1=expr IS NOT? distinct_from? e2=expr { poly (strict Bool) [e1;e2] }


### PR DESCRIPTION
### Description

This PR adds proper support of nullability inferring of subqueries

Examples:

DDL:
```sql
 CREATE TABLE table_30 (
      column_1 INT PRIMARY KEY,
      column_2 VARCHAR(50) NOT NULL,
      column_3 VARCHAR(50)
    )
```

Query                       | Before PR    | Since PR 
|-------------------|-------------|------------|
| ```SELECT (SELECT 1 WHERE 0) as result ```  | Not null |  Null 
| ```SELECT 1 as one, (SELECT COUNT(NULL)) as result```  | Not null |  Not Null
| ``` SELECT 'test' as t, (SELECT column_1 FROM table_30 WHERE FALSE LIMIT 1)```  | Not null | Null
| ```SELECT 1 as one, (SELECT COUNT(NULL) HAVING FALSE) as result``` | Not null | Null

