### PR TITLE
Make execute_response's insert_id : int64 option

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -198,7 +198,7 @@ type 'a connection = M.t
 type params = statement * M.Field.value array * int ref
 type row = M.Field.t array
 type result = M.Res.t
-type execute_response = { affected_rows: int64; insert_id: int64 }
+type execute_response = { affected_rows: int64; insert_id: int64 option }
 
 module Types = Types
 
@@ -289,8 +289,13 @@ let execute db sql set_params =
   with_stmt db sql @@ fun stmt ->
   let open IO in
   set_params stmt >>=
-  fun res -> return { affected_rows = Int64.of_int (M.Res.affected_rows res); insert_id = Int64.of_int (M.Res.insert_id res) }
-
+  fun res -> 
+    let insert_id =
+      match M.Res.insert_id res with
+      | 0 -> None
+      | x -> Some (Int64.of_int x)
+    in
+    return { affected_rows = Int64.of_int (M.Res.affected_rows res); insert_id }
 
 let select_one_maybe db sql set_params convert =
   with_stmt db sql @@ fun stmt ->

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -123,7 +123,7 @@ type 'a connection = Mysql.dbd
 type params = statement * string array * int ref
 type row = string option array
 type result = P.stmt_result
-type execute_response = { affected_rows: int64; insert_id: int64 }
+type execute_response = { affected_rows: int64; insert_id: int64 option }
 
 module Types = T
 open Types
@@ -204,7 +204,12 @@ let execute db sql set_params =
   with_stmt db sql (fun stmt ->
     let _ = set_params stmt in
     if 0 <> P.real_status stmt then oops "execute : %s" sql;
-    { affected_rows = P.affected stmt; insert_id = P.insert_id stmt})
+    let insert_id =
+      match P.insert_id stmt with
+      | 0L -> None
+      | x -> Some x
+    in
+    { affected_rows = P.affected stmt; insert_id; })
 
 let select_one_maybe db sql set_params convert =
   with_stmt db sql (fun stmt ->

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -27,7 +27,7 @@ module type M = sig
   type params
   type row
   type result
-  type execute_response = { affected_rows: int64; insert_id: int64 }
+  type execute_response = { affected_rows: int64; insert_id: int64 option }
 
   (** datatypes *)
   module Types : sig


### PR DESCRIPTION
To represent explicitly the case when the insert wasn't performed (can be because of `ON CONFLICT` clause for example).