### PR TITLE
add support for JSON column type + JSON_OBJECT

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -703,6 +703,7 @@ let () =
   "date_format" |> monomorphic text [datetime; text];
   "json_remove" |> multi ~ret:(Typ text) (Typ text);
   "json_array" |> multi ~ret:(Typ text) (Typ text);
+  "json_object" |> multi ~ret:(Typ text) (Typ text);
   "json_set" |> add 3 (F (Typ text, [Typ text; Typ text; Var 0]));
   "makedate" |> monomorphic datetime [int; int];
   ()

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -106,6 +106,7 @@ let keywords =
    "json_array", JSON_ARRAY;
    "json_set", JSON_SET;
    "json_remove", JSON_REMOVE;
+   "json_object", JSON_OBJECT;
    "straight_join",STRAIGHT_JOIN;
    "key",KEY;
    "lag", LAG;

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -103,10 +103,6 @@ let keywords =
    "into",INTO;
    "is", IS;
    "join",JOIN;
-   "json_array", JSON_ARRAY;
-   "json_set", JSON_SET;
-   "json_remove", JSON_REMOVE;
-   "json_object", JSON_OBJECT;
    "straight_join",STRAIGHT_JOIN;
    "key",KEY;
    "lag", LAG;

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -221,7 +221,7 @@ let keywords =
   all T_BOOLEAN ["bool";"boolean"];
   all T_FLOAT ["float";"real";"double";"float4";"float8";"int1";"int2";"int3";"int4";"int8"];
   all T_BLOB ["blob";"varbinary";"tinyblob";"mediumblob";"longblob"];
-  all T_TEXT ["text";"char";"varchar";"tinytext";"mediumtext";"longtext"];
+  all T_TEXT ["text";"char";"varchar";"tinytext";"mediumtext";"longtext";"json"];
   all T_TEXT ["varchar2"]; (* oracle *)
   all T_DATETIME ["datetime"];
   all T_UUID ["uuid"]; (* http://www.postgresql.org/docs/9.4/static/datatype-uuid.html *)
@@ -425,4 +425,3 @@ ruleCommentMulti acc = parse
     | Ident -> token
 
 }
-

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -41,7 +41,7 @@
        OF WITH NOWAIT ACTION NO IS INTERVAL SUBSTRING DIV MOD CONVERT LAG LEAD OVER
        FIRST_VALUE LAST_VALUE NTH_VALUE PARTITION ROWS RANGE UNBOUNDED PRECEDING FOLLOWING CURRENT ROW
        CAST GENERATED ALWAYS VIRTUAL STORED STATEMENT DOUBLECOLON QSTN TWO_QSTN INSTANT INPLACE COPY ALGORITHM RECURSIVE
-       SHARED EXCLUSIVE NONE JSON_ARRAY JSON_REMOVE JSON_SET
+       SHARED EXCLUSIVE NONE JSON_ARRAY JSON_REMOVE JSON_SET JSON_OBJECT
 %token FUNCTION PROCEDURE LANGUAGE RETURNS OUT INOUT BEGIN COMMENT
 %token MICROSECOND SECOND MINUTE HOUR DAY WEEK MONTH QUARTER YEAR
        SECOND_MICROSECOND MINUTE_MICROSECOND MINUTE_SECOND
@@ -460,7 +460,8 @@ expr:
     | DATE LPAREN e=expr RPAREN { Fun { kind = (Function.lookup "date" 1); parameters = [e]; is_over_clause = false } }
     | TIME LPAREN e=expr RPAREN { Fun { kind = (Function.lookup "time" 1); parameters = [e]; is_over_clause = false } }
     | DEFAULT LPAREN a=attr_name RPAREN { Fun { kind = Type.identity; parameters = [Column a]; is_over_clause = false } }
-    | JSON_ARRAY LPAREN l=expr_list RPAREN { Fun { kind = (Function.lookup "json_array" (List.length l)); parameters = l; is_over_clause = false } }
+    | JSON_ARRAY LPAREN l=optional_expr_list RPAREN { Fun { kind = (Function.lookup "json_array" (List.length l)); parameters = l; is_over_clause = false } }
+    | JSON_OBJECT LPAREN l=optional_expr_list RPAREN { Fun { kind = (Function.lookup "json_object" (List.length l)); parameters = l; is_over_clause = false } }
     | JSON_REMOVE LPAREN j=expr COMMA fs=expr_list RPAREN { Fun { kind = (Function.lookup "json_remove" (List.length fs + 1)); parameters = fs @ [j]; is_over_clause = false } }
     | JSON_SET LPAREN j=expr COMMA k=expr COMMA v=expr RPAREN { Fun { kind = (Function.lookup "json_set" 3); parameters = [j;k;v]; is_over_clause = false } }
     | CONVERT LPAREN e=expr USING IDENT RPAREN { e }
@@ -545,6 +546,7 @@ single_literal_value:
     | MINUS FLOAT { Value (strict Float) }
 
 expr_list: l=commas(expr) { l }
+optional_expr_list: l=separated_list(COMMA,expr) { l }
 func_params: DISTINCT? l=expr_list { l }
            | ASTERISK { [] }
            | (* *) { [] }

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -41,7 +41,7 @@
        OF WITH NOWAIT ACTION NO IS INTERVAL SUBSTRING DIV MOD CONVERT LAG LEAD OVER
        FIRST_VALUE LAST_VALUE NTH_VALUE PARTITION ROWS RANGE UNBOUNDED PRECEDING FOLLOWING CURRENT ROW
        CAST GENERATED ALWAYS VIRTUAL STORED STATEMENT DOUBLECOLON QSTN TWO_QSTN INSTANT INPLACE COPY ALGORITHM RECURSIVE
-       SHARED EXCLUSIVE NONE JSON_ARRAY JSON_REMOVE JSON_SET JSON_OBJECT
+       SHARED EXCLUSIVE NONE
 %token FUNCTION PROCEDURE LANGUAGE RETURNS OUT INOUT BEGIN COMMENT
 %token MICROSECOND SECOND MINUTE HOUR DAY WEEK MONTH QUARTER YEAR
        SECOND_MICROSECOND MINUTE_MICROSECOND MINUTE_SECOND
@@ -460,10 +460,6 @@ expr:
     | DATE LPAREN e=expr RPAREN { Fun { kind = (Function.lookup "date" 1); parameters = [e]; is_over_clause = false } }
     | TIME LPAREN e=expr RPAREN { Fun { kind = (Function.lookup "time" 1); parameters = [e]; is_over_clause = false } }
     | DEFAULT LPAREN a=attr_name RPAREN { Fun { kind = Type.identity; parameters = [Column a]; is_over_clause = false } }
-    | JSON_ARRAY LPAREN l=optional_expr_list RPAREN { Fun { kind = (Function.lookup "json_array" (List.length l)); parameters = l; is_over_clause = false } }
-    | JSON_OBJECT LPAREN l=optional_expr_list RPAREN { Fun { kind = (Function.lookup "json_object" (List.length l)); parameters = l; is_over_clause = false } }
-    | JSON_REMOVE LPAREN j=expr COMMA fs=expr_list RPAREN { Fun { kind = (Function.lookup "json_remove" (List.length fs + 1)); parameters = fs @ [j]; is_over_clause = false } }
-    | JSON_SET LPAREN j=expr COMMA k=expr COMMA v=expr RPAREN { Fun { kind = (Function.lookup "json_set" 3); parameters = [j;k;v]; is_over_clause = false } }
     | CONVERT LPAREN e=expr USING IDENT RPAREN { e }
     | CONVERT LPAREN e=expr COMMA t=sql_type RPAREN
     | CAST LPAREN e=expr AS t=sql_type RPAREN { Fun { kind = (Ret (depends t)); parameters = [e]; is_over_clause = false } }
@@ -546,7 +542,6 @@ single_literal_value:
     | MINUS FLOAT { Value (strict Float) }
 
 expr_list: l=commas(expr) { l }
-optional_expr_list: l=separated_list(COMMA,expr) { l }
 func_params: DISTINCT? l=expr_list { l }
            | ASTERISK { [] }
            | (* *) { [] }

--- a/test/json.sql
+++ b/test/json.sql
@@ -1,6 +1,6 @@
 -- -- https://dev.mysql.com/doc/refman/5.7/en/json-function-reference.html
 
-create table test ( foo JSON );
+create table test ( foo JSON DEFAULT (JSON_OBJECT()) );
 
 SELECT JSON_REMOVE('{"a":1,"b":2,"c":3}','$.b');
 --> '{"a":1,"c":3}'
@@ -13,3 +13,9 @@ SELECT JSON_ARRAY('a','b','c');
 
 SELECT JSON_SET('{"a":1,"b":2,"c":3}','$.b','foo');
 --> '{"a":1,"b":"foo","c":3}'
+
+SELECT JSON_ARRAY();
+--> '[]'
+
+SELECT JSON_OBJECT();
+--> '{}'

--- a/test/json.sql
+++ b/test/json.sql
@@ -1,5 +1,7 @@
 -- -- https://dev.mysql.com/doc/refman/5.7/en/json-function-reference.html
 
+create table test ( foo JSON );
+
 SELECT JSON_REMOVE('{"a":1,"b":2,"c":3}','$.b');
 --> '{"a":1,"c":3}'
 

--- a/test/out/json.xml
+++ b/test/out/json.xml
@@ -1,28 +1,37 @@
 <?xml version="1.0"?>
 
 <sqlgg>
- <stmt name="select_0" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b')" category="DQL" kind="select" cardinality="1">
+ <stmt name="create_test" sql="create table test ( foo JSON )" category="DDL" kind="create" target="test" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_1" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
    <value name="_0" type="Text"/>
   </out>
  </stmt>
- <stmt name="select_1" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','$.c')" category="DQL" kind="select" cardinality="1">
+ <stmt name="select_2" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','$.c')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
    <value name="_0" type="Text"/>
   </out>
  </stmt>
- <stmt name="select_2" sql="SELECT JSON_ARRAY('a','b','c')" category="DQL" kind="select" cardinality="1">
+ <stmt name="select_3" sql="SELECT JSON_ARRAY('a','b','c')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
    <value name="_0" type="Text"/>
   </out>
  </stmt>
- <stmt name="select_3" sql="SELECT JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','foo')" category="DQL" kind="select" cardinality="1">
+ <stmt name="select_4" sql="SELECT JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','foo')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
    <value name="_0" type="Text"/>
   </out>
  </stmt>
+ <table name="test">
+  <schema>
+   <value name="foo" type="Text" nullable="true"/>
+  </schema>
+ </table>
 </sqlgg>

--- a/test/out/json.xml
+++ b/test/out/json.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <sqlgg>
- <stmt name="create_test" sql="create table test ( foo JSON )" category="DDL" kind="create" target="test" cardinality="0">
+ <stmt name="create_test" sql="create table test ( foo JSON DEFAULT (JSON_OBJECT()) )" category="DDL" kind="create" target="test" cardinality="0">
   <in/>
   <out/>
  </stmt>
@@ -24,6 +24,18 @@
   </out>
  </stmt>
  <stmt name="select_4" sql="SELECT JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','foo')" category="DQL" kind="select" cardinality="1">
+  <in/>
+  <out>
+   <value name="_0" type="Text"/>
+  </out>
+ </stmt>
+ <stmt name="select_5" sql="SELECT JSON_ARRAY()" category="DQL" kind="select" cardinality="1">
+  <in/>
+  <out>
+   <value name="_0" type="Text"/>
+  </out>
+ </stmt>
+ <stmt name="select_6" sql="SELECT JSON_OBJECT()" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
    <value name="_0" type="Text"/>


### PR DESCRIPTION
* [First commit](https://github.com/ygrek/sqlgg/commit/894143dba3d3f2fab887905912acc1332846fcd2) add support for JSON column type
* [The second commit](https://github.com/ygrek/sqlgg/commit/f5b75faf915ce871f644748dd08a3339f51f26fd) adds `JSON_OBJECT` + make `JSON{ARRAY,OBJECT}` parameter optional

> [JSON_OBJECT()](https://dev.mysql.com/doc/refman/8.4/en/json-creation-functions.html#function_json-object) takes a (possibly empty) list of key-value pairs and returns a JSON object containing those pairs.

> [JSON_ARRAY()](https://dev.mysql.com/doc/refman/8.4/en/json-creation-functions.html#function_json-array) takes a (possibly empty) list of values and returns a JSON array containing those values