### PR TITLE
support default value as expression

### DIFF
--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -391,6 +391,7 @@ default_value: e=single_literal_value
              | LPAREN e=expr RPAREN { e }
 
 set_column: name=attr_name EQUAL e=expr { name,e }
+           | name=attr_name EQUAL DEFAULT { name, Value (depends Any) }
 
 anyall: ANY | ALL | SOME { }
 
@@ -429,6 +430,7 @@ expr:
     | VALUES LPAREN n=IDENT RPAREN { Inserted n }
     | v=literal_value | v=datetime_value { v }
     | v=interval_unit { v }
+    | DEFAULT { Value (depends Any) }
     | e1=expr mnot(IN) l=sequence(expr) { poly (depends Bool) (e1::l) }
     | e1=expr mnot(IN) LPAREN select=select_stmt RPAREN { poly (depends Bool) [e1; SelectExpr (select, `AsValue)] }
     | e1=expr IN table=table_name { Tables.check table; e1 }
@@ -511,7 +513,6 @@ case_branch: WHEN e1=expr THEN e2=expr { [e1;e2] }
 like: LIKE | LIKE_OP { }
 
 choice_body: c1=LCURLY e=expr c2=RCURLY { (c1,Some e,c2) }
-          | c1=LCURLY DEFAULT c2=RCURLY { (c1,Some (Value (depends Any)),c2) }
 choice: parser_state_normal label=IDENT? e=choice_body? { let (c1,e,c2) = Option.default (0,None,0) e in ({ label; pos = (c1+1,c2) },e) }
 choices: separated_nonempty_list(pair(parser_state_ident,NUM_BIT_OR),choice) { $1 }
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -390,8 +390,11 @@ default_value: e=single_literal_value
              | e=datetime_value { e } (* sub expr ? *)
              | LPAREN e=expr RPAREN { e }
 
-set_column: name=attr_name EQUAL e=expr { name,e }
-          | name=attr_name EQUAL DEFAULT { name, Value (depends Any) }
+set_column: name=attr_name EQUAL e=set_column_expr { name,e }
+
+set_column_expr:
+  | e=expr { e }
+  | DEFAULT { Value (depends Any) }
 
 anyall: ANY | ALL | SOME { }
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -433,7 +433,6 @@ expr:
     | VALUES LPAREN n=IDENT RPAREN { Inserted n }
     | v=literal_value | v=datetime_value { v }
     | v=interval_unit { v }
-    | DEFAULT { Value (depends Any) }
     | e1=expr mnot(IN) l=sequence(expr) { poly (depends Bool) (e1::l) }
     | e1=expr mnot(IN) LPAREN select=select_stmt RPAREN { poly (depends Bool) [e1; SelectExpr (select, `AsValue)] }
     | e1=expr IN table=table_name { Tables.check table; e1 }
@@ -515,7 +514,7 @@ in_or_not_in: IN { `In } | NOT IN { `NotIn }
 case_branch: WHEN e1=expr THEN e2=expr { [e1;e2] }
 like: LIKE | LIKE_OP { }
 
-choice_body: c1=LCURLY e=expr c2=RCURLY { (c1,Some e,c2) }
+choice_body: c1=LCURLY e=set_column_expr c2=RCURLY { (c1,Some e,c2) }
 choice: parser_state_normal label=IDENT? e=choice_body? { let (c1,e,c2) = Option.default (0,None,0) e in ({ label; pos = (c1+1,c2) },e) }
 choices: separated_nonempty_list(pair(parser_state_ident,NUM_BIT_OR),choice) { $1 }
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -386,7 +386,9 @@ column_def_extra: PRIMARY? KEY { Some PrimaryKey }
                 | COLLATE IDENT { None }
                 | pair(GENERATED,ALWAYS)? AS LPAREN expr RPAREN either(VIRTUAL,STORED)? { None } (* FIXME params and typing ignored *)
 
-default_value: e=single_literal_value | e=datetime_value { e } (* sub expr ? *)
+default_value: e=single_literal_value 
+             | e=datetime_value { e } (* sub expr ? *)
+             | LPAREN e=expr RPAREN { e }
 
 set_column: name=attr_name EQUAL e=expr { name,e }
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -391,7 +391,7 @@ default_value: e=single_literal_value
              | LPAREN e=expr RPAREN { e }
 
 set_column: name=attr_name EQUAL e=expr { name,e }
-           | name=attr_name EQUAL DEFAULT { name, Value (depends Any) }
+          | name=attr_name EQUAL DEFAULT { name, Value (depends Any) }
 
 anyall: ANY | ALL | SOME { }
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -511,6 +511,7 @@ case_branch: WHEN e1=expr THEN e2=expr { [e1;e2] }
 like: LIKE | LIKE_OP { }
 
 choice_body: c1=LCURLY e=expr c2=RCURLY { (c1,Some e,c2) }
+          | c1=LCURLY DEFAULT c2=RCURLY { (c1,Some (Value (depends Any)),c2) }
 choice: parser_state_normal label=IDENT? e=choice_body? { let (c1,e,c2) = Option.default (0,None,0) e in ({ label; pos = (c1+1,c2) },e) }
 choices: separated_nonempty_list(pair(parser_state_ident,NUM_BIT_OR),choice) { $1 }
 

--- a/test/default_expression.sql
+++ b/test/default_expression.sql
@@ -9,3 +9,7 @@ INSERT INTO `registration_feedbacks`
 SET
   `user_message` = @user_message,
   `grant_types` = @grant_types { None { DEFAULT } | Some { @grant_types } };
+
+INSERT INTO `registration_feedbacks`
+SET
+  `user_message` = DEFAULT;

--- a/test/default_expression.sql
+++ b/test/default_expression.sql
@@ -1,5 +1,11 @@
 CREATE TABLE IF NOT EXISTS registration_feedbacks (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),
+  `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO `registration_feedbacks`
+SET
+  `user_message` = @user_message,
+  `grant_types` = @grant_types { None { DEFAULT } | Some { @grant_types } };

--- a/test/default_expression.sql
+++ b/test/default_expression.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS registration_feedbacks (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/test/out/default_expression.xml
+++ b/test/out/default_expression.xml
@@ -12,6 +12,10 @@
   </in>
   <out/>
  </stmt>
+ <stmt name="insert_registration_feedbacks_2" sql="INSERT INTO `registration_feedbacks`&#x0A;SET&#x0A;  `user_message` = DEFAULT" category="DML" kind="insert" target="registration_feedbacks" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
  <table name="registration_feedbacks">
   <schema>
    <value name="id" type="Int"/>

--- a/test/out/default_expression.xml
+++ b/test/out/default_expression.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_registration_feedbacks" sql="CREATE TABLE IF NOT EXISTS registration_feedbacks (&#x0A;  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,&#x0A;  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),&#x0A;  PRIMARY KEY (`id`)&#x0A;) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" category="DDL" kind="create" target="registration_feedbacks" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <table name="registration_feedbacks">
+  <schema>
+   <value name="id" type="Int"/>
+   <value name="user_message" type="Text"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/out/default_expression.xml
+++ b/test/out/default_expression.xml
@@ -1,14 +1,22 @@
 <?xml version="1.0"?>
 
 <sqlgg>
- <stmt name="create_registration_feedbacks" sql="CREATE TABLE IF NOT EXISTS registration_feedbacks (&#x0A;  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,&#x0A;  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),&#x0A;  PRIMARY KEY (`id`)&#x0A;) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" category="DDL" kind="create" target="registration_feedbacks" cardinality="0">
+ <stmt name="create_registration_feedbacks" sql="CREATE TABLE IF NOT EXISTS registration_feedbacks (&#x0A;  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,&#x0A;  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),&#x0A;  `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',&#x0A;  PRIMARY KEY (`id`)&#x0A;) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" category="DDL" kind="create" target="registration_feedbacks" cardinality="0">
   <in/>
+  <out/>
+ </stmt>
+ <stmt name="insert_registration_feedbacks_1" sql="INSERT INTO `registration_feedbacks`&#x0A;SET&#x0A;  `user_message` = @user_message,&#x0A;  `grant_types` = {TODO dynamic choice}" category="DML" kind="insert" target="registration_feedbacks" cardinality="0">
+  <in>
+   <value name="user_message" type="Text"/>
+   <value name="grant_types" type="Text"/>
+  </in>
   <out/>
  </stmt>
  <table name="registration_feedbacks">
   <schema>
    <value name="id" type="Int"/>
    <value name="user_message" type="Text"/>
+   <value name="grant_types" type="Text"/>
   </schema>
  </table>
 </sqlgg>


### PR DESCRIPTION
The [first commit](https://github.com/ygrek/sqlgg/commit/283d56f576c2b1967b6f6daa9b24f303bc98c47e) adds support for default value as expression

```sql
CREATE TABLE IF NOT EXISTS registration_feedbacks (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
```

It currently fails with the following error

```
dune runtest
./run_test                            
Running regression tests
==> CREATE TABLE IF NOT EXISTS registration_feedbacks (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
Position 3:81 Tokens: (''),
  PRIMARY KEY (`id`)
) ENGI
Error: Sqlgg.Sql_parser.MenhirBasics.Error
Errors encountered, no code generated
FAILED test/default_exression.sql
make: *** [test] Error 2
```

The [second commit](https://github.com/ygrek/sqlgg/commit/7f3e7c47fcef95f035c64680ac440f378aea20e4) add support for DEFAULT in choice expression

```sql
INSERT INTO `registration_feedbacks`
SET
  `user_message` = @user_message,
  `grant_types` = @grant_types { None { DEFAULT } | Some { @grant_types } };
```

It currently fails with the following error

```
./run_test                           
Running regression tests
==> INSERT INTO `registration_feedbacks`
SET
  `user_message` = @user_message,
  `grant_types` = @grant_types { None { DEFAULT } | Some { @grant_types } }
Position 4:49 Tokens: } | Some { @grant_types } }
Error: Sqlgg.Sql_parser.MenhirBasics.Error
Errors encountered, no code generated
FAILED test/default_exression.sql
make: *** [test] Error 2
```

