### PR TITLE
implemented CASE expression as expression

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -22,6 +22,8 @@ struct
     let make ctors =  Ctors.of_list ctors
   end
 
+  type union = { ctors: Enum_kind.t; is_closed: bool } [@@deriving eq, show{with_path=false}]
+
   type kind =
     | Unit of [`Interval]
     | Int
@@ -31,7 +33,7 @@ struct
     | Bool
     | Datetime
     | Decimal
-    | Union of { ctors: Enum_kind.t; is_closed: bool }
+    | Union of union
     | StringLiteral of string
     | Any (* FIXME - Top and Bottom ? *)
     [@@deriving eq, show{with_path=false}]
@@ -505,6 +507,12 @@ and row_values = {
 and order = (expr * direction option) list
 and 'expr choices = (param_id * 'expr option) list
 and fun_ = { kind: Type.func; parameters: expr list; is_over_clause: bool; }
+and case_branch = { when_: expr; then_: expr }
+and case = {  
+  case: expr option;
+  branches: case_branch list;
+  else_: expr option;
+} [@@deriving show]
 and expr =
   | Value of Type.t (** literal value *)
   | Param of param
@@ -520,6 +528,7 @@ and expr =
       to use it during the substitution and to not depend on the magic numbers there.
    *) 
   | OptionActions of { choice: expr; pos: (pos * pos); kind: option_actions_kind }
+  | Case of case
 and column =
   | All
   | AllOf of table_name


### PR DESCRIPTION
### Description
This PR fixes inaccuracies during type inference for `CASE` expr and one small fix for `Choice` expr

#### Example 1
```sql
SELECT CASE WHEN TRUE THEN 1 ELSE 0.2 END `value`
```
Before the fix, Int was output, now the supertype is output and it is Float

#### Example 2
```sql
SELECT CASE WHEN TRUE THEN 1 WHEN TRUE THEN 0.2 END `value`
```
since there is no else branch, nullable is now generated, despite the fact that the return types themselves are not nullable

#### Example 3
```sql
CREATE TABLE test37 (id INT NOT NULL, status enum('A','B','C') NOT NULL);
SELECT CASE status WHEN 'A' THEN 1 WHEN 'B' THEN 2 WHEN 'C' THEN 0 END `value` FROM test37
```
for enum there is an additional check and else is not required in the case when all cases are matched

#### Example 4
```sql
SELECT @test{ A { 'ABCD' } | B { @abcd } };
```
Now `@abcd` will not output Any type

#### Example 5
```sql
SELECT
    (SELECT
         CASE
             WHEN TRUE
             THEN NULL
             WHEN TRUE
             THEN 2-1
             ELSE COUNT(1)
         END
     FROM test38
     WHERE FALSE
    ) AS value
```
The appearance of `COUNT` in one of the branches protects against the no rows case, which, for example, arises due to `WHERE FALSE`, because now `CASE` expr [participates](https://github.com/ygrek/sqlgg/pull/193/files#diff-e5b2ac5b61488c46149361560003e3185b33725d73f243f2cce2fc3020757438R320-R322) in the resolution of subqueries.