### PR TITLE
implement multiple partition in window fns

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -498,6 +498,10 @@ type columns = column list [@@deriving show]
 
 let expr_to_string = show_expr
 
+let make_partition_by = List.iter (function
+  | Value _ -> fail "ORDER BY or PARTITION BY uses legacy position indication which is not supported, use expression."
+  | _ -> ())
+
 type assignments = (col_name * expr) list
 
 type insert_action =

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -490,8 +490,8 @@ window_function:
   | NTH_VALUE LPAREN e=expr COMMA INTEGER RPAREN { e }
   | either(LAG,LEAD) LPAREN e=expr pair(COMMA, pair(MINUS?,INTEGER))? RPAREN { e }
 
-window_spec: LPAREN e=partition? order? frame? RPAREN (* TODO order parameters? *) { e }
-partition: PARTITION BY expr { } (* TODO check no params *)
+window_spec: LPAREN e=partition? o=order? frame? RPAREN (* TODO order parameters? *) { (Option.may (fun o -> make_partition_by (List.map fst o )) o); e }
+partition: PARTITION BY e=expr_list { make_partition_by e} (* TODO check no params *)
 
 frame: either(ROWS,RANGE) either(frame_border, frame_between) { }
 

--- a/src/test.ml
+++ b/src/test.ml
@@ -892,9 +892,9 @@ let test_add_with_window_function = [
   tt {| SELECT MAX(NULL) OVER() |} [attr' ~nullability:(Nullable) "" Any;] [];
 
   (* Same but with PARTITION BY and ORDER BY *)
-  tt {| SELECT SUM(1) OVER(PARTITION BY 'a') |} [attr' "" Int;] [];
-  tt {| SELECT SUM(1) OVER(ORDER BY 1) |} [attr' "" Int;] [];
-  tt {| SELECT SUM(1) OVER(PARTITION BY 'a' ORDER BY 1) |} [attr' "" Int;] [];
+  tt {| SELECT SUM(1) OVER(PARTITION BY COALESCE(NULL, 'a')) |} [attr' "" Int;] [];
+  tt {| SELECT SUM(1) OVER(ORDER BY 1 + 1) |} [attr' "" Int;] [];
+  tt {| SELECT SUM(1) OVER(PARTITION BY CONCAT('a') ORDER BY 1 - 0) |} [attr' "" Int;] [];
 
   tt {| SELECT 1 + (SELECT COUNT(1) OVER() WHERE FALSE) |} [attr' ~nullability:(Nullable) "" Int;] [];
 

--- a/test/agg_window_cardinality.sql
+++ b/test/agg_window_cardinality.sql
@@ -1,0 +1,27 @@
+-- @this_cardinality_one
+SELECT SUM(running_total) as total_sum
+FROM (
+    SELECT sum(evt) OVER (PARTITION BY id ORDER BY dt) as running_total
+    FROM (
+        VALUES 
+            row(1, 1, 1), 
+            row(1, 1, 1), 
+            row(1, 2, -1), 
+            row(1, 2, 1), 
+            row(1, 3, -1), 
+            row(1, 4, -1)
+    ) as t(id, dt, evt)
+) as subquery;
+
+
+-- @this_cardinality_n
+SELECT SUM(evt) OVER (PARTITION BY id ORDER BY dt) as running_total
+FROM (
+    VALUES 
+        row(1, 1, 1), 
+        row(1, 1, 1), 
+        row(1, 2, -1), 
+        row(1, 2, 1), 
+        row(1, 3, -1), 
+        row(1, 4, -1)
+) AS t(id, dt, evt);

--- a/test/out/agg_window_cardinality.xml
+++ b/test/out/agg_window_cardinality.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="this_cardinality_one" sql="SELECT SUM(running_total) as total_sum&#x0A;FROM (&#x0A;    SELECT sum(evt) OVER (PARTITION BY id ORDER BY dt) as running_total&#x0A;    FROM (&#x0A;        VALUES &#x0A;            row(1, 1, 1), &#x0A;            row(1, 1, 1), &#x0A;            row(1, 2, -1), &#x0A;            row(1, 2, 1), &#x0A;            row(1, 3, -1), &#x0A;            row(1, 4, -1)&#x0A;    ) as t(id, dt, evt)&#x0A;) as subquery" category="DQL" kind="select" cardinality="1">
+  <in/>
+  <out>
+   <value name="total_sum" type="Int" nullable="true"/>
+  </out>
+ </stmt>
+ <stmt name="this_cardinality_n" sql="SELECT SUM(evt) OVER (PARTITION BY id ORDER BY dt) as running_total&#x0A;FROM (&#x0A;    VALUES &#x0A;        row(1, 1, 1), &#x0A;        row(1, 1, 1), &#x0A;        row(1, 2, -1), &#x0A;        row(1, 2, 1), &#x0A;        row(1, 3, -1), &#x0A;        row(1, 4, -1)&#x0A;) AS t(id, dt, evt)" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="running_total" type="Int"/>
+  </out>
+ </stmt>
+</sqlgg>


### PR DESCRIPTION
### Description

This PR adds a support to use multiple expressions inside window functions PARTITION/ORDER and fixes cardinality when an aggregate + window function (examples in [tests](https://github.com/ygrek/sqlgg/pull/175/files#diff-486d205fa24abfd306b6e1951a931d199db61687d57a2d5961155e80af41cc8eR1-R27))
It also bans to use pure literals  IN PARTITION/ORDER BY, example: https://www.db-fiddle.com/f/7LzcxYEe6KdEYLzUZmHwrQ/0