### PR TITLE
Specialise inserts

### DIFF
--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -29,6 +29,7 @@ module type FNS = sig
   type statement
   type row
   type execute_response
+  type maybe_insert_response
 
   val finish_params : params -> result io_future
 
@@ -56,6 +57,12 @@ module type FNS = sig
     @raise Oops on error
   *)
   val execute : [>`WR] connection -> string -> (statement -> result io_future) -> execute_response io_future
+
+  (* execute but an insert: raise if [insert_id] is 0 *)
+  val insert : [>`WR] connection -> string -> (statement -> result io_future) -> execute_response io_future
+
+  (* insert but with special clause ON CONFLICT which might make it not insert *)
+  val maybe_insert : [>`WR] connection -> string -> (statement -> result io_future) -> maybe_insert_response io_future
 end
 
 module type M = sig
@@ -65,7 +72,8 @@ module type M = sig
   type params
   type row
   type result
-  type execute_response = { affected_rows: int64; insert_id: int64 option }
+  type execute_response = { affected_rows: int64; insert_id: int64 }
+  type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
 
   (** datatypes *)
   module Types : sig
@@ -125,6 +133,7 @@ module type M = sig
     with type statement := statement
     with type row := row
     with type execute_response := execute_response
+    with type maybe_insert_response := maybe_insert_response
 
 end
 
@@ -142,5 +151,6 @@ module type M_io = sig
     with type statement := statement
     with type row := row
     with type execute_response := execute_response
+    with type maybe_insert_response := maybe_insert_response
 
 end

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -72,7 +72,8 @@ type 'a connection = S.db
 type params = statement * int * int ref
 type row = statement
 type result = unit
-type execute_response = { affected_rows: int64; insert_id: int64 option }
+type execute_response = { affected_rows: int64; insert_id: int64 }
+type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
 
 type num = int64
 type text = string
@@ -159,13 +160,20 @@ let execute db sql set_params =
     set_params stmt;
     let rc = S.step (fst stmt) in
     if rc <> S.Rc.DONE then raise (Oops (sprintf "execute : %s" sql));
-    let insert_id =
-      match S.last_insert_rowid db with
-      | 0L -> None
-      | x -> Some x
-    in
-    { affected_rows = Int64.of_int (S.changes db); insert_id; }
+    { affected_rows = Int64.of_int (S.changes db); insert_id = S.last_insert_rowid db; }
   )
+
+let insert db sql set_params =
+  let response = execute db sql set_params in
+  if Int64.equal response.insert_id 0L then
+    raise (Oops "insert got no insert_id")
+  else
+    response
+
+let maybe_insert db sql set_params =
+  let { affected_rows; insert_id } = execute db sql set_params in
+  let maybe_insert_id = if Int64.equal insert_id 0L then None else Some insert_id in
+  { affected_rows; maybe_insert_id }
 
 let select_one_maybe db sql set_params convert =
   with_sql db sql (fun stmt ->

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -159,13 +159,23 @@ let output_select1_cb _ schema =
   output "in";
   name
 
+let has_on_conflict schema =
+  (List.exists (fun { extra; _ } -> Constraints.exists (function OnConflict _ -> true |
+    PrimaryKey | NotNull | Null | Unique | Autoincrement | WithDefault
+        -> false) extra) schema)
+
 let output_schema_binder index schema kind =
-  match schema with
-  | [] -> "execute",""
-  | _ -> match kind with
-         | Stmt.Select `Zero_one -> "select_one_maybe", output_select1_cb index schema
-         | Select `One -> "select_one", output_select1_cb index schema
-         | _ -> "select",output_schema_binder index schema
+  match schema, kind with
+  | [], Stmt.Insert (_, _) ->
+      if has_on_conflict schema then
+        "insert_with_on_conflict",""
+      else
+        "insert",""
+  | [], _ -> "execute",""
+  | _, Select `Zero_one -> "select_one_maybe", output_select1_cb index schema
+  | _, Select `One -> "select_one", output_select1_cb index schema
+  | _, _ -> "select",output_schema_binder index schema
+
 
 let is_callback stmt =
   match stmt.schema, stmt.kind with
@@ -489,7 +499,13 @@ let generate_stmt style index stmt =
     | Some id ->
     match id.label with
     | None -> failwith "empty label in tuple substitution"
-    | Some label -> sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> %s)|} label exec
+    | Some label ->
+    match stmt.kind with
+    | Insert (_, _) when has_on_conflict stmt.schema ->
+        sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; maybe_insert_id = None } | _ :: _ -> %s)|} label exec
+    | _ ->
+        sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; insert_id = 0L } | _ :: _ -> %s)|} label exec
+
   in
   output "%s%s" bind exec;
   if style = `Fold then output "(fun () -> IO.return !r_acc)";


### PR DESCRIPTION
on top of https://github.com/ygrek/sqlgg/pull/157

This PR treats different kinds of non-query statements differently. Specifically, it specialises the function generated for `INSERT` statements to fail when `insert_id=0L` and sets a different return type for `INSERT` statements which have an `ON CONFLICT` clause (to strongly encourage users to check whether the statement inserted or not).

This is to restore some of the backwards compatibility with the state that the library was in before the introduciton of the option type in the return of `insert`.