### PR TITLE
Implement safe enums: literals + poly variants gen

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -24,6 +24,14 @@ module type Value = sig
   val to_literal : t -> string
 end
 
+module type Enum = sig 
+  type t
+
+  val inj: string -> t
+
+  val proj: t -> string
+end
+
 module type Types = sig
   type field
   type value
@@ -36,6 +44,7 @@ module type Types = sig
   module Datetime : Value
   module Decimal : Value
   module Any : Value
+  module Make_enum : functor (E : Enum) -> Value with type t = E.t
 end
 
 module Default_types(M : Mariadb.Nonblocking.S) : Types with
@@ -183,6 +192,20 @@ struct
     let to_value x = x
     let to_literal _ = failwith "to_literal Any"
   end)
+
+  module Make_enum (E: Enum) = Make(struct
+  
+    include E
+  
+    let of_field field = 
+      match M.Field.value field with
+      | `String x -> inj x
+      | value -> convfail "enum" field value
+  
+    let to_value v = `String (proj v)
+  
+    let to_literal = proj
+  end)
 end
 
 module Make
@@ -257,6 +280,19 @@ let set_param_Int = set_param_ty Int.to_value
 let set_param_Float = set_param_ty Float.to_value
 let set_param_Decimal = set_param_ty Decimal.to_value
 let set_param_Datetime = set_param_ty Datetime.to_value
+
+module Make_enum (E: Enum) = struct 
+
+  module E = Make_enum(E)
+
+  type t = E.t
+
+  let get_column, get_column_nullable = get_column_ty "Enum" E.of_field
+
+  let set_param = set_param_ty E.to_value
+
+  let to_literal = E.to_literal
+end
 
 let no_params stmt =
   let open IO in

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -126,6 +126,15 @@ type result = P.stmt_result
 type execute_response = { affected_rows: int64; insert_id: int64 }
 
 module Types = T
+
+module type Enum = sig 
+  type t
+
+  val inj: string -> t
+
+  val proj: t -> string
+end
+
 open Types
 
 (* compatibility *)
@@ -177,6 +186,17 @@ let set_param_Int = set_param_ty Int.to_string
 let set_param_Float = set_param_ty Float.to_string
 let set_param_Decimal = set_param_ty Decimal.to_string
 let set_param_Datetime = set_param_ty Datetime.to_string
+
+module Make_enum (E: Enum) = struct 
+
+  include E
+
+  let get_column, get_column_nullable = get_column_ty "Enum" E.inj
+
+  let set_param = set_param_ty E.proj
+
+  let to_literal = E.proj
+end
 
 let no_params stmt = P.execute stmt [||]
 

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -20,6 +20,14 @@ module type Value = sig
   val to_literal : t -> string
 end
 
+module type Enum = sig 
+  type t
+
+  val inj: string -> t
+
+  val proj: t -> string
+end
+
 module type M = sig
 
   type statement
@@ -79,6 +87,14 @@ module type M = sig
   val set_param_Float : params -> Float.t -> unit
   val set_param_Decimal : params -> Decimal.t -> unit
   val set_param_Datetime : params -> Datetime.t -> unit
+
+  module Make_enum: functor (E : Enum) -> sig
+    (* The type itself is not exposed to provide a user a polymorphic type without aliases. *)
+    val get_column : row -> int -> E.t
+    val get_column_nullable : row -> int -> E.t option
+    val set_param : params -> E.t -> unit
+    val to_literal : E.t -> string
+  end
 
   val no_params : statement -> result
 

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -67,6 +67,14 @@ module Types = struct
   module Any = Text
 end
 
+module type Enum = sig 
+  type t
+
+  val inj: string -> t
+
+  val proj: t -> string
+end
+
 type statement = S.stmt * string
 type 'a connection = S.db
 type params = statement * int * int ref
@@ -109,6 +117,17 @@ let get_column_Any, get_column_Any_nullable = get_column_ty Conv.text
 let get_column_Float, get_column_Float_nullable = get_column_ty Conv.float
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty Conv.decimal
 let get_column_Datetime, get_column_Datetime_nullable = get_column_ty Conv.float
+
+module Make_enum (E: Enum) = struct 
+
+  include E
+
+  let get_column, get_column_nullable = failwith "sqlite does not support enums"
+
+  let set_param = failwith "sqlite does not support enums"
+
+  let to_literal = failwith "sqlite does not support enums"
+end
 
 let test_ok sql rc =
   if rc <> S.Rc.OK then

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -38,8 +38,8 @@ struct
     (* TODO NULL is currently typed as Any? which actually is a misnormer *)
 
     let show_kind = function 
-      | Union { ctors; _ } -> sprintf "Union (%s)" (String.concat ", " (Enum_kind.Ctors.elements ctors))
-      (* | StringLiteral l -> sprintf "StringLiteral (%s)" l *)
+      | Union { ctors; _ } -> sprintf "Union (%s)" (String.concat "| " (Enum_kind.Ctors.elements ctors))
+      | StringLiteral l -> sprintf "StringLiteral (%s)" l
       | k -> show_kind k
 
   type nullability =

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -17,7 +17,7 @@ struct
           (String.concat "; " (elements s))  
     end
 
-    let enum_as_variant = ref true
+    let enum_as_variant = ref false
     let enum_is_str = ref false
 
     type t = Ctors.t [@@deriving eq, show{with_path=false}]

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -17,7 +17,7 @@ struct
           (String.concat "; " (elements s))  
     end
 
-    let enum_as_variant = ref false
+    let type_safe_enums = ref false
     let enum_is_str = ref false
 
     type t = Ctors.t [@@deriving eq, show{with_path=false}]
@@ -60,7 +60,7 @@ struct
   let make_strict { t; nullability=_ } = strict t
   
   let make_enum_kind ctors = 
-      if !Enum_kind.enum_as_variant then Enum (Enum_kind.make ctors) else Text 
+      if !Enum_kind.type_safe_enums then Enum (Enum_kind.make ctors) else Text 
 
   let is_strict { nullability; _ } = nullability = Strict
 

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -9,16 +9,13 @@ struct
 
   module Enum_kind = struct
 
-    module Ctors = struct 
+    module Ctors =  struct 
       include Set.Make(String)
-
+  
       let pp fmt s = 
         Format.fprintf fmt "{%s}" 
           (String.concat "; " (elements s))  
     end
-
-    let type_safe_enums = ref false
-    let enum_is_str = ref false
 
     type t = Ctors.t [@@deriving eq, show{with_path=false}]
 
@@ -34,13 +31,15 @@ struct
     | Bool
     | Datetime
     | Decimal
-    | Enum of Enum_kind.t
+    | Union of { ctors: Enum_kind.t; is_closed: bool }
+    | StringLiteral of string
     | Any (* FIXME - Top and Bottom ? *)
     [@@deriving eq, show{with_path=false}]
     (* TODO NULL is currently typed as Any? which actually is a misnormer *)
 
     let show_kind = function 
-      | Enum ctors -> sprintf "Enum (%s)" (String.concat ", " (Enum_kind.Ctors.elements ctors))
+      | Union { ctors; _ } -> sprintf "Union (%s)" (String.concat ", " (Enum_kind.Ctors.elements ctors))
+      (* | StringLiteral l -> sprintf "StringLiteral (%s)" l *)
       | k -> show_kind k
 
   type nullability =
@@ -59,8 +58,7 @@ struct
 
   let make_strict { t; nullability=_ } = strict t
   
-  let make_enum_kind ctors = 
-      if !Enum_kind.type_safe_enums then Enum (Enum_kind.make ctors) else Text 
+  let make_enum_kind ctors = Union { ctors = (Enum_kind.make ctors); is_closed = true }
 
   let is_strict { nullability; _ } = nullability = Strict
 
@@ -77,20 +75,34 @@ struct
   let is_unit = function { t = Unit _; _ } -> true | _ -> false
 
   (** @return (subtype, supertype) *)
-  let order_kind x y =
+  let order_kind x y =  
     match x, y with
     | x, y when equal_kind x y -> `Equal
-    | Enum a, Enum b when Enum_kind.Ctors.subset a b -> `Equal
-    | Enum a, Enum b when Enum_kind.Ctors.subset b a -> `Equal
-    | Any, t | t, Any -> `Order (t,t)
-    | Int, Float | Float, Int -> `Order (Int,Float)
-    (* arbitrary decision : allow int<->decimal but require explicit cast for floats *)
-    | Decimal, Int | Int, Decimal -> `Order (Int,Decimal)
-    | Text, Blob | Blob, Text -> `Order (Text,Blob)
-    | (Text, Enum e | Enum e, Text) when !Enum_kind.enum_is_str -> `Order (Enum e, Text)
-    | Int, Datetime | Datetime, Int -> `Order (Int,Datetime)
-    | Text, Datetime | Datetime, Text -> `Order (Datetime,Text)
+    | StringLiteral a, StringLiteral b -> 
+      `StringLiteralUnion (Union { ctors = (Enum_kind.make [a; b]); is_closed = false })
+
+    | StringLiteral a, Union { ctors = b; is_closed  } | Union { ctors = b; is_closed  }, StringLiteral a when Enum_kind.Ctors.mem a b 
+      -> `Order (StringLiteral a, Union { ctors = (Enum_kind.Ctors.add a b); is_closed })
+
+    | StringLiteral a, Union { ctors = b; is_closed = false  }  | Union { ctors = b; is_closed = false  }, StringLiteral a -> 
+      `StringLiteralUnion (Union { ctors = (Enum_kind.Ctors.add a b); is_closed = false; })
+
+    | StringLiteral _  as x , Text -> `Order (x, Text)
+    | Text, (StringLiteral _ as x) -> `Order (x, Text)
+
+    | Text, (Union _ as x) -> `Order (x, Text)
+    | Union { ctors = a; _ } as x1, (Union { ctors = b ;_ } as x2)  when Enum_kind.Ctors.subset b a -> `Order (x2, x1)
+
+    | StringLiteral x, Datetime | Datetime, StringLiteral x -> `Order (Datetime, StringLiteral x)
+    | StringLiteral x, Blob | Blob, StringLiteral x -> `Order (Blob, StringLiteral x)
+    | Any, t | t, Any -> `Order (t, t)
+    | Int, Float | Float, Int -> `Order (Int, Float)
+    | Decimal, Int | Int, Decimal -> `Order (Int, Decimal)
+    | Text, Blob | Blob, Text -> `Order (Text, Blob)
+    | Int, Datetime | Datetime, Int -> `Order (Int, Datetime)
+    | Text, Datetime | Datetime, Text -> `Order (Datetime, Text)
     | _ -> `No
+    
 
   let order_nullability x y =
     match x,y with
@@ -117,19 +129,30 @@ struct
   let common_type_ order x y =
     match order_nullability x.nullability y.nullability, order_kind x.t y.t with
     | _, `No -> None
-    | `Equal nullability, `Order pair -> Some {t = order pair; nullability}
+    | `Equal nullability, `Order pair -> `CommonType pair |> order |> Option.map (fun t -> { t = t; nullability })
     | `Equal nullability, `Equal -> Some { x with nullability }
     | (`Nullable_Strict|`Strict_Nullable), `Equal -> Some (nullable x.t) (* FIXME need nullability order? *)
-    | (`Nullable_Strict|`Strict_Nullable), `Order pair -> Some (nullable @@ order pair)
+    | (`Nullable_Strict|`Strict_Nullable), `Order pair -> `CommonType pair |> order |> Option.map nullable
+    | `Equal nullability, `StringLiteralUnion t -> `StringLiteralUnion t |> order |> Option.map (fun t -> { t = t; nullability })
+    | (`Nullable_Strict | `Strict_Nullable), `StringLiteralUnion t -> `StringLiteralUnion t |> order |> Option.map nullable
 
   let common_type_l_ order = function
   | [] -> None
   | t::ts -> List.fold_left (fun acc t -> match acc with None -> None | Some prev -> common_type_ order prev t) (Some t) ts
 
-  let subtype = common_type_ fst
-  let supertype = common_type_ snd
-  let common_subtype = common_type_l_ fst
-  let common_supertype = common_type_l_ snd
+  let get_subtype = function 
+  | `CommonType t -> Some (fst t)
+  | `StringLiteralUnion t -> Some t
+
+  let get_supertype = function 
+  | `CommonType t -> Some (snd t)
+  | `StringLiteralUnion t -> Some t
+
+  let subtype = common_type_ get_subtype
+  let supertype = common_type_ get_supertype
+  let common_subtype = common_type_l_ get_subtype
+
+  let common_supertype = common_type_l_ get_supertype
 
   let common_type = subtype
 
@@ -393,7 +416,6 @@ and var =
 | TupleList of param_id * tuple_list_kind
 (* It differs from Choice that in this case we should generate sql "TRUE", it doesn't seem reusable *)
 | OptionBoolChoice of param_id * var list * (pos * pos)
-| EnumCtor of string * pos
 and tuple_list_kind = Insertion of schema | Where_in of Type.t list | ValueRows of { types: Type.t list; values_start_pos: int; }
 [@@deriving show]
 type vars = var list [@@deriving show]
@@ -465,7 +487,6 @@ and expr =
       to use it during the substitution and to not depend on the magic numbers there.
    *) 
   | OptionBoolChoices of { choice: expr; pos: (pos * pos) }
-  | EnumCtor of { ctor_name: string; pos: pos; }
 and column =
   | All
   | AllOf of table_name

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -318,7 +318,6 @@ ruleMain = parse
   | "?" { QSTN }
   | [':' '@'] (ident as str) { PARAM { label = Some str; pos = pos lexbuf } }
   | "::" { DOUBLECOLON }
-  | "^@" "'"  {  keep_lexeme_start lexbuf (fun () -> ENUM_LITERAL (ruleInSingleQuotes "" lexbuf)) }
 
   | '"' { keep_lexeme_start lexbuf (fun () -> ident (ruleInQuotes "" lexbuf)) }
   | "'" { keep_lexeme_start lexbuf (fun () -> TEXT (ruleInSingleQuotes "" lexbuf)) }

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -318,6 +318,7 @@ ruleMain = parse
   | "?" { QSTN }
   | [':' '@'] (ident as str) { PARAM { label = Some str; pos = pos lexbuf } }
   | "::" { DOUBLECOLON }
+  | "^@" "'"  {  keep_lexeme_start lexbuf (fun () -> ENUM_LITERAL (ruleInSingleQuotes "" lexbuf)) }
 
   | '"' { keep_lexeme_start lexbuf (fun () -> ident (ruleInQuotes "" lexbuf)) }
   | "'" { keep_lexeme_start lexbuf (fun () -> TEXT (ruleInSingleQuotes "" lexbuf)) }

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -25,7 +25,7 @@
 %}
 
 %token <int> INTEGER
-%token <string> IDENT TEXT BLOB
+%token <string> IDENT TEXT BLOB ENUM_LITERAL
 %token <float> FLOAT
 %token <Sql.param_id> PARAM
 %token <int> LCURLY RCURLY
@@ -425,6 +425,7 @@ expr:
     | LPAREN e=expr RPAREN { e }
     | a=attr_name collate? { Column a }
     | VALUES LPAREN n=IDENT RPAREN { Inserted n }
+    | ctor_name=ENUM_LITERAL { EnumCtor { ctor_name; pos=($startofs, $endofs) }}
     | v=literal_value | v=datetime_value { v }
     | v=interval_unit { v }
     | e1=expr mnot(IN) l=sequence(expr) { poly (depends Bool) (e1::l) }
@@ -555,7 +556,7 @@ sql_type_flavor: T_INTEGER UNSIGNED? ZEROFILL? { Int }
                | T_DECIMAL { Decimal }
                | binary { Blob }
                | NATIONAL? text VARYING? charset? collate? { Text }
-               | ENUM sequence(TEXT) charset? collate? { Text }
+               | ENUM ctors=sequence(TEXT) charset? collate? { make_enum_kind ctors }
                | T_FLOAT PRECISION? { Float }
                | T_BOOLEAN { Bool }
                | T_DATETIME | YEAR | DATE | TIME | TIMESTAMP { Datetime }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -31,6 +31,8 @@ module Tables_with_derived = struct
   let get_from ~env name = get_from  (env.ctes @ env.tables) name
 end
 
+type enum_ctor_value_data = { ctor_name: string; pos: pos; }  [@@deriving show]
+
 (* expr with all name references resolved to values or "functions" *)
 type res_expr =
   | ResValue of Type.t (** literal value *)
@@ -42,6 +44,7 @@ type res_expr =
   | ResFun of Type.func * res_expr list (** function kind (return type and flavor), arguments *)
   | ResAggValue of res_expr
   | ResOptionBoolChoice of { choice_id: param_id; res_choice: res_expr; pos: (pos * pos) }
+  | ResEnumCtorValue of enum_ctor_value_data
   [@@deriving show]
   
 and res_in_tuple_list = 
@@ -96,6 +99,7 @@ let rec get_params_of_res_expr (e:res_expr) =
     | ResValue _ -> acc
     | ResInChoice (param, kind, e) -> ChoiceIn { param; kind; vars = get_params_of_res_expr e } :: acc
     | ResChoices (p,l) -> Choice (p, List.map (fun (n,e) -> Simple (n, Option.map get_params_of_res_expr e)) l) :: acc
+    | ResEnumCtorValue { ctor_name; pos } -> EnumCtor (ctor_name, pos) :: acc
   in
   loop [] e |> List.rev
 
@@ -112,6 +116,7 @@ let rec is_grouping = function
 | Inparam _
 | InTupleList _
 | OptionBoolChoices _
+| EnumCtor _
 | Inserted _ -> false
 | Choices (p,l) ->
   begin match list_same @@ List.map (fun (_,expr) -> Option.map_default is_grouping false expr) l with
@@ -206,7 +211,7 @@ let resolve_aggregations =
     | ResInTupleList (param_id, Res res) -> ResInTupleList(param_id, Res (List.map (handle ~is_agg) res))
     | ResInChoice(param_id, kind, res) -> ResInChoice(param_id, kind, (handle ~is_agg res))
     | ResValue _ | ResParam _  | ResOptionBoolChoice _
-    | ResInparam _| ResChoices (_, _)
+    | ResInparam _| ResChoices (_, _) | ResEnumCtorValue _
     | ResAggValue _ | ResInTupleList _ -> res_expr
   in
   handle ~is_agg:false 
@@ -221,6 +226,7 @@ let rec bool_choice_id = function
   | SelectExpr _
   | OptionBoolChoices _
   | Choices _
+  | EnumCtor _
   | Value _ -> None 
   | Inparam p
   | Param p -> Some p.id
@@ -239,6 +245,7 @@ let rec resolve_columns env expr =
   let rec each e =
     match e with
     | Value x -> ResValue x
+    | EnumCtor { ctor_name; pos } -> ResEnumCtorValue { ctor_name; pos; }
     | Column col -> ResValue (resolve_column ~env col).attr.domain
     | OptionBoolChoices { choice; pos } ->
       let choice_id = match bool_choice_id choice with
@@ -258,6 +265,7 @@ let rec resolve_columns env expr =
         | ResValue _
         | ResParam _
         | ResAggValue _
+        | ResEnumCtorValue _ -> res_expr
         | ResFun _ -> res_expr
         | ResInparam _
         | ResChoices _
@@ -274,6 +282,7 @@ let rec resolve_columns env expr =
     | SelectExpr (select, usage) ->
       let rec params_of_var = function
         | Single p -> [ResParam p]
+        | EnumCtor (ctor_name, pos) -> [ResEnumCtorValue { ctor_name; pos }]
         (* Better do not separate ChoiceIn and SingleIn , fix it subsequently *)
         | SingleIn p -> failed ~at:p.id.pos "Unexpected right side of WHERE IN"
         | ChoiceIn { vars; param; kind } -> 
@@ -305,7 +314,7 @@ let rec resolve_columns env expr =
               | Some _ -> Option.map_default with_count None e
             ) (Some domain) chs
           | OptionBoolChoices { choice; _ } -> with_count choice  
-          | Value _| Param _| Inparam _ | InChoice (_, _, _)
+          | Value _| Param _| Inparam _ | InChoice (_, _, _) | EnumCtor _
           | Column _| Inserted _| InTupleList (_, _) -> None
         in
         let default_null = Type.make_nullable domain in
@@ -330,6 +339,7 @@ and assign_types env expr =
   let rec typeof_ (e:res_expr) = (* FIXME simplify *)
     match e with
     | ResValue t -> e, `Ok t
+    | ResEnumCtorValue { ctor_name; _ } as r -> r, `Ok Type.(strict (Enum (Enum_kind.Ctors.of_list [ctor_name])))
     | ResParam p -> e, `Ok p.typ
     | ResInparam p -> e, `Ok p.typ
     | ResOptionBoolChoice choice ->
@@ -541,6 +551,7 @@ and params_of_order order final_schema env =
 
 and ensure_res_expr = function
   | Value x -> ResValue x
+  | EnumCtor { ctor_name; pos } -> ResEnumCtorValue { ctor_name; pos }
   | Param x -> ResParam x
   | Inparam x -> ResInparam x
   | InTupleList (_, p) -> failed ~at:p.pos "ensure_res_expr InTupleList TBD"
@@ -873,7 +884,7 @@ let unify_params l =
     check_choice_name p;
     List.iter traverse l
   | Choice (p,l) -> check_choice_name p; List.iter (function Simple (_,l) -> Option.may (List.iter traverse) l | Verbatim _ -> ()) l
-  | TupleList _ -> ()
+  | TupleList _ | EnumCtor _ -> ()
   in
   let rec map = function
   | Single { id; typ; } ->
@@ -886,6 +897,7 @@ let unify_params l =
   | OptionBoolChoice (p, l, pos) -> OptionBoolChoice (p, (List.map map l), pos)
   | Choice (p, l) -> Choice (p, List.map (function Simple (n,l) -> Simple (n, Option.map (List.map map) l) | Verbatim _ as v -> v) l)
   | TupleList _ as x -> x
+  | EnumCtor _ as x -> x
   in
   List.iter traverse l;
   List.map map l

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -103,7 +103,7 @@ let main () =
     "-static-header", Arg.Unit (fun () -> Sqlgg_config.gen_header := Some `Static), "only output short static header without version/timestamp";
     "-show-tables", Arg.Unit Tables.print_all, " Show all current tables";
     "-show-table", Arg.String Tables.print1, "<name> Show specified table";
-    "-type-safe-enums", Arg.Unit (fun () -> Sqlgg_config.type_safe_enums := true), " Represent enums as variants in generated code";
+    "-enum-poly-variant", Arg.Unit (fun () -> Sqlgg_config.enum_as_poly_variant := true), " Represent enums as variants in generated code";
     "-", Arg.Unit (fun () -> work "-"), " Read sql from stdin";
     "-test", Arg.Unit Test.run, " Run unit tests";
   ]

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -103,7 +103,7 @@ let main () =
     "-static-header", Arg.Unit (fun () -> Sqlgg_config.gen_header := Some `Static), "only output short static header without version/timestamp";
     "-show-tables", Arg.Unit Tables.print_all, " Show all current tables";
     "-show-table", Arg.String Tables.print1, "<name> Show specified table";
-    "-enum-as-variant", Arg.Unit (fun () -> Sqlgg_config.enum_as_variant := true), " Represent enums as variants in generated code";
+    "-type-safe-enums", Arg.Unit (fun () -> Sqlgg_config.type_safe_enums := true), " Represent enums as variants in generated code";
     "-", Arg.Unit (fun () -> work "-"), " Read sql from stdin";
     "-test", Arg.Unit Test.run, " Run unit tests";
   ]

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -103,6 +103,7 @@ let main () =
     "-static-header", Arg.Unit (fun () -> Sqlgg_config.gen_header := Some `Static), "only output short static header without version/timestamp";
     "-show-tables", Arg.Unit Tables.print_all, " Show all current tables";
     "-show-table", Arg.String Tables.print1, "<name> Show specified table";
+    "-enum-as-variant", Arg.Unit (fun () -> Sqlgg_config.enum_as_variant := true), " Represent enums as variants in generated code";
     "-", Arg.Unit (fun () -> work "-"), " Read sql from stdin";
     "-test", Arg.Unit Test.run, " Run unit tests";
   ]

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -171,16 +171,6 @@ let substitute_vars s vars subst_param =
       in
       let acc = Dynamic (name, pieces) :: Static (String.slice ~first:i ~last:f1 s) :: acc in
       loop acc f2 parami tl
-    | EnumCtor (_, (i1,i2)) :: tl -> 
-      assert (i2 > i1);
-      assert (i1 > i);
-      let acc =
-        Static (String.slice ~first:(i1 + 2) ~last:(i2) s) ::
-        Static (String.slice ~first:i ~last:(i1) s) :: 
-        acc
-      in
-      loop acc i2 parami tl
-
   in
   let (acc,last) = loop [] 0 0 vars in
   let acc = List.rev (Static (String.slice ~first:last s) :: acc) in
@@ -191,7 +181,6 @@ let substitute_vars s vars subst_param =
   in
   squash [] acc
 
-(* let    *)
 
 let subst_named index p = "@" ^ (show_param_name p index)
 let subst_oracle index p = ":" ^ (show_param_name p index)
@@ -258,8 +247,7 @@ let rec find_param_ids l =
       | Choice (id,_) -> [ id ]
       | OptionBoolChoice (id, _, _) -> [id]
       | ChoiceIn { param; vars; _ } -> find_param_ids vars @ [param]
-      | TupleList (id, _) -> [ id ]
-      | EnumCtor _ -> [ ])
+      | TupleList (id, _) -> [ id ])
     l
 
 let names_of_vars l =
@@ -276,7 +264,7 @@ let rec params_only l =
       | ChoiceIn { vars; _ } -> params_only vars
       | OptionBoolChoice _
       | Choice _ -> fail "dynamic choices not supported for this host language"
-      | TupleList _ | EnumCtor _ -> [])
+      | TupleList _ -> [])
     l
 
 let rec inparams_only l =

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -171,6 +171,16 @@ let substitute_vars s vars subst_param =
       in
       let acc = Dynamic (name, pieces) :: Static (String.slice ~first:i ~last:f1 s) :: acc in
       loop acc f2 parami tl
+    | EnumCtor (_, (i1,i2)) :: tl -> 
+      assert (i2 > i1);
+      assert (i1 > i);
+      let acc =
+        Static (String.slice ~first:(i1 + 2) ~last:(i2) s) ::
+        Static (String.slice ~first:i ~last:(i1) s) :: 
+        acc
+      in
+      loop acc i2 parami tl
+
   in
   let (acc,last) = loop [] 0 0 vars in
   let acc = List.rev (Static (String.slice ~first:last s) :: acc) in
@@ -180,6 +190,8 @@ let substitute_vars s vars subst_param =
   | x::xs -> squash (x::acc) xs
   in
   squash [] acc
+
+(* let    *)
 
 let subst_named index p = "@" ^ (show_param_name p index)
 let subst_oracle index p = ":" ^ (show_param_name p index)
@@ -246,7 +258,8 @@ let rec find_param_ids l =
       | Choice (id,_) -> [ id ]
       | OptionBoolChoice (id, _, _) -> [id]
       | ChoiceIn { param; vars; _ } -> find_param_ids vars @ [param]
-      | TupleList (id, _) -> [ id ])
+      | TupleList (id, _) -> [ id ]
+      | EnumCtor _ -> [ ])
     l
 
 let names_of_vars l =
@@ -263,7 +276,7 @@ let rec params_only l =
       | ChoiceIn { vars; _ } -> params_only vars
       | OptionBoolChoice _
       | Choice _ -> fail "dynamic choices not supported for this host language"
-      | TupleList _ -> [])
+      | TupleList _ | EnumCtor _ -> [])
     l
 
 let rec inparams_only l =

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -119,21 +119,13 @@ let comment () fmt = Printf.kprintf (indent_endline $ make_comment) fmt
 
 let empty_line () = print_newline ()
 
-let enums_hash_tbl = Hashtbl.create 20
+let enums_hash_tbl = Hashtbl.create 100
 
-let hash_enum_name ctors enum_count =
-  let hash = Type.Enum_kind.Ctors.elements ctors |> String.concat "_" in
-  if Hashtbl.mem enums_hash_tbl hash then
-    Hashtbl.find enums_hash_tbl hash, enum_count
-  else
-    let enum_count = enum_count + 1 in
-    let name = sprintf "Enum_%d" enum_count in
-    Hashtbl.add enums_hash_tbl hash name;
-    name, enum_count
+let enum_get_hash ctors = Type.Enum_kind.Ctors.elements ctors |> String.concat "_"
 
-let get_enum_name ctors =
-  let hash = Type.Enum_kind.Ctors.elements ctors |> String.concat "_" in
-  Hashtbl.find enums_hash_tbl hash
+let enum_name = Printf.sprintf "Enum_%d"
+
+let get_enum_name ctors = ctors |> enum_get_hash |> Hashtbl.find enums_hash_tbl |> fst |> enum_name
 
 module L = struct
   open Type
@@ -573,14 +565,9 @@ let generate_enum_modules stmts =
     | EnumCtor _ -> []
   ) vars in
 
-  let result = schemas_to_enums schemas @ vars_to_enums vars in
-  let (_, result) = List.fold_left_map (fun acc enum -> 
-    let (name, acc) = hash_enum_name enum acc in  acc, (enum, name)
-  ) 0 result in
-
-  let unique = List.sort_uniq (fun (_, a) (_, b) -> String.compare a b) result in
+  Hashtbl.reset enums_hash_tbl;
   
-  let generate_enum_module (enum, module_name) = 
+  let generate_enum_module enum_count enum = 
     let get_ctor_name x = x |> sanitize_to_variant_name |> vname ~is_poly:true in
     let ctor_list = Ctors.elements enum in
     output {|
@@ -590,7 +577,7 @@ let generate_enum_modules stmts =
       let proj = function  %s
     end)
     |}
-    module_name
+    (enum_name enum_count)
     (ctor_list |> List.map get_ctor_name |> String.concat " | ")
     (String.concat " "
     (List.map (fun ctor -> Printf.sprintf "| \"%s\" -> %s" (String.escaped ctor) (get_ctor_name ctor)) ctor_list))
@@ -598,7 +585,18 @@ let generate_enum_modules stmts =
     (List.map (fun ctor -> Printf.sprintf "| %s -> \"%s\"" (get_ctor_name ctor) (String.escaped ctor)) ctor_list))
   in
 
-  indented (fun () -> List.iter (fun n -> empty_line (); generate_enum_module n) unique)
+  indented (fun () -> 
+    let result = schemas_to_enums schemas @ vars_to_enums vars in
+    let (_: int * unit list) = List.fold_left_map begin fun acc enum -> 
+      let hash = enum_get_hash enum in
+      if Hashtbl.mem enums_hash_tbl hash then acc, ()
+      else begin
+        Hashtbl.add enums_hash_tbl hash (acc, enum);
+        acc + 1, begin empty_line (); generate_enum_module acc enum end
+      end
+    end 0 result in 
+    ()
+  )
   
 
 let generate ~gen_io name stmts =
@@ -612,7 +610,6 @@ let generate ~gen_io name stmts =
     | true -> "Sqlgg_traits.M_io", "T.IO"
     | false -> "Sqlgg_traits.M", "Sqlgg_io.Blocking"
   in
-  Hashtbl.clear enums_hash_tbl;
   output "module %s (T : %s) = struct" (String.capitalize_ascii name) traits;
   empty_line ();
   inc_indent ();

--- a/src/gen_csharp.ml
+++ b/src/gen_csharp.ml
@@ -42,7 +42,8 @@ let as_api_type t =
   | Decimal -> "Decimal"
   | Datetime -> "Datetime"
   | Any -> "String"
-  | Enum _
+  | Union _
+  | StringLiteral _ -> "String"
   | Unit _ -> assert false
 
 let as_lang_type = as_api_type

--- a/src/gen_csharp.ml
+++ b/src/gen_csharp.ml
@@ -42,6 +42,7 @@ let as_api_type t =
   | Decimal -> "Decimal"
   | Datetime -> "Datetime"
   | Any -> "String"
+  | Enum _
   | Unit _ -> assert false
 
 let as_lang_type = as_api_type

--- a/src/gen_java.ml
+++ b/src/gen_java.ml
@@ -42,7 +42,8 @@ let as_lang_type t =
   | Bool -> "boolean"
   | Decimal -> "float" (* BigDecimal? *)
   | Datetime -> "Timestamp"
-  | Enum _
+  | StringLiteral _ -> "String"
+  | Union _
   | Unit _ -> assert false
 
 let as_api_type = String.capitalize_ascii $ as_lang_type

--- a/src/gen_java.ml
+++ b/src/gen_java.ml
@@ -42,6 +42,7 @@ let as_lang_type t =
   | Bool -> "boolean"
   | Decimal -> "float" (* BigDecimal? *)
   | Datetime -> "Timestamp"
+  | Enum _
   | Unit _ -> assert false
 
 let as_api_type = String.capitalize_ascii $ as_lang_type

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -58,7 +58,7 @@ let value ?(inparam=false) v =
   Node ("value", attrs, [])
 
 let tuplelist_value_of_param = function
-  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionBoolChoice _ -> None
+  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionBoolChoice _ | EnumCtor _ -> None
   | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
@@ -103,7 +103,8 @@ let rec params_only l =
         choices
         |> List.map (function Sql.Verbatim _ | Simple (_,None) -> [] | Simple (_name,Some vars) -> params_only vars) (* TODO prefix names *)
         |> List.concat
-      | TupleList _ -> [])
+      | TupleList _ -> []
+      | EnumCtor _ -> [])
     l
 
 let generate_code (x,_) index stmt =

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -58,7 +58,7 @@ let value ?(inparam=false) v =
   Node ("value", attrs, [])
 
 let tuplelist_value_of_param = function
-  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionBoolChoice _ | EnumCtor _ -> None
+  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionBoolChoice _ -> None
   | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
@@ -103,8 +103,7 @@ let rec params_only l =
         choices
         |> List.map (function Sql.Verbatim _ | Simple (_,None) -> [] | Simple (_name,Some vars) -> params_only vars) (* TODO prefix names *)
         |> List.concat
-      | TupleList _ -> []
-      | EnumCtor _ -> [])
+      | TupleList _ -> [])
     l
 
 let generate_code (x,_) index stmt =

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -16,3 +16,5 @@ let debug1 () = !debug_level > 0
 let gen_header : [ `Full | `Without_timestamp | `Static ] option ref = ref (Some `Full)
 
 let include_category : [ `All | `None | `Only of Stmt.category list | `Except of Stmt.category list ] ref = ref `All
+
+let enum_as_variant = Sql.Type.Enum_kind.enum_as_variant

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -17,4 +17,4 @@ let gen_header : [ `Full | `Without_timestamp | `Static ] option ref = ref (Some
 
 let include_category : [ `All | `None | `Only of Stmt.category list | `Except of Stmt.category list ] ref = ref `All
 
-let enum_as_variant = Sql.Type.Enum_kind.enum_as_variant
+let type_safe_enums = Sql.Type.Enum_kind.type_safe_enums

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -17,4 +17,4 @@ let gen_header : [ `Full | `Without_timestamp | `Static ] option ref = ref (Some
 
 let include_category : [ `All | `None | `Only of Stmt.category list | `Except of Stmt.category list ] ref = ref `All
 
-let type_safe_enums = Sql.Type.Enum_kind.type_safe_enums
+let enum_as_poly_variant = ref false

--- a/src/test.ml
+++ b/src/test.ml
@@ -167,13 +167,11 @@ let test_join_result_cols () =
     [named "x" Int];
   ()
 
-let test_enum = 
-  let enum = Sql.(Type.(Enum (Enum_kind.Ctors.of_list ["true"; "false"]))) in
-  [
-    tt "CREATE TABLE test6 (x enum('true','false') COLLATE utf8_bin NOT NULL, y INT DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
-    tt "SELECT * FROM test6" [attr "x" enum ~extra:[NotNull;]; attr ~extra:[WithDefault;] "y" Int] [];
-    tt "SELECT x, y+10 FROM test6" [attr "x" enum ~extra:[NotNull;]; attr "" Int] [];
-  ]
+let test_enum = [
+  tt "CREATE TABLE test6 (x enum('true','false') COLLATE utf8_bin NOT NULL, y INT DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
+  tt "SELECT * FROM test6" [attr "x" Text ~extra:[NotNull;]; attr ~extra:[WithDefault;] "y" Int] [];
+  tt "SELECT x, y+10 FROM test6" [attr "x" Text ~extra:[NotNull;]; attr "" Int] [];
+]
 
 let test_manual_param = [
   tt "CREATE TABLE test7 (x INT NULL DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
@@ -820,20 +818,30 @@ let test_select_exposed_alias = [
 ] [];
 ]
 
-let test_another_enum = [
- tt "CREATE TABLE test35 (status enum('active','pending','deleted') NOT NULL DEFAULT 'pending')" [] [];
- 
- tt "SELECT status FROM test35" [
-   attr' ~extra:[NotNull; WithDefault] "status" 
-     (Type.(Enum (Enum_kind.Ctors.of_list ["active"; "pending"; "deleted"])))
- ] [];
+let test_enum_as_variant = [
+  "test_enum_as_variant" >:: (fun _ ->
 
- tt "INSERT INTO test35 (status) VALUES (@status)" [] [
-   named "status" (Type.(Enum (Enum_kind.Ctors.of_list ["active"; "pending"; "deleted"])))
- ];
+    Sqlgg_config.type_safe_enums := true;
+
+    do_test "CREATE TABLE test35 (status enum('active','pending','deleted') NOT NULL DEFAULT 'pending')" [] [];
+ 
+    do_test "SELECT status FROM test35" [
+      attr' ~extra:[NotNull; WithDefault] "status" 
+        (Type.(Enum (Enum_kind.Ctors.of_list ["active"; "pending"; "deleted"])))
+    ] [];
+   
+    do_test "INSERT INTO test35 (status) VALUES (@status)" [] [
+      named "status" (Type.(Enum (Enum_kind.Ctors.of_list ["active"; "pending"; "deleted"])))
+    ];
+
+    Sqlgg_config.type_safe_enums := false;
+  )
 ]
 
-let test_another_enum_2 () = 
+let test_enum_literal () = 
+
+  Sqlgg_config.type_safe_enums := true;
+
   do_test "CREATE TABLE test36 (status enum('active','pending','deleted') NOT NULL DEFAULT 'pending')" [] [];
   
   let stmt = parse {|INSERT INTO test36 VALUES(^@'pending')|} in
@@ -863,7 +871,7 @@ let test_another_enum_2 () =
     [attr' ~extra:[NotNull; WithDefault] "status" 
       (Type.(Enum (Enum_kind.Ctors.of_list ["active"; "pending"; "deleted"])))]
     stmt6.schema;
-  ()
+  Sqlgg_config.type_safe_enums := false
 
 let run () =
   Gen.params_mode := Some Named;
@@ -890,8 +898,8 @@ let run () =
     "test_subquery_nullability" >::: test_subquery_nullability;
     "test_values_row" >::: test_values_row;
     "test_select_exposed_alias" >::: test_select_exposed_alias;
-    "test_another_enum" >::: test_another_enum;
-    "test_another_enum_2" >:: test_another_enum_2;
+    "test_enum_as_variant" >::: test_enum_as_variant;
+    "test_enum_literal" >:: test_enum_literal;
   ]
   in
   let test_suite = "main" >::: tests in


### PR DESCRIPTION
### Description
This PR introduces two main enums related features:

#### 1. String Literal Types and Unions
The primary feature is that any string literal now has a StringLiteral type. When used in expressions like:

```
ROW..VALUES
SELECT .. UNION
WHERE IN (...)
@param { ...} | { ... } | {...}
```

or any other cases where `StringLiteral` can accept multiple values, the type will be inferred as a Union.
There are two types of Unions:

Open Union (resulting from combining StringLiterals or other Unions)
Closed Union (literal/Enum)

The relationships between these types can be seen [here](https://github.com/ygrek/sqlgg/pull/152/files#diff-080579952fb3ca76eab28b5486112bfe26d6ba34f8f0edcd115f0a37aee1a168R78-R105)

Also check [tests](https://github.com/ygrek/sqlgg/pull/152/files#diff-8ea9ba782f39d6a4f13234e5c57b9662624994b402b68b3b1e62bd255f7e10b5R821-R883)

This PR adds a new flag `type-safe-enums` (name is negotiable). When this flag is enabled parameters to enum fields and enum literals (new syntax too) now are checked.

##### Type Inference and Subtyping Example

```sql
INSERT INTO `tblname` (`col1`, `col2`, `col3`, `col4`, `col5`) 
SELECT @param3 { A { 'A' } | B { 'B' } | C { 'C' } }
-- rest of the query omitted for clarity
```

##### Enum Type Inference
In this case, the matching values are inferred as:

StringLiteral 'A'
StringLiteral 'B'
StringLiteral 'C'

These are then combined into an enum type A | B | C. The system verifies that this enum is either the same type as or a subtype of the closed enum A | B | C

##### Subtyping Rules
For example, this would be valid:

```sql
@param3 { A { 'A' } | B { 'B' } }
```

Because A | B is a valid subtype of A | B | C - you can safely write a value of type A | B where A | B | C is expected.

##### String Operations and Type Coercion
String operations work naturally:

```sql
SELECT CONCAT(col3, 'test') FROM tblname;
```

This is valid because Enum is a subtype of Text, so the enum value is automatically coerced to text. The reverse operation (text to enum) is not allowed.
Here's a complete example demonstrating insertion with string concatenation:

```sql
INSERT INTO tblname (col3) 
SELECT CONCAT(
  @param3 { A { 'A' } | B { 'B' } | C { 'C' } },
  '_suffix'
);
```

This will fail type checking because:

col3 expects an enum of type A | B | C
CONCAT() produces a Text type
You cannot assign a Text value to an enum field - even if the text matches one of the enum variants (like 'A', 'B', or 'C')


```sql
INSERT INTO tblname (col3) VALUES ('A');  -- Ok
INSERT INTO tblname (col3) VALUES (CONCAT('A', '')); -- Fails: Text to Enum
```

#### 2. Optional and flag-controlled. It adds the ability to generate polymorphic variants when a parameter is inferred as an enum.

#### Let's make an example.

##### DDL:

```sql
CREATE TABLE `some_table` (
  `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
  `status` enum('pending','sending','sent','cancelled')  NOT NULL,
  `status_b` enum('a','b','c','d')  NOT NULL
);
```

#### Example (flag is disabled)

```sql
INSERT INTO `some_table` (
  `status`,
  `status_b`
) VALUES (
  'pending',
  @status_b
);
```

Here nothing is changed

```ocaml
  let insert_some_table_0 db ~status_b =
    let set_params stmt =
      let p = T.start_params stmt (1) in
      T.set_param_Text p status_b;
      T.finish_params p
    in
    T.execute db ("INSERT INTO `some_table` (\n\
  `status`,\n\
  `status_b`\n\
) VALUES (\n\
  'pending',\n\
  ?\n\
)") set_params
```

This is what is generated

#### Example (flag is enabled)


```sql
INSERT INTO `some_table` (
  `status`,
  `status_b`
) VALUES (
 'pending',
  @status_b
);
```

This is the result

```ocaml
    module Enum_0 = T.Make_enum(struct
      type t = [`A | `B | `C | `D]
      let inj = function | "a" -> `A | "b" -> `B | "c" -> `C | "d" -> `D | s -> failwith (Printf.sprintf "Invalid enum value: %s" s)
      let proj = function  | `A -> "a"| `B -> "b"| `C -> "c"| `D -> "d"
    end)

  let insert_some_table_0 db ~status_b =
    let set_params stmt =
      let p = T.start_params stmt (1) in
      Enum_0.set_param p status_b;
      T.finish_params p
    in
    T.execute db ("INSERT INTO `some_table` (\n\
  `status`,\n\
  `status_b`\n\
) VALUES (\n\
  'pending',\n\
  ?\n\
)") set_params
```
