### PR TITLE
Type mapping step 3, INSERT/UPDATE

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -240,6 +240,15 @@ module Meta = struct
     end
 
   let equal = StringMap.equal String.equal
+
+  let merge_right t1 t2 =
+    StringMap.merge (fun _ v1 v2 ->
+      match v1, v2 with
+      | Some v, None -> Some v
+      | Some _, Some v2 -> Some v2
+      | None, Some v -> Some v
+      | None, None -> None
+    ) t1 t2
 end
 
 type attr = {name : string; domain : Type.t; extra : Constraints.t; meta: Meta.t }
@@ -517,15 +526,15 @@ and case = {
 } [@@deriving show]
 and expr =
   | Value of Type.t (** literal value *)
-  | Param of param
-  | Inparam of param
+  | Param of param * Meta.t
+  | Inparam of param * Meta.t
   | Choices of param_id * expr choices
   | InChoice of param_id * in_or_not_in * expr
   | Fun of fun_
   | SelectExpr of select_full * [ `AsValue | `Exists ]
   | Column of col_name
   | Inserted of string (** inserted value *)
-  | InTupleList of { exprs: expr list; param_id: param_id; kind: in_or_not_in; pos: pos }
+  | InTupleList of { exprs: expr list; param_id: param_id; kind: in_or_not_in; pos: pos;}
    (* pos - full syntax pos from {, to }?, pos is only sql, that inside {}?
       to use it during the substitution and to not depend on the magic numbers there.
    *) 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -443,15 +443,15 @@ expr:
     | e1=expr IN table=table_name { Tables.check table; e1 }
     | e1=expr k=in_or_not_in p=param
       {
-        let e = poly (depends Bool) [ e1; Inparam (new_param p (depends Any)) ] in
+        let e = poly (depends Bool) [ e1; Inparam (new_param p (depends Any), Meta.empty()) ] in
         InChoice ({ label = p.label; pos = ($startofs, $endofs) }, k, e )
       }
-    | LPAREN names=commas(expr) RPAREN k=in_or_not_in p=param
+    | LPAREN exprs=commas(expr) RPAREN k=in_or_not_in p=param
       {
-        InTupleList({exprs = names; param_id = p; kind = k; pos = ($startofs, $endofs) })
+        InTupleList({exprs; param_id = p; kind = k; pos = ($startofs, $endofs); })
       }
     | LPAREN select=select_stmt RPAREN { SelectExpr (select, `AsValue) }
-    | p=param t=preceded(DOUBLECOLON, manual_type)? { Param (new_param { p with pos=($startofs, $endofs) } (Option.default (depends Any) t))  }
+    | p=param t=preceded(DOUBLECOLON, manual_type)? { Param (new_param { p with pos=($startofs, $endofs) } (Option.default (depends Any) t), Meta.empty())  }
     | LCURLY e=expr RCURLY QSTN { OptionActions ({ choice=e; pos=(($startofs, $endofs), ($startofs + 1, $endofs - 2)); kind = BoolChoices}) }
     | p=param parser_state_ident LCURLY l=choices c2=RCURLY { let { label; pos=(p1,_p2) } = p in Choices ({ label; pos = (p1,c2+1)},l) }
     | SUBSTRING LPAREN s=expr FROM p=expr FOR n=expr RPAREN

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -293,7 +293,7 @@ let rec set_param ~meta index param =
       let set_param_name = set_param |> Sql.Meta.find_opt meta |> Option.default set_param in
       let runtime_repr_name = L.as_runtime_repr_name param'.typ in
       if nullable then
-         set_param_nullable pname @@ sprintf "T.set_param_%s p (%s);" runtime_repr_name (sprintf "%s.%s v" m set_param_name)
+         set_param_nullable pname @@ sprintf "T.set_param_%s p (%s);" runtime_repr_name (sprintf "%s.%s %s" m set_param_name pname)
       else
         output "T.set_param_%s p (%s);" runtime_repr_name (sprintf "%s.%s %s" m set_param_name pname)
   


### PR DESCRIPTION
### Description

This update extends column-level customization to `INSERT` and `UPDATE` statements, building on the existing metadata propagation system from [PR #198](https://github.com/ygrek/sqlgg/pull/198). Now custom modules are consistently applied across all SQL operations: SELECT results, query parameters, INSERT values, and UPDATE assignments.

### Example

Using the same schema and modules from the query parameters PR:

```sql
CREATE TABLE customers (
  -- [sqlgg] module=UUID
  id CHAR(36) PRIMARY KEY,
  
  -- [sqlgg] module=Email
  email VARCHAR(255) NOT NULL UNIQUE,
  
  -- [sqlgg] module=Money
  balance BIGINT NOT NULL
);

-- @create_customer
INSERT INTO customers (id, email, balance)
VALUES (@id, @email, @balance);

-- @update_customer_balance
UPDATE customers 
SET balance = @new_balance 
WHERE id = @customer_id;
```

Generated OCaml:

```ocaml
let create_customer db ~id ~email ~balance =
  let set_params stmt =
    let p = T.start_params stmt 3 in
    T.set_param_string p (UUID.set_param id);
    T.set_param_string p (Email.set_param email);
    T.set_param_int64 p (Money.set_param balance);
    T.finish_params p
  in
  T.execute db "INSERT INTO customers (id, email, balance) VALUES (?, ?, ?)" set_params

let update_customer_balance db ~new_balance ~customer_id =
  let set_params stmt =
    let p = T.start_params stmt 2 in
    T.set_param_int64 p (Money.set_param new_balance);
    T.set_param_string p (UUID.set_param customer_id);
    T.finish_params p
  in
  T.execute db "UPDATE customers SET balance = ? WHERE id = ?" set_params
```
