### PR TITLE
implement `DEFAULT`, and default syntax `{expr}??`

### DIFF
--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -339,7 +339,8 @@ ruleMain = parse
   | "<>" | "!=" | "==" { NUM_EQ_OP }
   | "<=>" { NOT_DISTINCT_OP }
 
-  | "?" { QSTN }
+  | "?"   { QSTN }
+  | "??"  { TWO_QSTN }
   | [':' '@'] (ident as str) { PARAM { label = Some str; pos = pos lexbuf } }
   | '&' (ident as ref_name) { SHARED_QUERY_REF { ref_name; pos = pos lexbuf } }
   | "::" { DOUBLECOLON }

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -58,7 +58,7 @@ let value ?(inparam=false) v =
   Node ("value", attrs, [])
 
 let tuplelist_value_of_param = function
-  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionBoolChoice _ | SharedVarsGroup _ -> None
+  | Sql.Single _ | SingleIn _ | Choice _ | ChoiceIn _ | OptionActionChoice _ | SharedVarsGroup _ -> None
   | TupleList ({ label = None; _ }, _) -> failwith "empty label in tuple subst"
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
@@ -96,7 +96,7 @@ let rec params_only l =
   List.map
     (function
       | Sql.Single p -> [p]
-      | OptionBoolChoice (_, v, _) -> params_only v
+      | OptionActionChoice (_, v, _, _) -> params_only v
       | SingleIn _ -> []
       | SharedVarsGroup (vars, _)
       | ChoiceIn { vars; _ } -> params_only vars

--- a/src/test.ml
+++ b/src/test.ml
@@ -24,7 +24,7 @@ let do_test sql ?kind schema params =
   let stmt = parse sql in
   assert_equal ~msg:"schema" ~printer:Sql.Schema.to_string schema stmt.schema;
   assert_equal ~msg:"params" ~cmp:cmp_params ~printer:Sql.show_params params
-  (List.map (function Single p -> p | SharedVarsGroup _ | OptionBoolChoice _ | SingleIn _ | Choice _ | ChoiceIn _ | TupleList _ -> assert false) stmt.vars);
+  (List.map (function Single p -> p | SharedVarsGroup _ | OptionActionChoice _ | SingleIn _ | Choice _ | ChoiceIn _ | TupleList _ -> assert false) stmt.vars);
   match kind with
   | Some k -> assert_equal ~msg:"kind" ~printer:[%derive.show: Stmt.kind] k stmt.kind
   | None -> ()

--- a/test/cram/set_default_syntax.sql
+++ b/test/cram/set_default_syntax.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS registration_feedbacks (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),
+  `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO `registration_feedbacks`
+SET
+  `user_message` = { CONCAT(@user_message, '22222') }??,
+  `grant_types` = { @grant_types { A {'2'} | B {'2'} } }??;

--- a/test/cram/set_default_syntax_fail.sql
+++ b/test/cram/set_default_syntax_fail.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS random (
+  `test` varchar(80) COLLATE utf8_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+INSERT INTO `random`
+SET
+  `test` = { @test { A {'2'} | B {'2'} } }??;

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -43,3 +43,31 @@ Compare SQL queries in test2 (with &abcd substitution) and test3 (without substi
   $ diff test2_sql.tmp test3_sql.tmp
   $ echo $?
   0
+
+Implement set default feature:
+
+  $ cat set_default_syntax.sql | sqlgg -params unnamed -gen caml - > output.ml
+
+  $ sed -n '17,38p' output.ml
+    let insert_registration_feedbacks_1 db ~user_message ~grant_types =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match user_message with Some _ -> 1 | None -> 0) + (match grant_types with Some (grant_types) -> 0 + (match grant_types with `A -> 0 | `B -> 0) | None -> 0)) in
+        begin match user_message with
+        | None -> ()
+        | Some (user_message) ->
+          T.set_param_Text p user_message;
+        end;
+        begin match grant_types with
+        | None -> ()
+        | Some (grant_types) ->
+          begin match grant_types with
+          | `A -> ()
+          | `B -> ()
+          end;
+        end;
+        T.finish_params p
+      in
+      T.execute db ("INSERT INTO `registration_feedbacks`\n\
+  SET\n\
+    `user_message` = " ^ (match user_message with Some _ -> " ( " ^ " CONCAT(" ^ "?" ^ ", '22222') " ^ " ) " | None -> " DEFAULT ") ^ ",\n\
+    `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> "'2'" | `B -> "'2'") ^ " " ^ " ) " | None -> " DEFAULT ")) set_params

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -71,3 +71,8 @@ Implement set default feature:
   SET\n\
     `user_message` = " ^ (match user_message with Some _ -> " ( " ^ " CONCAT(" ^ "?" ^ ", '22222') " ^ " ) " | None -> " DEFAULT ") ^ ",\n\
     `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> "'2'" | `B -> "'2'") ^ " " ^ " ) " | None -> " DEFAULT ")) set_params
+
+Implement set default feature, no way to set DEFAULT for fields without DEFAULT:
+
+  $ cat set_default_syntax_fail.sql | sqlgg -params unnamed -gen caml - 2>&1 | grep "Column test doesn't have default value"
+  Fatal error: exception Failure("Column test doesn't have default value")


### PR DESCRIPTION
### Description

This PR adds support to `DEFAULT` and special `{expr}??` syntax that generates a regular option when insert.

The main motivation is to not make DEFAULT part of regular expr, because in sql this DEFAULT is only available on insert and update.

That is, writing like this will not be valid and an error will be caught:

```sql
SELECT ... WHERE {@x + 2}??
```

On the contrary, using this on insert/update will just generate option, and if there is no data, `DEFAULT` will be generated, similar to how it works for filtering and skipping `{expr}?` syntax.

example taken from tests:

```sql
INSERT INTO `registration_feedbacks`
SET
  `user_message` = { CONCAT(@user_message, '22222') }??,
  `grant_types` = { @grant_types { A {'2'} | B {'2'} } }??;
```

The generated result:

```ocaml
T.execute db ("INSERT INTO `registration_feedbacks`\n\
SET\n\
  `user_message` = " ^ (match user_message with Some _ -> " ( " ^ " CONCAT(" ^ "?" ^ ", '22222') " ^ " ) " | None -> " DEFAULT ") ^ ",\n\
  `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> "'2'" | `B -> "'2'") ^ " " ^ " ) " | None -> " DEFAULT ")) set_params
```