### PR TITLE
implement values row syntax , first part (joins)

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -365,7 +365,7 @@ and var =
 | TupleList of param_id * tuple_list_kind
 (* It differs from Choice that in this case we should generate sql "TRUE", it doesn't seem reusable *)
 | OptionBoolChoice of param_id * var list * (pos * pos)
-and tuple_list_kind = Insertion of schema | Where_in of Type.t list | ValueRows of Type.t list 
+and tuple_list_kind = Insertion of schema | Where_in of Type.t list | ValueRows of { types: Type.t list; values_start_pos: int; }
 [@@deriving show]
 type vars = var list [@@deriving show]
 
@@ -413,7 +413,7 @@ and select_complete = {
   limit : limit option;
 }
 and select_full = { select_complete: select_complete; cte: cte option; }
-and row_constructor_list = RowExprList of expr list list | RowParam of { id : param_id; types : Type.t list; } 
+and row_constructor_list = RowExprList of expr list list | RowParam of { id : param_id; types : Type.t list; values_start_pos: int; } 
 and row_values = {
   row_constructor_list: row_constructor_list;
   row_order: order;

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -365,7 +365,7 @@ and var =
 | TupleList of param_id * tuple_list_kind
 (* It differs from Choice that in this case we should generate sql "TRUE", it doesn't seem reusable *)
 | OptionBoolChoice of param_id * var list * (pos * pos)
-and tuple_list_kind = Insertion of schema | Where_in of Type.t list
+and tuple_list_kind = Insertion of schema | Where_in of Type.t list | ValueRows of Type.t list 
 [@@deriving show]
 type vars = var list [@@deriving show]
 
@@ -392,10 +392,11 @@ type limit_t = [ `Limit | `Offset ]
 type col_name = {
   cname : string; (** column name *)
   tname : table_name option;
-}
+} [@@deriving show]
+type source_alias = { table_name : table_name; column_aliases : schema option } [@@deriving show]
 and limit = param list * bool
 and nested = source * (source * Schema.Join.typ * join_condition) list
-and source = [ `Select of select_full | `Table of table_name | `Nested of nested ] * table_name option (* alias *)
+and source = [ `Select of select_full | `Table of table_name | `Nested of nested | `ValueRows of row_values ] * source_alias option (* alias *)
 and join_condition = expr Schema.Join.condition
 and select = {
   columns : column list;
@@ -412,6 +413,12 @@ and select_complete = {
   limit : limit option;
 }
 and select_full = { select_complete: select_complete; cte: cte option; }
+and row_constructor_list = RowExprList of expr list list | RowParam of { id : param_id; types : Type.t list; } 
+and row_values = {
+  row_constructor_list: row_constructor_list;
+  row_order: order;
+  row_limit: limit option;
+}
 and order = (expr * direction option) list
 and 'expr choices = (param_id * 'expr option) list
 and expr =

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -476,11 +476,11 @@ expr:
     | e=window_function OVER window_spec { e }
 
 values_stmt1: 
-  | expr_list=commas(preceded(ROW, delimited(LPAREN, expr_list, RPAREN))) { RowExprList expr_list }
-  | id=PARAM DOUBLECOLON types=sequence(manual_type) { RowParam { id={ id with pos=($startofs, $endofs) } ; types } }
+  | VALUES expr_list=commas(preceded(ROW, delimited(LPAREN, expr_list, RPAREN))) { RowExprList expr_list }
+  | VALUES id=PARAM DOUBLECOLON types=sequence(manual_type) { RowParam { id={ id with pos=($startofs, $endofs) } ; types; values_start_pos = $startofs  } }
 
 values_stmt: 
-  | VALUES kind=values_stmt1 row_order=loption(order) row_limit=limit_t? {{ row_constructor_list = kind; row_order; row_limit; }}
+  | kind=values_stmt1 row_order=loption(order) row_limit=limit_t? {{ row_constructor_list = kind; row_order; row_limit;}}
 
 (* https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html *)
 window_function:

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -618,9 +618,9 @@ and resolve_source env (x, alias) =
         let select = dummy_select exprs in
         let select_complete = { select = select, unions; order=row_order; limit=row_limit; } in
         eval_select_full env { select_complete; cte = None }
-      | RowParam { id; types } -> 
+      | RowParam { id; types; values_start_pos } ->
         List.map (fun t -> { attr = make_attribute' "" t; Schema.Source.Attr.sources = []}) 
-          types, [ TupleList (id, ValueRows types) ], Stmt.Select `Nat
+          types, [ TupleList (id, ValueRows { types; values_start_pos }) ], Stmt.Select `Nat
     in
     match alias with 
     | Some { table_name; column_aliases = Some col_schema } -> 

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -139,6 +139,12 @@ let substitute_vars s vars subst_param =
       assert (i1 > i);
       let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
       loop acc i2 parami tl
+    | TupleList (id, ValueRows x) :: tl ->
+      let (i1,i2) = id.pos in
+      assert (i2 > i1);
+      assert (i1 > i);
+      let acc = SubstTuple (id, ValueRows x) :: Static (String.slice ~first:i ~last:x.values_start_pos s) :: acc in
+      loop acc i2 parami tl
     | TupleList (id, kind) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -63,7 +63,7 @@ let tuplelist_value_of_param = function
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
     | Insertion schema -> schema 
-    | Where_in types -> Gen_caml.make_schema_of_tuple_types name types
+    | Where_in types | ValueRows types -> Gen_caml.make_schema_of_tuple_types name types
     in
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -63,7 +63,7 @@ let tuplelist_value_of_param = function
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
     | Insertion schema -> schema 
-    | Where_in types | ValueRows types -> Gen_caml.make_schema_of_tuple_types name types
+    | Where_in types | ValueRows { types; _ } -> Gen_caml.make_schema_of_tuple_types name types
     in
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in

--- a/test/out/values_row.xml
+++ b/test/out/values_row.xml
@@ -9,7 +9,7 @@
   <in/>
   <out/>
  </stmt>
- <stmt name="select_2" sql="SELECT entitlement, product_name&#x0A;FROM products p&#x0A;JOIN ( VALUES @@@values ) AS x (product_name, entitlement)&#x0A;ON p.name = x.product_name" category="DQL" kind="select" cardinality="n">
+ <stmt name="select_2" sql="SELECT entitlement, product_name&#x0A;FROM products p&#x0A;JOIN ( @@@values ) AS x (product_name, entitlement)&#x0A;ON p.name = x.product_name" category="DQL" kind="select" cardinality="n">
   <in>
    <value name="values" type="list(Text, Int)"/>
   </in>

--- a/test/out/values_row.xml
+++ b/test/out/values_row.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_products" sql="CREATE TABLE products (&#x0A;    id SERIAL PRIMARY KEY,       &#x0A;    name VARCHAR(255) NOT NULL&#x0A;)" category="DDL" kind="create" target="products" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_entitlements" sql="CREATE TABLE entitlements (&#x0A;    id SERIAL PRIMARY KEY,      &#x0A;    product_id INT NOT NULL,     &#x0A;    entitlement INT NOT NULL&#x0A;)" category="DDL" kind="create" target="entitlements" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_2" sql="SELECT entitlement, product_name&#x0A;FROM products p&#x0A;JOIN ( VALUES @@@values ) AS x (product_name, entitlement)&#x0A;ON p.name = x.product_name" category="DQL" kind="select" cardinality="n">
+  <in>
+   <value name="values" type="list(Text, Int)"/>
+  </in>
+  <out>
+   <value name="entitlement" type="Int"/>
+   <value name="product_name" type="Text"/>
+  </out>
+ </stmt>
+ <stmt name="insert_entitlements_3" sql="INSERT INTO entitlements ( product_id, entitlement )&#x0A;SELECT p.id, x.entitlement&#x0A;FROM products p&#x0A;JOIN ( VALUES ROW('a', 1), ROW('b', 2), ROW('c', 3) ) AS x (product_name, entitlement)&#x0A;ON p.name = x.product_name" category="DML" kind="insert" target="entitlements" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <table name="entitlements">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="product_id" type="Int"/>
+   <value name="entitlement" type="Int"/>
+  </schema>
+ </table>
+ <table name="products">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="name" type="Text"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/values_row.sql
+++ b/test/values_row.sql
@@ -1,0 +1,21 @@
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,       
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE entitlements (
+    id SERIAL PRIMARY KEY,      
+    product_id INT NOT NULL,     
+    entitlement INT NOT NULL
+);
+
+SELECT entitlement, product_name
+FROM products p
+JOIN ( VALUES @values :: (Text, Int) ) AS x (product_name, entitlement)
+ON p.name = x.product_name;
+
+INSERT INTO entitlements ( product_id, entitlement )
+SELECT p.id, x.entitlement
+FROM products p
+JOIN ( VALUES ROW('a', 1), ROW('b', 2), ROW('c', 3) ) AS x (product_name, entitlement)
+ON p.name = x.product_name;


### PR DESCRIPTION
### Description
This PR adds a support of `VALUES ROW(..)` syntax.

https://dev.mysql.com/doc/refman/8.4/en/values.html

At the current step, it's supported for `JOIN`S, but it's already now considered as a new source, so it wouldn't be a problem to support the rest of the usages of this syntax.

Also it supports two variants of it:

```
SELECT p.id, x.a
FROM products p
JOIN ( VALUES ROW(...) ) AS x (a, b)
ON p.name = x.b;
```

And

```
SELECT p.id, x.a
FROM products p
JOIN ( VALUES @param ) AS x (a, b)
ON p.name = x.b;
```

And since `VALUES` with no ROWs afters is invalid syntax, I added a default expression when the passed list is empty:

```SELECT %cols% WHERE FALSE```

This part is up for debate, but it seems safer
