### PR TITLE
Type mapping step 2, column metadata in params

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -39,20 +39,28 @@ module type Types = sig
   module Bool : sig 
     include Value 
     val get_bool : field -> bool
+    val set_bool: bool -> value
+    val bool_to_literal : bool -> string
   end
   module Int : sig 
     include Value
     val get_int64 : field -> int64
+    val set_int64: int64 -> value
+    val int64_to_literal : int64 -> string
   end
   (* you probably want better type, e.g. (int*int) or Z.t *)
   module Float : sig
     include Value
     val get_float : field -> float
+    val set_float: float -> value
+    val float_to_literal : float -> string
   end
   (* you probably want better type, e.g. (int*int) or Z.t *)
   module Text : sig 
     include Value
     val get_string : field -> string
+    val set_string: string -> value
+    val string_to_literal : string -> string
   end
   module Blob : sig
     include Value
@@ -61,10 +69,14 @@ module type Types = sig
   module Datetime : sig 
     include Value
     val get_string : field -> string
+    val set_float: float -> value
+    val float_to_literal : float -> string
   end
   module Decimal : sig 
     include Value
     val get_float : field -> float
+    val set_float: float -> value
+    val float_to_literal : float -> string
   end
   module Any : Value
   module Make_enum : functor (E : Enum) -> Value with type t = E.t
@@ -123,6 +135,8 @@ struct
       let to_literal = Int64.to_string
     end) 
     let get_int64 = of_field
+    let set_int64 = to_value
+    let int64_to_literal = to_literal
   end
 
   module Bool = struct 
@@ -133,6 +147,8 @@ struct
       let to_literal = string_of_bool
     end)
     let get_bool = of_field
+    let set_bool = to_value
+    let bool_to_literal = to_literal
   end
 
   module Float = struct 
@@ -148,7 +164,8 @@ struct
       let to_literal = string_of_float
     end)
     let get_float = of_field
-  
+    let set_float = to_value
+    let float_to_literal = to_literal
   end
 
   (* you probably want better type, e.g. (int*int) or Z.t *)
@@ -179,6 +196,8 @@ struct
         Buffer.contents b
     end) 
     let get_string = of_field
+    let set_string = to_value
+    let string_to_literal = to_literal
   end
 
   module Blob = struct 
@@ -228,6 +247,8 @@ struct
     end)
 
     let get_string f = f |> of_field |> to_literal
+    let set_float t = `Time (M.Time.utc_timestamp t)
+    let float_to_literal t = t |> M.Time.utc_timestamp |> to_literal
   end
 
   module Any = Make(struct
@@ -332,6 +353,13 @@ let set_param_Int = set_param_ty Int.to_value
 let set_param_Float = set_param_ty Float.to_value
 let set_param_Decimal = set_param_ty Decimal.to_value
 let set_param_Datetime = set_param_ty Datetime.to_value
+
+let set_param_bool = set_param_ty Bool.set_bool
+let set_param_int64 = set_param_ty Int.set_int64
+let set_param_string = set_param_ty Text.set_string
+let set_param_float = set_param_ty Float.set_float
+let set_param_decimal = set_param_ty Decimal.set_float
+let set_param_datetime = set_param_ty Datetime.set_float
 
 module Make_enum (E: Enum) = struct 
 

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -77,13 +77,31 @@ module type M = sig
 
   (** datatypes *)
   module Types : sig
-    module Bool : Value
-    module Int : Value
-    module Float : Value
-    module Text : Value
+    module Bool : sig
+      include Value
+      val bool_to_literal : bool -> string
+    end
+    module Int : sig 
+      include Value
+      val int64_to_literal : int64 -> string
+    end
+    module Float : sig
+      include Value
+      val float_to_literal : float -> string
+    end
+    module Text : sig
+      include Value
+      val string_to_literal : string -> string
+    end
     module Blob : Value
-    module Decimal : Value
-    module Datetime : Value
+    module Decimal : sig
+      include Value
+      val float_to_literal : float -> string
+    end
+    module Datetime : sig 
+      include Value
+      val float_to_literal : float -> string
+    end
     module Any : Value
   end
 
@@ -142,6 +160,13 @@ module type M = sig
   val set_param_Float : params -> Float.t -> unit
   val set_param_Decimal : params -> Decimal.t -> unit
   val set_param_Datetime : params -> Datetime.t -> unit
+
+  val set_param_bool : params -> bool -> unit
+  val set_param_int64 : params -> int64 -> unit
+  val set_param_float : params -> float -> unit
+  val set_param_decimal : params -> float -> unit
+  val set_param_string : params -> string -> unit
+  val set_param_datetime : params -> float -> unit
 
   module Make_enum: functor (E : Enum) -> sig
     (* The type itself is not exposed to provide a user a polymorphic type without aliases. *)

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -20,8 +20,16 @@ module M = struct
 module S = Sqlite3
 
 module Types = struct
-  module Bool = struct type t = bool let to_literal = string_of_bool end
-  module Int = struct include Int64 let to_literal = to_string end
+  module Bool = struct 
+    type t = bool 
+    let to_literal = string_of_bool
+    let bool_to_literal = to_literal
+  end
+  module Int = struct 
+    include Int64 
+    let to_literal = to_string
+    let int64_to_literal = to_literal
+  end
   module Text = struct
     type t = string
 
@@ -41,6 +49,8 @@ module Types = struct
       done;
       Buffer.add_string b "'";
       Buffer.contents b
+    
+    let string_to_literal = to_literal
   end
   module Blob = struct
     (* "BLOB literals are string literals containing hexadecimal data and preceded
@@ -60,7 +70,11 @@ module Types = struct
       Buffer.add_string b "'";
       Buffer.contents b
   end
-  module Float = struct type t = float let to_literal = string_of_float end
+  module Float = struct 
+    type t = float 
+    let to_literal = string_of_float
+    let float_to_literal = to_literal
+  end
   (* you probably want better type, e.g. (int*int) or Z.t *)
   module Decimal = Float
   module Datetime = Float (* ? *)
@@ -159,6 +173,13 @@ let set_param_Int stmt v = bind_param (S.Data.INT v) stmt
 let set_param_Float stmt v = bind_param (S.Data.FLOAT v) stmt
 let set_param_Decimal = set_param_Float
 let set_param_Datetime = set_param_Float
+
+let set_param_bool = set_param_Bool
+let set_param_int64 = set_param_Int
+let set_param_float = set_param_Float
+let set_param_decimal = set_param_Float
+let set_param_string = set_param_Text
+let set_param_datetime = set_param_Float
 
 let no_params _ = ()
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -53,7 +53,7 @@ let get_statement_error stmt sql =
     Some UnitOutputColumn
   ) else 
     let unit_params = List.filter_map 
-      (function (i, Single p) when Type.is_unit p.typ -> Some (Gen.show_param_name p i) | _ -> None) 
+      (function (i, Single (p, _)) when Type.is_unit p.typ -> Some (Gen.show_param_name p i) | _ -> None) 
       (List.mapi (fun i p -> i, p) stmt.vars) 
     in
     match unit_params with

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -86,3 +86,8 @@ Implement type mappings, fst part, no insert, no update, no params, only select:
   $ /bin/sh ./sqlgg_test.sh type_mappings.sql type_mappings.compare.ml  
   $ echo $?
   0
+
+Implement type mappings, snd part, comparison op, IN, IN with tuples:
+  $ /bin/sh ./sqlgg_test.sh type_mappings_params.sql type_mappings_params.compare.ml  
+  $ echo $?
+  0

--- a/test/cram/type_mappings_params.compare.ml
+++ b/test/cram/type_mappings_params.compare.ml
@@ -1,0 +1,157 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_example db  =
+    T.execute db ("CREATE TABLE example (\n\
+    id INT AUTO_INCREMENT PRIMARY KEY,\n\
+    name VARCHAR(255) NOT NULL,\n\
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP\n\
+)") T.no_params
+
+  let select_1 db ~x callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(ExampleId.get_column (T.get_column_int64 stmt 0))
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match x with [] -> 0 | _ :: _ -> 0)) in
+      begin match x with
+      | [] -> ()
+      | _ :: _ ->
+        ()
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params invoke_callback
+
+  let create_example2 db  =
+    T.execute db ("CREATE TABLE example2 (\n\
+    id INT AUTO_INCREMENT PRIMARY KEY,\n\
+    name_2 VARCHAR(255) NOT NULL\n\
+)") T.no_params
+
+  let select_3 db ~name ~name_2 ~id callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~name_2:(Name2.get_column (T.get_column_string stmt 1))
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (1 + (match name with [] -> 0 | _ :: _ -> 0) + (match name_2 with [] -> 0 | _ :: _ -> 0)) in
+      begin match name with
+      | [] -> ()
+      | _ :: _ ->
+        ()
+      end;
+      begin match name_2 with
+      | [] -> ()
+      | _ :: _ ->
+        ()
+      end;
+      T.set_param_int64 p (ExampleId.set_param id);
+      T.finish_params p
+    in
+    T.select db ("SELECT example2.id, name_2 \n\
+FROM example\n\
+JOIN example2 ON example.id = example2.id\n\
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params invoke_callback
+
+  module Fold = struct
+    let select_1 db ~x callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(ExampleId.get_column (T.get_column_int64 stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with [] -> 0 | _ :: _ -> 0)) in
+        begin match x with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let select_3 db ~name ~name_2 ~id callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name_2:(Name2.get_column (T.get_column_string stmt 1))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1 + (match name with [] -> 0 | _ :: _ -> 0) + (match name_2 with [] -> 0 | _ :: _ -> 0)) in
+        begin match name with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        begin match name_2 with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.set_param_int64 p (ExampleId.set_param id);
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT example2.id, name_2 \n\
+FROM example\n\
+JOIN example2 ON example.id = example2.id\n\
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let select_1 db ~x callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(ExampleId.get_column (T.get_column_int64 stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with [] -> 0 | _ :: _ -> 0)) in
+        begin match x with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let select_3 db ~name ~name_2 ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name_2:(Name2.get_column (T.get_column_string stmt 1))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1 + (match name with [] -> 0 | _ :: _ -> 0) + (match name_2 with [] -> 0 | _ :: _ -> 0)) in
+        begin match name with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        begin match name_2 with
+        | [] -> ()
+        | _ :: _ ->
+          ()
+        end;
+        T.set_param_int64 p (ExampleId.set_param id);
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT example2.id, name_2 \n\
+FROM example\n\
+JOIN example2 ON example.id = example2.id\n\
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/type_mappings_params.sql
+++ b/test/cram/type_mappings_params.sql
@@ -1,0 +1,19 @@
+CREATE TABLE example (
+-- [sqlgg] module=ExampleId  
+    id INT AUTO_INCREMENT PRIMARY KEY,
+-- [sqlgg] module=Name
+    name VARCHAR(255) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+SELECT id FROM example WHERE (name, id) IN @x;
+
+CREATE TABLE example2 (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+-- [sqlgg] module=Name2
+    name_2 VARCHAR(255) NOT NULL
+);
+
+SELECT example2.id, name_2 
+FROM example
+JOIN example2 ON example.id = example2.id
+WHERE name IN @name AND example2.name_2 IN @name_2 AND example.id = @id;


### PR DESCRIPTION
### Description
This update extends the metadata system with automatic propagation of column annotations to query parameters.


### Example
```sql
CREATE TABLE customers (
  -- [sqlgg] module=UUID
  id CHAR(36) PRIMARY KEY,
  
  -- [sqlgg] module=Email
  email VARCHAR(255) NOT NULL UNIQUE,
  
  -- [sqlgg] module=Money
  balance BIGINT NOT NULL
);

-- @find_customer_by_id
SELECT * FROM customers WHERE id = @id;

-- @find_customers_by_status_and_balance
SELECT * FROM customers 
WHERE email = @email AND balance > @min_balance;
```

Generated OCaml:

```ocaml
let find_customer_by_id db ~id callback =
  (* ... *)
  let set_params stmt =
    let p = T.start_params stmt (1) in
    T.set_param_string p (UUID.set_param id);
    T.finish_params p
  in
  (* ... *)

let find_customers_by_status_and_balance db ~email ~min_balance callback =
  (* ... *)
  let set_params stmt =
    let p = T.start_params stmt (2) in
    T.set_param_string p (Email.set_param email);
    T.set_param_int64 p (Money.set_param min_balance);
    T.finish_params p
  in
  (* ... *)
```

Domain Modules Example:

```ocaml
module UUID = struct
  type t = Uuidm.t

  (* For result columns *)
  let get_column (s : string) : t = 
    Uuidm.of_string s |> Option.get
    
  (* For parameters - NEW *)
  let set_param (id : t) : string =
    Uuidm.to_string id
end

module Email = struct
  type t = { 
    address: string; 
    domain: string 
  }
  
  (* For result columns *)
  let get_column (s : string) : t =
    match String.split_on_char '@' s with
    | [addr; dom] -> { address = addr; domain = dom }
    | _ -> failwith "Invalid email format"
    
  (* For parameters - NEW *)
  let set_param (email : t) : string =
    email.address ^ "@" ^ email.domain
end

module Money = struct
  type t = float (* dollars with cents as decimal *)
  
  (* For result columns *)
  let get_column (cents : float) : t =
    cents /. 100.0
    
  (* For parameters - NEW *)
  let set_param (dollars : t) : float =
    dollars *. 100.0
end
```

With this enhancement, application code becomes cleaner:

Before:

```ocaml
let update_customer ~user_id ~new_email ~new_balance =
  let id_str = UUID.to_string user_id in
  let email_str = Email.to_string new_email in
  let balance_cents = Int64.of_float (new_balance *. 100.0) in
  Sqlgg.update_customer db ~id:id_str ~email:email_str ~balance:balance_cents
```

After:

```ocaml
let update_customer ~user_id ~new_email ~new_balance =
  Sqlgg.update_customer db ~id:user_id ~email:new_email ~balance:new_balance
```