### PR TITLE
Type mappings for columns

### DIFF
--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -112,6 +112,21 @@ module type M = sig
   val get_column_Decimal_nullable : row -> int -> Decimal.t option
   val get_column_Datetime_nullable : row -> int -> Datetime.t option
 
+  val get_column_bool : row -> int -> bool
+  val get_column_regular_bool_nullable : row -> int -> bool option
+  
+  val get_column_int64 : row -> int -> int64
+  val get_column_int64_nullable : row -> int -> int64 option
+  
+  val get_column_float : row -> int -> float
+  val get_column_float_nullable : row -> int -> float option
+  
+  val get_column_decimal : row -> int -> float
+  val get_column_decimal_nullable : row -> int -> float option
+  
+  val get_column_datetime : row -> int -> string
+  val get_column_datetime_nullable : row -> int -> string option
+
   val start_params : statement -> int -> params
 
   (** [set_param_* stmt index val]. [index] is 0-based,
@@ -159,4 +174,28 @@ module type M_io = sig
     with type row := row
     with type execute_response := execute_response
 
+end
+
+module type M_default_types = M with type Types.Bool.t = bool
+  and type Types.Int.t = int64
+  and type Types.Float.t = float
+  and type Types.Text.t = string
+  and type Types.Blob.t = string
+  and type Types.Decimal.t = float
+  and type Types.Datetime.t = float
+  and type Types.Any.t = string
+
+module type M_io_default_types = sig 
+  include M_default_types
+  
+  module IO : Sqlgg_io.M
+
+  include FNS
+    with type params := params
+    with type result := result
+    with type 'a io_future := 'a IO.future
+    with type 'a connection := 'a connection
+    with type statement := statement
+    with type row := row
+    with type execute_response := execute_response
 end

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -98,6 +98,8 @@ module Conv = struct
   let text = "Text", function TEXT s | BLOB s -> s | x -> raise (Type_mismatch x)
   let float = "Float", function FLOAT x -> x | x -> raise (Type_mismatch x)
   let decimal = "Decimal", function INT i -> Int64.to_float i | FLOAT x -> x | x -> raise (Type_mismatch x)
+
+  let datetime = "Datetime", fun x -> Float.to_string @@ snd float x
 end
 
 let get_column_ty (name,conv) =
@@ -117,6 +119,12 @@ let get_column_Any, get_column_Any_nullable = get_column_ty Conv.text
 let get_column_Float, get_column_Float_nullable = get_column_ty Conv.float
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty Conv.decimal
 let get_column_Datetime, get_column_Datetime_nullable = get_column_ty Conv.float
+
+let get_column_bool, get_column_regular_bool_nullable = (get_column_Bool, get_column_Bool_nullable)
+let get_column_int64, get_column_int64_nullable = (get_column_Int, get_column_Int_nullable)
+let get_column_float, get_column_float_nullable = (get_column_Float, get_column_Float_nullable)
+let get_column_decimal, get_column_decimal_nullable = (get_column_Decimal, get_column_Decimal_nullable)
+let get_column_datetime, get_column_datetime_nullable = get_column_ty Conv.datetime
 
 module Make_enum (E: Enum) = struct 
 

--- a/lib/parser_state.ml
+++ b/lib/parser_state.ml
@@ -4,4 +4,10 @@ let mode = ref Normal
 let mode_normal () = mode := Normal
 let mode_ignore () = mode := Ignore
 let mode_ident () = mode := Ident
+module Stmt_metadata = struct
+  let stmt_metadata: (int, (string * string) list) Hashtbl.t = Hashtbl.create 16
 
+  let add k v = Hashtbl.add stmt_metadata k v
+  let find_all k = Hashtbl.find_all stmt_metadata k
+  let reset () = Hashtbl.reset stmt_metadata
+end

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -211,18 +211,45 @@ module Constraints = struct
   let pp fmt s = Format.fprintf fmt "%s" (show s)
 end
 
-type attr = {name : string; domain : Type.t; extra : Constraints.t; }
+module Meta = struct
+
+  module StringMap = Map.Make(String)
+  
+  type t = string StringMap.t
+  
+  let of_list list = List.fold_left (fun map (k, v) -> StringMap.add k v map) StringMap.empty list
+  
+  let empty () = StringMap.empty
+  
+  let find_opt k map = StringMap.find_opt map k
+  let pp fmt t =
+    if StringMap.is_empty t then
+      Format.fprintf fmt "{}"
+    else begin
+      Format.fprintf fmt "{";
+      let first_key = fst (StringMap.min_binding t) in
+      StringMap.iter (fun k v ->
+        if k = first_key then
+          Format.fprintf fmt "%s = %s" k v
+        else
+          Format.fprintf fmt "; %s = %s" k v
+      ) t;
+      Format.fprintf fmt "}"
+    end
+end
+
+type attr = {name : string; domain : Type.t; extra : Constraints.t; meta: Meta.t }
   [@@deriving show {with_path=false}]
 
-let make_attribute name kind extra =
-  if Constraints.mem Null extra && Constraints.mem NotNull extra then fail "Column %s can be either NULL or NOT NULL, but not both" name;
-  let domain = Type.{ t = Option.default Int kind; nullability = if List.exists (fun cstrt -> Constraints.mem cstrt extra) [NotNull; PrimaryKey]
-    then Strict else Nullable } in
-  {name;domain;extra}
+  let make_attribute name kind extra ~meta =
+    if Constraints.mem Null extra && Constraints.mem NotNull extra then fail "Column %s can be either NULL or NOT NULL, but not both" name;
+    let domain = Type.{ t = Option.default Int kind; nullability = if List.exists (fun cstrt -> Constraints.mem cstrt extra) [NotNull; PrimaryKey]
+      then Strict else Nullable } in
+    {name;domain;extra;meta=Meta.of_list meta}
 
-let unnamed_attribute domain = {name="";domain;extra=Constraints.empty}
+    let unnamed_attribute ?(meta = Meta.empty()) domain = {name="";domain;extra=Constraints.empty;meta}
 
-let make_attribute' ?(extra = Constraints.empty) name domain = { name; domain; extra }
+    let make_attribute' ?(extra = Constraints.empty) ?(meta = []) name domain = { name; domain; extra; meta = Meta.of_list meta }
 
 module Schema =
 struct
@@ -395,7 +422,7 @@ type pos = (int * int) [@@deriving show]
 
 let print_table out (name,schema) =
   IO.write_line out (show_table_name name);
-  schema |> List.iter begin fun {name;domain;extra} ->
+  schema |> List.iter begin fun {name;domain;extra;_} ->
     IO.printf out "%10s %s %s\n" (Type.show domain) name (Constraints.show extra)
   end;
   IO.write_line out ""
@@ -450,7 +477,7 @@ type col_name = {
 } [@@deriving show]
 type source_alias = { table_name : table_name; column_aliases : schema option } [@@deriving show]
 and limit = param list * bool
-and nested = source * (source * Schema.Join.typ * join_condition) list
+and nested = source * (source * Schema.Join.typ * join_condition) list [@@deriving show]
 and source = [ `Select of select_full | `Table of table_name | `Nested of nested | `ValueRows of row_values ] * source_alias option (* alias *)
 and join_condition = expr Schema.Join.condition
 and select = {

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -266,7 +266,7 @@ let cmnt = "--" | "//" | "#"
 (* extract separate statements *)
 rule ruleStatement = parse
   | ['\n' ' ' '\r' '\t']+ as tok { `Space tok }
-  | cmnt wsp* "[sqlgg]" wsp+ (ident+ as n) wsp* "=" wsp* ([^'\n']* as v) '\n' { `Props [(n,v)] }
+  | cmnt wsp* "[sqlgg]" wsp+ (ident+ as n) wsp* "=" wsp* ([^'\n']* as v) '\n' { `Props [(n, String.trim v)] }
   | cmnt wsp* "@" (ident+ as name) wsp* "|" ([^'\n']* as v) '\n' 
     { 
       let props = rulePropList [] (Lexing.from_string v) in

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -352,8 +352,10 @@ drop_behavior: CASCADE | RESTRICT { }
 
 column_def: name=IDENT t=sql_type? extra=column_def_extra*
   {
+    let rule_start_pos_cnum = $startpos.Lexing.pos_cnum in
+    let meta = List.concat @@ Parser_state.Stmt_metadata.find_all rule_start_pos_cnum in
     let extra = Constraints.of_list @@ List.filter_map identity extra in
-    make_attribute name t extra
+    make_attribute name t extra ~meta
   }
 
 column_def1: c=column_def { `Attr c }

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -2,4 +2,5 @@
  (deps
   %{bin:sqlgg}
   (glob_files *.sql)
-  (glob_files *.compare.ml)))
+  (glob_files *.compare.ml)
+  sqlgg_test.sh))

--- a/test/cram/sqlgg_test.sh
+++ b/test/cram/sqlgg_test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+SQL_FILE=$1
+COMPARE_FILE=$2
+
+cat "$SQL_FILE" | sqlgg -no-header -gen caml_io -params unnamed -gen caml - > output.ml
+
+# Note: We normalize line endings before comparison to ensure consistent results
+# across different operating systems (Windows CRLF vs Unix LF)
+# This prevents diff from reporting false differences on Windows systems
+# where the standard diff command doesn't support the --strip-trailing-cr option
+tr -d '\r' < output.ml > output_normalized.ml
+tr -d '\r' < "$COMPARE_FILE" > compare_normalized.ml
+diff output_normalized.ml compare_normalized.ml
+exit $?

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -78,16 +78,11 @@ Implement set default feature, no way to set DEFAULT for fields without DEFAULT:
   Fatal error: exception Failure("Column test doesn't have default value")
 
 WHERE IN tuples composable with the rest:
+  $ /bin/sh ./sqlgg_test.sh where_in_composable.sql where_in_composable.compare.ml
+  $ echo $?
+  0
 
-  $ cat where_in_composable.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml - > output.ml
-
-# Note: We normalize line endings before comparison to ensure consistent results
-# across different operating systems (Windows CRLF vs Unix LF)
-# This prevents diff from reporting false differences on Windows systems
-# where the standard diff command doesn't support the --strip-trailing-cr option
-
-  $ tr -d '\r' < output.ml > output_normalized.ml
-  $ tr -d '\r' < where_in_composable.compare.ml > compare_normalized.ml
-  $ diff output_normalized.ml compare_normalized.ml
+Implement type mappings, fst part, no insert, no update, no params, only select:
+  $ /bin/sh ./sqlgg_test.sh type_mappings.sql type_mappings.compare.ml  
   $ echo $?
   0

--- a/test/cram/type_mappings.compare.ml
+++ b/test/cram/type_mappings.compare.ml
@@ -1,0 +1,113 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_table_37 db  =
+    T.execute db ("CREATE TABLE table_37 (\n\
+                col_1 INT PRIMARY KEY,\n\
+                        col_2 INT NOT NULL\n\
+      )") T.no_params
+
+  let create_table_38 db  =
+    T.execute db ("CREATE TABLE table_38 (\n\
+                col_3 INT PRIMARY KEY,\n\
+        col_4 TEXT NOT NULL\n\
+      )") T.no_params
+
+  let select_2 db  callback =
+    let invoke_callback stmt =
+      callback
+        ~deeply_nested_query:(HelloWorld.get_column_nullable (T.get_column_int64_nullable stmt 0))
+        ~col_2:(Abcdefg.test (T.get_column_int64 stmt 1))
+        ~col_3:(FooBar.get_column_nullable (T.get_column_int64_nullable stmt 2))
+        ~col_4:(T.get_column_Text_nullable stmt 3)
+    in
+    T.select db ("SELECT \n\
+  (\n\
+    SELECT MAX(x.col_val)\n\
+    FROM (\n\
+      SELECT col_1 as col_val,\n\
+           1 + 3 as aaaaa,\n\
+           1 + col_1 as bbb\n\
+      FROM table_37 \n\
+      WHERE col_1 > (\n\
+        SELECT MIN(col_1) \n\
+        FROM table_37\n\
+      )\n\
+    ) as x\n\
+  ) as deeply_nested_query,\n\
+  col_2,\n\
+  col_3,\n\
+  col_4\n\
+FROM table_37\n\
+LEFT JOIN table_38\n\
+  ON table_37.col_1 = table_38.col_3") T.no_params invoke_callback
+
+  module Fold = struct
+    let select_2 db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~deeply_nested_query:(HelloWorld.get_column_nullable (T.get_column_int64_nullable stmt 0))
+          ~col_2:(Abcdefg.test (T.get_column_int64 stmt 1))
+          ~col_3:(FooBar.get_column_nullable (T.get_column_int64_nullable stmt 2))
+          ~col_4:(T.get_column_Text_nullable stmt 3)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT \n\
+  (\n\
+    SELECT MAX(x.col_val)\n\
+    FROM (\n\
+      SELECT col_1 as col_val,\n\
+           1 + 3 as aaaaa,\n\
+           1 + col_1 as bbb\n\
+      FROM table_37 \n\
+      WHERE col_1 > (\n\
+        SELECT MIN(col_1) \n\
+        FROM table_37\n\
+      )\n\
+    ) as x\n\
+  ) as deeply_nested_query,\n\
+  col_2,\n\
+  col_3,\n\
+  col_4\n\
+FROM table_37\n\
+LEFT JOIN table_38\n\
+  ON table_37.col_1 = table_38.col_3") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let select_2 db  callback =
+      let invoke_callback stmt =
+        callback
+          ~deeply_nested_query:(HelloWorld.get_column_nullable (T.get_column_int64_nullable stmt 0))
+          ~col_2:(Abcdefg.test (T.get_column_int64 stmt 1))
+          ~col_3:(FooBar.get_column_nullable (T.get_column_int64_nullable stmt 2))
+          ~col_4:(T.get_column_Text_nullable stmt 3)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT \n\
+  (\n\
+    SELECT MAX(x.col_val)\n\
+    FROM (\n\
+      SELECT col_1 as col_val,\n\
+           1 + 3 as aaaaa,\n\
+           1 + col_1 as bbb\n\
+      FROM table_37 \n\
+      WHERE col_1 > (\n\
+        SELECT MIN(col_1) \n\
+        FROM table_37\n\
+      )\n\
+    ) as x\n\
+  ) as deeply_nested_query,\n\
+  col_2,\n\
+  col_3,\n\
+  col_4\n\
+FROM table_37\n\
+LEFT JOIN table_38\n\
+  ON table_37.col_1 = table_38.col_3") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/type_mappings.sql
+++ b/test/cram/type_mappings.sql
@@ -1,0 +1,34 @@
+CREATE TABLE table_37 (
+        -- [sqlgg] module=HelloWorld
+        col_1 INT PRIMARY KEY,
+        -- [sqlgg] module=Abcdefg
+        -- [sqlgg] get_column=test
+        col_2 INT NOT NULL
+      );
+
+ CREATE TABLE table_38 (
+        -- [sqlgg] module=FooBar
+        col_3 INT PRIMARY KEY,
+        col_4 TEXT NOT NULL
+      );
+
+SELECT 
+  (
+    SELECT MAX(x.col_val)
+    FROM (
+      SELECT col_1 as col_val,
+           1 + 3 as aaaaa,
+           1 + col_1 as bbb
+      FROM table_37 
+      WHERE col_1 > (
+        SELECT MIN(col_1) 
+        FROM table_37
+      )
+    ) as x
+  ) as deeply_nested_query,
+  col_2,
+  col_3,
+  col_4
+FROM table_37
+LEFT JOIN table_38
+  ON table_37.col_1 = table_38.col_3;


### PR DESCRIPTION
### Description

This PR adds the ability to customize how column values are handled in SELECT queries using simple annotations. You can now easily convert database types to your domain types directly in table definitions.

### How it works

- Custom column value mapping using `-- [sqlgg]` comments in table definitions
- Support for module-level customization with `module=Module_name` annotation
- Optional function-level customization with `get_column=function_name` annotation
- Automatic handling of both nullable and non-nullable column values

### Usage Example

```sql
CREATE TABLE orders (
  -- [sqlgg] module=UUID
  id CHAR(36) PRIMARY KEY,
  
  -- [sqlgg] module=Money
  -- [sqlgg] get_column=cents_to_dollars
  amount BIGINT NOT NULL,
  
  -- [sqlgg] module=DateTime
  created_at DATETIME NOT NULL,
  
  status TEXT NOT NULL
);
```
And query

```sql
-- @select_orders
SELECT id, amount, created_at, status FROM orders;
```

This generates code that:
- Converts `id` from string to UUID object via `UUID.get_column`
- Transforms `amount` from cents (stored as BIGINT) to dollars using `Money.cents_to_dollars`
- Parses `created_at` into proper datetime with `DateTime.get_column`
- Leaves `status` with default trait implementation

### Example Generated Code

```ocaml
let select_orders db callback =
  let invoke_callback stmt =
    callback
      ~id:(UUID.get_column (T.get_column_Text stmt 0))
      ~amount:(Money.cents_to_dollars (T.get_column_int64 stmt 1))
      ~created_at:(DateTime.get_column (T.get_column_datetime stmt 2))
      ~status:(T.get_column_Text stmt 3)
  in
  T.select db "SELECT id, amount, created_at, status FROM orders" T.no_params invoke_callback
```

With these custom conversions, application code can work directly with domain types:

```ocaml
let total_sales db =
  Sqlgg.Fold.select_orders db 
    (fun ~id ~amount ~created_at ~status acc -> 
      let open Money in
     (* let (+) a b = ... *)
      acc + amount)
    Money.zero
```

### Future Work

- Support for customizing parameter handling in WHERE clauses
- Support for DML operations (INSERT/UPDATE)
- Implementation for other target languages
