### PR TITLE
Add subqueries ctor instead of ResFun

### DIFF
--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -37,6 +37,7 @@ type enum_ctor_value_data = { ctor_name: string; pos: pos; }  [@@deriving show]
 type res_expr =
   | ResValue of Type.t (** literal value *)
   | ResParam of param
+  | ResSelect of Type.t * vars
   | ResInTupleList of param_id * res_in_tuple_list
   | ResInparam of param
   | ResChoices of param_id * res_expr choices
@@ -88,6 +89,7 @@ let rec get_params_of_res_expr (e:res_expr) =
   let rec loop acc e =
     match e with
     | ResAggValue e -> loop acc e
+    | ResSelect (_, p) -> p @ acc
     | ResParam p -> Single p::acc
     | ResOptionBoolChoice { choice_id; res_choice; pos} -> 
       OptionBoolChoice (choice_id, get_params_of_res_expr res_choice, pos) :: acc
@@ -204,11 +206,12 @@ let resolve_aggregations =
     match res_expr with
     | ResFun (Agg kind, res) -> ResFun(Agg kind, List.map (handle ~is_agg:true) res)
     | ResFun (Ret _, _) when is_agg -> ResAggValue(res_expr)
+    | ResSelect _  when is_agg -> ResAggValue(res_expr)
     | ResFun (fn, res) -> ResFun(fn, List.map (handle ~is_agg) res)
     | ResInTupleList (param_id, Res res) -> ResInTupleList(param_id, Res (List.map (handle ~is_agg) res))
     | ResInChoice(param_id, kind, res) -> ResInChoice(param_id, kind, (handle ~is_agg res))
     | ResValue _ | ResParam _  | ResOptionBoolChoice _
-    | ResInparam _| ResChoices (_, _)
+    | ResInparam _| ResChoices (_, _) | ResSelect _
     | ResAggValue _ | ResInTupleList _ -> res_expr
   in
   handle ~is_agg:false 
@@ -260,6 +263,7 @@ let rec resolve_columns env expr =
         | ResValue _
         | ResParam _
         | ResAggValue _
+        | ResSelect _
         | ResFun _ -> res_expr
         | ResInparam _
         | ResChoices _
@@ -274,23 +278,6 @@ let rec resolve_columns env expr =
     | Fun (r,l) ->
       ResFun (r,List.map each l)
     | SelectExpr (select, usage) ->
-      let rec params_of_var = function
-        | Single p -> [ResParam p]
-        (* Better do not separate ChoiceIn and SingleIn , fix it subsequently *)
-        | SingleIn p -> failed ~at:p.id.pos "Unexpected right side of WHERE IN"
-        | ChoiceIn { vars; param; kind } -> 
-          (* SingleIn is the right-side parameter inside WHERE IN expression (e.g., expr IN @param2, this is @param2 here) *)
-          let rec extract_singlein acc = function
-          | [] -> failed ~at:param.pos "Invalid IN containing left part and containing nothing inside ()"
-           (* The rest vars are params contained in the left side part of the expression (before IN)  *)
-          | (SingleIn p) :: xs -> (p, List.rev_append acc xs)
-          | x :: xs -> extract_singlein (x :: acc) xs in
-          let (p, vars) = extract_singlein [] vars in
-          ResInChoice (param, kind, ResInparam p) :: as_params vars
-        | Choice (_,l) -> l |> flat_map (function Simple (_, vars) -> Option.map_default as_params [] vars | Verbatim _ -> [])
-        | OptionBoolChoice ( p, _, _) -> failed  ~at:p.pos "BoolChoice isn't supported in Select"
-        | TupleList (p, _) -> failed ~at:p.pos "FIXME TupleList in SELECT subquery"
-      and as_params p = flat_map params_of_var p in
       let (schema,p,_) = eval_select_full env select in
       let schema = Schema.Source.from_schema schema in
       (* represet nested selects as functions with sql parameters as function arguments, some hack *)
@@ -319,9 +306,9 @@ let rec resolve_columns env expr =
         | ({ columns = [_]; _ }, _) -> default_null
         | _ -> raise (Schema.Error (schema, "nested sub-select used as an expression returns more than one column"))
         in
-        ResFun (Type.Ret (typ), as_params p)
+        ResSelect (typ, p)
       | s, `AsValue -> raise (Schema.Error (s, "only one column allowed for SELECT operator in this expression"))
-      | _, `Exists -> ResFun (Type.Ret (Type.depends Any), as_params p)
+      | _, `Exists -> ResSelect (Type.depends Any, p)
   in
   each expr
 
@@ -334,6 +321,7 @@ and assign_types env expr =
     | ResValue t -> e, `Ok t
     | ResParam p -> e, `Ok p.typ
     | ResInparam p -> e, `Ok p.typ
+    | ResSelect (t, _) -> e, `Ok t
     | ResOptionBoolChoice choice ->
       let (res_choice, t) = typeof choice.res_choice in
       let t =

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -89,7 +89,7 @@ let rec get_params_of_res_expr (e:res_expr) =
   let rec loop acc e =
     match e with
     | ResAggValue e -> loop acc e
-    | ResSelect (_, p) -> p @ acc
+    | ResSelect (_, p) -> (List.rev p) @ acc
     | ResParam p -> Single p::acc
     | ResOptionBoolChoice { choice_id; res_choice; pos} -> 
       OptionBoolChoice (choice_id, get_params_of_res_expr res_choice, pos) :: acc

--- a/test/out/subquery_res_expr.xml
+++ b/test/out/subquery_res_expr.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_tbl_1" sql="CREATE TABLE tbl_1 (&#x0A;    col_1_1 INT AUTO_INCREMENT PRIMARY KEY,&#x0A;    col_1_2 VARCHAR(100) NOT NULL,&#x0A;    col_1_3 VARCHAR(50) NOT NULL,&#x0A;    col_1_4 FLOAT DEFAULT 0.0,&#x0A;    col_1_5 BOOLEAN DEFAULT FALSE&#x0A;) ENGINE=InnoDB" category="DDL" kind="create" target="tbl_1" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_tbl_2" sql="CREATE TABLE tbl_2 (&#x0A;    col_2_1 INT AUTO_INCREMENT PRIMARY KEY,&#x0A;    col_2_2 INT NOT NULL,&#x0A;    col_2_3 DATE NOT NULL,&#x0A;    col_2_4 VARCHAR(20) NOT NULL&#x0A;) ENGINE=InnoDB" category="DDL" kind="create" target="tbl_2" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="create_tbl_3" sql="CREATE TABLE tbl_3 (&#x0A;    col_3_1 INT AUTO_INCREMENT PRIMARY KEY,&#x0A;    col_3_2 INT NOT NULL,&#x0A;    col_3_3 INT NOT NULL,&#x0A;    col_3_4 INT DEFAULT 1,&#x0A;    col_3_5 FLOAT DEFAULT 0.0,&#x0A;    FOREIGN KEY (col_3_2) REFERENCES tbl_2(col_2_1) ON DELETE CASCADE,&#x0A;    FOREIGN KEY (col_3_3) REFERENCES tbl_1(col_1_1) ON DELETE CASCADE&#x0A;) ENGINE=InnoDB" category="DDL" kind="create" target="tbl_3" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_3" sql="SELECT col_1_2, col_1_3, col_1_4 &#x0A;FROM tbl_1&#x0A;WHERE col_1_1 IN (&#x0A;    SELECT col_1_1 &#x0A;    FROM tbl_1&#x0A;    WHERE {TODO dynamic choice}&#x0A;)" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="col_1_2" type="Text"/>
+   <value name="col_1_3" type="Text"/>
+   <value name="col_1_4" type="Float" nullable="true"/>
+  </out>
+ </stmt>
+ <stmt name="select_4" sql="SELECT t2.col_2_1, t2.col_2_4&#x0A;FROM tbl_2 t2&#x0A;WHERE col_2_1 IN (&#x0A;    SELECT col_2_1 &#x0A;    FROM tbl_2&#x0A;    WHERE {TODO dynamic choice}&#x0A;)" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="col_2_1" type="Int"/>
+   <value name="col_2_4" type="Text"/>
+  </out>
+ </stmt>
+ <stmt name="select_5" sql="SELECT t1.col_1_2, t1.col_1_3, t1.col_1_4&#x0A;FROM tbl_1 t1&#x0A;WHERE t1.col_1_1 IN (&#x0A;    SELECT col_1_1&#x0A;    FROM tbl_1&#x0A;    WHERE {TODO dynamic choice}&#x0A;)" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="col_1_2" type="Text"/>
+   <value name="col_1_3" type="Text"/>
+   <value name="col_1_4" type="Float" nullable="true"/>
+  </out>
+ </stmt>
+ <stmt name="select_6" sql="SELECT t2.col_2_1, t2.col_2_2, t2.col_2_4&#x0A;FROM tbl_2 t2&#x0A;WHERE t2.col_2_1 IN (&#x0A;    SELECT t2.col_2_1&#x0A;    FROM tbl_2&#x0A;    WHERE {TODO dynamic choice}&#x0A;)" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="col_2_1" type="Int"/>
+   <value name="col_2_2" type="Int"/>
+   <value name="col_2_4" type="Text"/>
+  </out>
+ </stmt>
+ <table name="tbl_3">
+  <schema>
+   <value name="col_3_1" type="Int"/>
+   <value name="col_3_2" type="Int"/>
+   <value name="col_3_3" type="Int"/>
+   <value name="col_3_4" type="Int" nullable="true"/>
+   <value name="col_3_5" type="Float" nullable="true"/>
+  </schema>
+ </table>
+ <table name="tbl_2">
+  <schema>
+   <value name="col_2_1" type="Int"/>
+   <value name="col_2_2" type="Int"/>
+   <value name="col_2_3" type="Datetime"/>
+   <value name="col_2_4" type="Text"/>
+  </schema>
+ </table>
+ <table name="tbl_1">
+  <schema>
+   <value name="col_1_1" type="Int"/>
+   <value name="col_1_2" type="Text"/>
+   <value name="col_1_3" type="Text"/>
+   <value name="col_1_4" type="Float" nullable="true"/>
+   <value name="col_1_5" type="Bool" nullable="true"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/subquery_res_expr.sql
+++ b/test/subquery_res_expr.sql
@@ -1,0 +1,120 @@
+CREATE TABLE tbl_1 (
+    col_1_1 INT AUTO_INCREMENT PRIMARY KEY,
+    col_1_2 VARCHAR(100) NOT NULL,
+    col_1_3 VARCHAR(50) NOT NULL,
+    col_1_4 FLOAT DEFAULT 0.0,
+    col_1_5 BOOLEAN DEFAULT FALSE
+) ENGINE=InnoDB;
+
+CREATE TABLE tbl_2 (
+    col_2_1 INT AUTO_INCREMENT PRIMARY KEY,
+    col_2_2 INT NOT NULL,
+    col_2_3 DATE NOT NULL,
+    col_2_4 VARCHAR(20) NOT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE tbl_3 (
+    col_3_1 INT AUTO_INCREMENT PRIMARY KEY,
+    col_3_2 INT NOT NULL,
+    col_3_3 INT NOT NULL,
+    col_3_4 INT DEFAULT 1,
+    col_3_5 FLOAT DEFAULT 0.0,
+    FOREIGN KEY (col_3_2) REFERENCES tbl_2(col_2_1) ON DELETE CASCADE,
+    FOREIGN KEY (col_3_3) REFERENCES tbl_1(col_1_1) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+SELECT col_1_2, col_1_3, col_1_4 
+FROM tbl_1
+WHERE col_1_1 IN (
+    SELECT col_1_1 
+    FROM tbl_1
+    WHERE @var_1 { 
+        Pat_1 { col_1_3 = 'cat_a' } 
+        | Pat_2 { col_1_4 > 300.00 }
+    }
+);
+
+SELECT t2.col_2_1, t2.col_2_4
+FROM tbl_2 t2
+WHERE col_2_1 IN (
+    SELECT col_2_1 
+    FROM tbl_2
+    WHERE @var_2 {
+        Pat_3 { t2.col_2_4 = 'stat_1' }
+        | Pat_4 {
+            EXISTS (
+                SELECT 1 
+                FROM tbl_3 t3
+                JOIN tbl_1 t1 ON t3.col_3_3 = t1.col_1_1
+                WHERE t3.col_3_2 = t2.col_2_1
+                AND t1.col_1_3 = 'cat_a'
+            )
+        }
+    }
+);
+
+SELECT t1.col_1_2, t1.col_1_3, t1.col_1_4
+FROM tbl_1 t1
+WHERE t1.col_1_1 IN (
+    SELECT col_1_1
+    FROM tbl_1
+    WHERE @var_4 {
+        Pat_7 { 
+            col_1_3 = 'cat_a' AND
+            @var_5 {
+                SubPat_1 { col_1_4 > 200 }
+                | SubPat_2 { col_1_4 <= 200 }
+            }
+        }
+        | Pat_8 {
+            col_1_3 = 'cat_b' AND
+            @var_6 {
+                SubPat_3 { col_1_5 = TRUE }
+                | SubPat_4 { col_1_5 = FALSE }
+            }
+        }
+    }
+);
+
+SELECT t2.col_2_1, t2.col_2_2, t2.col_2_4
+FROM tbl_2 t2
+WHERE t2.col_2_1 IN (
+    SELECT t2.col_2_1
+    FROM tbl_2
+    WHERE @var_7 {
+        Pat_9 {
+            t2.col_2_4 = 'stat_1' AND
+            EXISTS (
+                SELECT 1
+                FROM tbl_3 t3
+                WHERE t3.col_3_2 = t2.col_2_1
+                GROUP BY t3.col_3_2
+                HAVING COUNT(*) > 1
+            )
+        }
+        | Pat_10 {
+            t2.col_2_4 = 'stat_3' AND
+            EXISTS (
+                SELECT 1
+                FROM tbl_3 t3
+                WHERE t3.col_3_2 = t2.col_2_1 AND
+                t3.col_3_5 * t3.col_3_4 > 300
+            )
+        }
+        | Pat_11 {
+            @var_8 {
+                SubPat_5 { 
+                    t2.col_2_2 IN (
+                        SELECT col_2_2
+                        FROM tbl_2
+                        GROUP BY col_2_2
+                        HAVING COUNT(*) > 1
+                    )
+                }
+                | SubPat_6 {
+                    t2.col_2_3 > '2024-03-01'
+                }
+            }
+        }
+    }
+);


### PR DESCRIPTION
### Description

This PR fixes a bug related to subqueries and the Choices expression.

Problem
Before this PR, when inferring a subquery, we would extract vars, but then attempt to reconstruct an expression from them ([see this code block](https://github.com/ygrek/sqlgg/pull/159/files#diff-e5b2ac5b61488c46149361560003e3185b33725d73f243f2cce2fc3020757438L277-L290)). However, an exact isomorphism from res_expr to vars is not always possible, as many expressions cannot be reconstructed from vars.

For example, consider the following query:

sql
Копировать код
select 1 where 1 in (select 1 where @foo { Foo { IF (...) } | Bar { IF (...) } })
In this case, inference produces vars, but we cannot reconstruct the original Choices expression.

Solution
This PR removes the problematic behavior and introduces a new ResSelect constructor to store vars