### PR TITLE
gen_caml: generate option type for option record field insert_id

### DIFF
--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -489,7 +489,7 @@ let generate_stmt style index stmt =
     | Some id ->
     match id.label with
     | None -> failwith "empty label in tuple substitution"
-    | Some label -> sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; insert_id = 0L } | _ :: _ -> %s)|} label exec
+    | Some label -> sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> %s)|} label exec
   in
   output "%s%s" bind exec;
   if style = `Fold then output "(fun () -> IO.return !r_acc)";


### PR DESCRIPTION
follow-up of 9fa038598a266df37cb92c31a4d547ec01694ebc (in which a field was made oiptional, but not changes were made to the caml code generation)