### PR TITLE
Fix, make WHERE IN Tuples composable

### DIFF
--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -447,9 +447,9 @@ expr:
         let e = poly (depends Bool) [ e1; Inparam (new_param p (depends Any)) ] in
         InChoice ({ label = p.label; pos = ($startofs, $endofs) }, k, e )
       }
-    | LPAREN names=commas(expr) RPAREN in_or_not_in p=param
+    | LPAREN names=commas(expr) RPAREN k=in_or_not_in p=param
       {
-        InTupleList(names, p)
+        InTupleList({exprs = names; param_id = p; kind = k; pos = ($startofs, $endofs) })
       }
     | LPAREN select=select_stmt RPAREN { SelectExpr (select, `AsValue) }
     | p=param t=preceded(DOUBLECOLON, manual_type)? { Param (new_param { p with pos=($startofs, $endofs) } (Option.default (depends Any) t))  }

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -139,6 +139,15 @@ let substitute_vars s vars subst_param =
       assert (i1 > i);
       let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
       loop s acc i2 parami tl
+    | TupleList (id, Where_in (types, in_not_in, (j1, j2))) :: tl ->
+      let (i1,i2) = id.pos in
+      assert (i2 > i1);
+      assert (i1 > i);
+      assert (j2 > j1);
+      assert (j1 > i); 
+      let sub = [Static (String.slice ~first:j1 ~last:i1 s); SubstTuple (id, Where_in (types, in_not_in, (j1, j2)))] in
+      let acc =  DynamicIn (id, in_not_in, sub) :: acc @ [Static (String.slice ~first:i ~last:j1 s)] in
+      loop s acc i2 parami tl
     | TupleList (id, ValueRows x) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -63,7 +63,7 @@ let tuplelist_value_of_param = function
   | TupleList ({ label = Some name; _ }, kind) ->
     let schema = match kind with 
     | Insertion schema -> schema 
-    | Where_in types | ValueRows { types; _ } -> Gen_caml.make_schema_of_tuple_types name types
+    | Where_in (types, _, _) | ValueRows { types; _ } -> Gen_caml.make_schema_of_tuple_types name types
     in
     let typ = "list(" ^ String.concat ", " (List.map (fun { Sql.domain; _ } -> Sql.Type.type_name domain) schema) ^ ")" in
     let attrs = ["name", name; "type", typ] in

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,4 +1,5 @@
 (cram
  (deps
   %{bin:sqlgg}
-  (glob_files *.sql)))
+  (glob_files *.sql)
+  (glob_files *.compare.ml)))

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -76,3 +76,18 @@ Implement set default feature, no way to set DEFAULT for fields without DEFAULT:
 
   $ cat set_default_syntax_fail.sql | sqlgg -params unnamed -gen caml - 2>&1 | grep "Column test doesn't have default value"
   Fatal error: exception Failure("Column test doesn't have default value")
+
+WHERE IN tuples composable with the rest:
+
+  $ cat where_in_composable.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml - > output.ml
+
+# Note: We normalize line endings before comparison to ensure consistent results
+# across different operating systems (Windows CRLF vs Unix LF)
+# This prevents diff from reporting false differences on Windows systems
+# where the standard diff command doesn't support the --strip-trailing-cr option
+
+  $ tr -d '\r' < output.ml > output_normalized.ml
+  $ tr -d '\r' < where_in_composable.compare.ml > compare_normalized.ml
+  $ diff output_normalized.ml compare_normalized.ml
+  $ echo $?
+  0

--- a/test/cram/where_in_composable.compare.ml
+++ b/test/cram/where_in_composable.compare.ml
@@ -1,0 +1,193 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_random_table_1 db  =
+    T.execute db ("CREATE TABLE IF NOT EXISTS random_table_1 (\n\
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
+  `id2` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
+  PRIMARY KEY (`id`)\n\
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") T.no_params
+
+  let select_1 db ~id ~ids2 callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match id with `Another (ids) -> 0 + (match ids with [] -> 0 | _ :: _ -> 0) | `Andanother _ -> 1 | `Lol (idss) -> 0 + (match idss with [] -> 0 | _ :: _ -> 0)) + (match ids2 with Some (ids2) -> 0 + (match ids2 with [] -> 0 | _ :: _ -> 0) | None -> 0)) in
+      begin match id with
+      | `Another (ids) ->
+        begin match ids with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+      | `Andanother (x) ->
+        T.set_param_Int p x;
+      | `Lol (idss) ->
+        begin match idss with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+      end;
+      begin match ids2 with
+      | None -> ()
+      | Some (ids2) ->
+        begin match ids2 with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM random_table_1\n\
+WHERE \n\
+  " ^ (match id with `Another (ids) -> " " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " " | `Andanother _ -> " " ^ "?" ^ " > 2 " | `Lol (idss) -> " " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ") ^ " \n\
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params invoke_callback
+
+  let select_2 db ~ids2 callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match ids2 with [] -> 0 | _ :: _ -> 0)) in
+      begin match ids2 with
+      | [] -> ()
+      | _ :: _ ->
+        ()
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params invoke_callback
+
+  module Fold = struct
+    let select_1 db ~id ~ids2 callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match id with `Another (ids) -> 0 + (match ids with [] -> 0 | _ :: _ -> 0) | `Andanother _ -> 1 | `Lol (idss) -> 0 + (match idss with [] -> 0 | _ :: _ -> 0)) + (match ids2 with Some (ids2) -> 0 + (match ids2 with [] -> 0 | _ :: _ -> 0) | None -> 0)) in
+        begin match id with
+        | `Another (ids) ->
+          begin match ids with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        | `Andanother (x) ->
+          T.set_param_Int p x;
+        | `Lol (idss) ->
+          begin match idss with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        end;
+        begin match ids2 with
+        | None -> ()
+        | Some (ids2) ->
+          begin match ids2 with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+WHERE \n\
+  " ^ (match id with `Another (ids) -> " " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " " | `Andanother _ -> " " ^ "?" ^ " > 2 " | `Lol (idss) -> " " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ") ^ " \n\
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let select_2 db ~ids2 callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids2 with [] -> 0 | _ :: _ -> 0)) in
+        begin match ids2 with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let select_1 db ~id ~ids2 callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match id with `Another (ids) -> 0 + (match ids with [] -> 0 | _ :: _ -> 0) | `Andanother _ -> 1 | `Lol (idss) -> 0 + (match idss with [] -> 0 | _ :: _ -> 0)) + (match ids2 with Some (ids2) -> 0 + (match ids2 with [] -> 0 | _ :: _ -> 0) | None -> 0)) in
+        begin match id with
+        | `Another (ids) ->
+          begin match ids with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        | `Andanother (x) ->
+          T.set_param_Int p x;
+        | `Lol (idss) ->
+          begin match idss with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        end;
+        begin match ids2 with
+        | None -> ()
+        | Some (ids2) ->
+          begin match ids2 with
+          | [] -> ()
+          | _ :: _ ->
+            ()
+          end;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+WHERE \n\
+  " ^ (match id with `Another (ids) -> " " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " " | `Andanother _ -> " " ^ "?" ^ " > 2 " | `Lol (idss) -> " " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ") ^ " \n\
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let select_2 db ~ids2 callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids2 with [] -> 0 | _ :: _ -> 0)) in
+        begin match ids2 with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/where_in_composable.sql
+++ b/test/cram/where_in_composable.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS random_table_1 (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id2` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+SELECT id FROM random_table_1
+WHERE 
+  @id {
+    `Another` { (`id`, `id2`) IN @ids } |
+    `AndAnother` { @x > 2 } |
+    `Lol` { `id` IN @idss }
+  } 
+  OR { (`id`, `id2`) IN @ids2 }?;  
+
+SELECT id FROM random_table_1
+WHERE (`id`, `id2`) IN @ids2;


### PR DESCRIPTION
### Description

This PR fixes the `TupleList` expr, it makes it work with the rest of the expressions, it also fixes this expr when the substitution and adds the default case `TRUE/FALSE` (depends on IN/NOT IN) when a list is empty