### PR TITLE
Fix CI build

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -217,6 +217,7 @@ struct
 module IO = IO
 
 type statement = M.Stmt.t
+type 'a io_future = 'a
 type 'a connection = M.t
 type params = statement * M.Field.value array * int ref
 type row = M.Field.t array

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -120,6 +120,7 @@ module Make_(T : Types) = struct
 
 type statement = P.stmt
 type 'a connection = Mysql.dbd
+type 'a io_future = 'a
 type params = statement * string array * int ref
 type row = string option array
 type result = P.stmt_result

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -70,6 +70,7 @@ module type M = sig
 
   type statement
   type -'a connection
+  type 'a io_future
   type params
   type row
   type result
@@ -136,7 +137,7 @@ module type M = sig
   include FNS
     with type params := params
     with type result := result
-    with type 'a io_future := 'a
+    with type 'a io_future := 'a io_future
     with type 'a connection := 'a connection
     with type statement := statement
     with type row := row

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -76,6 +76,7 @@ module type Enum = sig
 end
 
 type statement = S.stmt * string
+type 'a io_future = 'a
 type 'a connection = S.db
 type params = statement * int * int ref
 type row = statement

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -4,6 +4,8 @@ exception At of ((int * int) * exn)
 let ($) f g = function x -> f (g x)
 
 external identity : 'a -> 'a = "%identity"
+
+let const c _ = c
 let flip f x y = f y x
 
 let tuck l x = l := x :: !l

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -363,7 +363,7 @@ and assign_types env expr =
             (String.concat ", " @@ List.map show types)
         in
         if !debug then eprintfn "func %s" (show_func ());
-        let types_to_arg each_arg = List.map (Fun.const each_arg) types in
+        let types_to_arg each_arg = List.map (const each_arg) types in
         let func =
           match func with
           | Multi (ret,each_arg) -> F (ret, types_to_arg each_arg)

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -464,7 +464,7 @@ let make_sql l =
         let label = resolve_tuple_label id in
         let schema = make_schema_of_tuple_types label types in
         let empty = schema 
-          |> List.map (Fun.const "NULL") 
+          |> List.map (const "NULL") 
           |> String.join ", " 
           |> sprintf {|"SELECT %s WHERE FALSE"|} in
         let not_empty = gen_tuple_substitution ~is_row:true label schema in


### PR DESCRIPTION
### Description

This PR fixes two things broking a build

- Using Fn module (ocaml 4.05.0 build)
- type constructors with identical parameters can be substituted  (ocaml 4.05.0 build)