### PR TITLE
Revert "handle execute/insert/insert_with_on_conflict differently"

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -221,8 +221,7 @@ type 'a connection = M.t
 type params = statement * M.Field.value array * int ref
 type row = M.Field.t array
 type result = M.Res.t
-type execute_response = { affected_rows: int64; insert_id: int64 }
-type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
+type execute_response = { affected_rows: int64; insert_id: int64 option }
 
 module Types = Types
 
@@ -326,22 +325,13 @@ let execute db sql set_params =
   with_stmt db sql @@ fun stmt ->
   let open IO in
   set_params stmt >>=
-  fun res ->
-    return { affected_rows = Int64.of_int (M.Res.affected_rows res); insert_id = Int64.of_int (M.Res.insert_id res) }
-
-let insert db sql set_params =
-  let open IO in
-  execute db sql set_params >>= fun response ->
-  if Int64.equal response.insert_id 0L then
-    oops "insert has no insert_id"
-  else
-    return response
-
-let maybe_insert db sql set_params =
-  let open IO in
-  execute db sql set_params >>= fun { affected_rows; insert_id } ->
-  let maybe_insert_id = if Int64.equal insert_id 0L then None else Some insert_id in
-  return { affected_rows; maybe_insert_id }
+  fun res -> 
+    let insert_id =
+      match M.Res.insert_id res with
+      | 0 -> None
+      | x -> Some (Int64.of_int x)
+    in
+    return { affected_rows = Int64.of_int (M.Res.affected_rows res); insert_id }
 
 let select_one_maybe db sql set_params convert =
   with_stmt db sql @@ fun stmt ->

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -123,8 +123,7 @@ type 'a connection = Mysql.dbd
 type params = statement * string array * int ref
 type row = string option array
 type result = P.stmt_result
-type execute_response = { affected_rows: int64; insert_id: int64 }
-type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
+type execute_response = { affected_rows: int64; insert_id: int64 option }
 
 module Types = T
 
@@ -225,19 +224,12 @@ let execute db sql set_params =
   with_stmt db sql (fun stmt ->
     let _ = set_params stmt in
     if 0 <> P.real_status stmt then oops "execute : %s" sql;
-    { affected_rows = P.affected stmt; insert_id = P.insert_id stmt; })
-
-let insert db sql set_params =
-  let response = execute db sql set_params in
-  if Int64.equal response.insert_id 0L then
-    oops "insert has no insert_id"
-  else
-    response
-
-let maybe_insert db sql set_params =
-  let {affected_rows; insert_id} = execute db sql set_params in
-  let maybe_insert_id = if Int64.equal insert_id 0L then None else Some insert_id in
-  { affected_rows; maybe_insert_id }
+    let insert_id =
+      match P.insert_id stmt with
+      | 0L -> None
+      | x -> Some x
+    in
+    { affected_rows = P.affected stmt; insert_id; })
 
 let select_one_maybe db sql set_params convert =
   with_stmt db sql (fun stmt ->

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -37,7 +37,6 @@ module type FNS = sig
   type statement
   type row
   type execute_response
-  type maybe_insert_response
 
   val finish_params : params -> result io_future
 
@@ -65,12 +64,6 @@ module type FNS = sig
     @raise Oops on error
   *)
   val execute : [>`WR] connection -> string -> (statement -> result io_future) -> execute_response io_future
-
-  (* execute but an insert: raise if [insert_id] is 0 *)
-  val insert : [>`WR] connection -> string -> (statement -> result io_future) -> execute_response io_future
-
-  (* insert but with special clause ON CONFLICT which might make it not insert *)
-  val maybe_insert : [>`WR] connection -> string -> (statement -> result io_future) -> maybe_insert_response io_future
 end
 
 module type M = sig
@@ -80,8 +73,7 @@ module type M = sig
   type params
   type row
   type result
-  type execute_response = { affected_rows: int64; insert_id: int64 }
-  type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
+  type execute_response = { affected_rows: int64; insert_id: int64 option }
 
   (** datatypes *)
   module Types : sig
@@ -149,7 +141,6 @@ module type M = sig
     with type statement := statement
     with type row := row
     with type execute_response := execute_response
-    with type maybe_insert_response := maybe_insert_response
 
 end
 
@@ -167,6 +158,5 @@ module type M_io = sig
     with type statement := statement
     with type row := row
     with type execute_response := execute_response
-    with type maybe_insert_response := maybe_insert_response
 
 end

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -80,8 +80,7 @@ type 'a connection = S.db
 type params = statement * int * int ref
 type row = statement
 type result = unit
-type execute_response = { affected_rows: int64; insert_id: int64 }
-type maybe_insert_response = { affected_rows: int64; maybe_insert_id: int64 option }
+type execute_response = { affected_rows: int64; insert_id: int64 option }
 
 type num = int64
 type text = string
@@ -179,20 +178,13 @@ let execute db sql set_params =
     set_params stmt;
     let rc = S.step (fst stmt) in
     if rc <> S.Rc.DONE then raise (Oops (sprintf "execute : %s" sql));
-    { affected_rows = Int64.of_int (S.changes db); insert_id = S.last_insert_rowid db; }
+    let insert_id =
+      match S.last_insert_rowid db with
+      | 0L -> None
+      | x -> Some x
+    in
+    { affected_rows = Int64.of_int (S.changes db); insert_id; }
   )
-
-let insert db sql set_params =
-  let response = execute db sql set_params in
-  if Int64.equal response.insert_id 0L then
-    raise (Oops "insert got no insert_id")
-  else
-    response
-
-let maybe_insert db sql set_params =
-  let { affected_rows; insert_id } = execute db sql set_params in
-  let maybe_insert_id = if Int64.equal insert_id 0L then None else Some insert_id in
-  { affected_rows; maybe_insert_id }
 
 let select_one_maybe db sql set_params convert =
   with_sql db sql (fun stmt ->


### PR DESCRIPTION
### Description

The original [commit](https://github.com/ygrek/sqlgg/commit/6334e20613665be0277a9fb41d081d94ce131b50) added an error throw when LAST_INSERT_ID() = 0,  assuming this always indicates a failed insertion. However, this is  incorrect as LAST_INSERT_ID() can legitimately return 0 in several  valid scenarios:

1. Tables without AUTO_INCREMENT fields
2. Tables with composite primary keys without AUTO_INCREMENT
