### PR TITLE
Support Json type

### DIFF
--- a/impl/ocaml/dune
+++ b/impl/ocaml/dune
@@ -1,4 +1,5 @@
 (library
-  (wrapped false)
-  (name sqlgg_traits)
-  (public_name sqlgg.traits))
+ (wrapped false)
+ (name sqlgg_traits)
+ (public_name sqlgg.traits)
+ (libraries sqlgg_json_path))

--- a/impl/ocaml/mariadb/dune
+++ b/impl/ocaml/mariadb/dune
@@ -1,5 +1,5 @@
 (library
-  (name sqlgg_mariadb)
-  (public_name sqlgg.mariadb)
-  (optional)
-  (libraries mariadb sqlgg.traits))
+ (name sqlgg_mariadb)
+ (public_name sqlgg.mariadb)
+ (optional)
+ (libraries mariadb yojson sqlgg.traits))

--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -32,6 +32,18 @@ module type Enum = sig
   val proj: t -> string
 end
 
+type json = [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of json list
+  | `Assoc of (string * json) list 
+]
+
+type json_path = Sqlgg_json_path.Ast.t
+type one_or_all = [ `One | `All ]
+
 module type Types = sig
   type field
   type value
@@ -78,6 +90,25 @@ module type Types = sig
     val set_float: float -> value
     val float_to_literal : float -> string
   end
+  module Json : sig
+    include Value
+    val get_json : field -> json
+    val set_json: json -> value
+    val json_to_literal : json -> string
+  end
+  module Json_path : sig
+    include Value
+    val get_json_path : field -> json_path
+    val set_json_path: json_path -> value
+    val json_path_to_literal : json_path -> string
+  end
+  module One_or_all : sig
+    include Value
+    val to_literal : one_or_all -> string
+    val get_one_or_all : field -> one_or_all
+    val set_one_or_all: one_or_all -> value
+    val one_or_all_to_literal : one_or_all -> string
+  end
   module Any : Value
   module Make_enum : functor (E : Enum) -> Value with type t = E.t
 end
@@ -92,6 +123,9 @@ module Default_types(M : Mariadb.Nonblocking.S) : Types with
   type Float.t = float and
   type Decimal.t = float and
   type Datetime.t = M.Time.t and
+  type Json.t = Yojson.Basic.t and
+  type Json_path.t = json_path and
+  type One_or_all.t = one_or_all and
   type Any.t = M.Field.value =
 struct
   type field = M.Field.t
@@ -117,6 +151,7 @@ struct
       | `String x -> sprintf "string %S" x
       | `Bytes x -> sprintf "bytes %S" (Bytes.to_string x)
       | `Decimal x -> sprintf "decimal %S" x
+      | `Json x -> sprintf "json %S" x
       | `Time x ->
       let open M.Time in
       sprintf "time %04d-%02d-%02d %02d:%02d:%02d.%03d" (year x) (month x) (day x) (hour x) (minute x) (second x) (microsecond x)
@@ -251,6 +286,67 @@ struct
     let float_to_literal t = t |> M.Time.utc_timestamp |> to_literal
   end
 
+  module Json = struct
+    include Make (struct
+      type t = Yojson.Basic.t
+
+      let handle_with_json v = function
+        | `String x -> Yojson.Basic.from_string x
+        | `Json x -> Yojson.Basic.from_string x
+        | #M.Field.value as value -> convfail "json" v value
+
+      let of_field field = handle_with_json field (M.Field.value field )
+      let to_value x = `String (Yojson.Basic.to_string x)
+      let to_literal x = Text.to_literal (Yojson.Basic.to_string x)
+    end)
+
+    let get_json = of_field
+    let set_json = to_value
+    let json_to_literal = to_literal
+  end
+
+  module Json_path = struct
+
+    open Sqlgg_json_path
+
+    include Make(struct
+      type t = json_path
+      
+      let of_field field =
+        match M.Field.value field with
+        | `String x -> Json_path.parse_json_path x
+        | value -> convfail "json_path" field value
+      
+      let to_value x = `String (Json_path.string_of_json_path x)
+      
+      let to_literal x = Text.to_literal (Json_path.string_of_json_path x)
+    end)
+
+    let get_json_path = of_field
+    let set_json_path = to_value
+    let json_path_to_literal = to_literal
+  end
+
+  module One_or_all = struct
+  include Make(struct
+    type t = one_or_all
+    let of_field field =
+      match M.Field.value field with
+      | `String s -> 
+        (match String.lowercase_ascii s with
+         | "one" -> `One
+         | "all" -> `All
+         | _ -> convfail "one_or_all" field (`String s))
+      | value -> convfail "one_or_all" field value
+    let to_value = function `One -> `String "one" | `All -> `String "all"
+    let to_literal = function `One -> "one" | `All -> "all"
+  end)
+
+  let get_one_or_all = of_field
+  let set_one_or_all = to_value
+  let one_or_all_to_literal = to_literal
+end
+
   module Any = Make(struct
     type t = M.Field.value
     let of_field = M.Field.value
@@ -325,6 +421,9 @@ let get_column_Float, get_column_Float_nullable = get_column_ty "Float" Float.of
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty "Decimal" Decimal.of_field
 let get_column_Datetime, get_column_Datetime_nullable = get_column_ty "Datetime" Datetime.of_field
 let get_column_Any, get_column_Any_nullable = get_column_ty "Any" Any.of_field
+let get_column_Json, get_column_Json_nullable = get_column_ty "Json" Json.of_field
+let get_column_Json_path, get_column_Json_path_nullable = get_column_ty "Json_path" Json_path.of_field
+let get_column_One_or_all, get_column_One_or_all_nullable = get_column_ty "One_or_all" One_or_all.of_field
 
 let get_column_bool, get_column_bool_nullable = get_column_ty "bool" Bool.get_bool
 let get_column_int64, get_column_int64_nullable = get_column_ty "int64" Int.get_int64
@@ -332,6 +431,9 @@ let get_column_float, get_column_float_nullable = get_column_ty "float" Float.ge
 let get_column_decimal, get_column_decimal_nullable = get_column_ty "float" Decimal.get_float
 let get_column_datetime, get_column_datetime_nullable = get_column_ty "string" Datetime.get_string
 let get_column_string, get_column_string_nullable = get_column_ty "string" Text.get_string
+let get_column_json, get_column_json_nullable = get_column_ty "json" Json.get_json
+let get_column_json_path, get_column_json_path_nullable = get_column_ty "json_path" Json_path.get_json_path
+let get_column_one_or_all, get_column_one_or_all_nullable = get_column_ty "one_or_all" One_or_all.get_one_or_all
 
 
 let bind_param data (_, params, index) = assert (!index < Array.length params); params.(!index) <- data; incr index
@@ -353,6 +455,10 @@ let set_param_Int = set_param_ty Int.to_value
 let set_param_Float = set_param_ty Float.to_value
 let set_param_Decimal = set_param_ty Decimal.to_value
 let set_param_Datetime = set_param_ty Datetime.to_value
+let set_param_Json = set_param_ty Json.to_value
+let set_param_Json_path = set_param_ty Json_path.to_value
+let set_param_One_or_all = set_param_ty One_or_all.to_value
+
 
 let set_param_bool = set_param_ty Bool.set_bool
 let set_param_int64 = set_param_ty Int.set_int64
@@ -360,6 +466,9 @@ let set_param_string = set_param_ty Text.set_string
 let set_param_float = set_param_ty Float.set_float
 let set_param_decimal = set_param_ty Decimal.set_float
 let set_param_datetime = set_param_ty Datetime.set_float
+let set_param_json = set_param_ty Json.set_json
+let set_param_json_path = set_param_ty Json_path.set_json_path
+let set_param_one_or_all = set_param_ty One_or_all.set_one_or_all
 
 module Make_enum (E: Enum) = struct 
 

--- a/impl/ocaml/mysql/dune
+++ b/impl/ocaml/mysql/dune
@@ -1,5 +1,5 @@
 (library
-  (name sqlgg_mysql)
-  (public_name sqlgg.mysql)
-  (optional)
-  (libraries mysql sqlgg.traits))
+ (name sqlgg_mysql)
+ (public_name sqlgg.mysql)
+ (optional)
+ (libraries mysql yojson sqlgg.traits))

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -17,6 +17,18 @@ open Printf
 
 module P = Mysql.Prepared
 
+type json = [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of json list
+  | `Assoc of (string * json) list 
+]
+
+type json_path = Sqlgg_json_path.Ast.t
+type one_or_all = [ `One | `All ]
+
 module type Value = sig
   type t
   val of_string : string -> t
@@ -70,6 +82,29 @@ module type Types = sig
     val set_float: float -> string
     val float_to_literal : float -> string
   end
+
+  module Json : sig
+    include Value
+    val get_string : string -> json
+    val set_string : json -> string
+    val json_to_literal : json -> string
+  end
+
+  module Json_path: sig
+    include Value
+    val get_json_path : string -> json_path
+
+    val set_json_path : json_path -> string
+    val json_path_to_literal : json_path -> string
+  end
+
+  module One_or_all : sig
+    include Value
+    val get_one_or_all : string -> one_or_all
+    val set_one_or_all : one_or_all -> string
+    val one_or_all_to_literal : one_or_all -> string
+  end
+
   module Any : Value
 end
 
@@ -156,6 +191,59 @@ module Default_types = struct
     let set_float x = Text.set_string (Float.to_string x)
     let float_to_literal x = Text.to_literal (Float.to_literal x)
   end
+
+  
+  module Json = struct
+    type t = json
+
+    let of_string s = Yojson.Basic.from_string s
+
+    let to_string j = Yojson.Basic.to_string j
+
+    let to_literal j = Text.to_literal (to_string j)
+
+    let get_string = of_string
+    let set_string = to_string
+    let json_to_literal = to_literal
+  end
+
+ module Json_path = struct
+    open Sqlgg_json_path
+    type t = json_path
+    
+    let of_string = Json_path.parse_json_path
+    let to_string = Json_path.string_of_json_path
+    let to_literal j = Text.to_literal (Json_path.string_of_json_path j)
+
+    let get_json_path = Json_path.parse_json_path
+
+    let set_json_path = Json_path.string_of_json_path
+
+    let json_path_to_literal = to_literal
+  end
+
+  module One_or_all = struct
+    type t = one_or_all
+
+    let of_string s =
+      match String.lowercase_ascii s with
+      | "one" -> `One
+      | "all" -> `All
+      | _ -> failwith (sprintf "One_or_all.of_string: unknown value %s" s)
+
+    let to_string = function
+      | `One -> "one"
+      | `All -> "all"
+
+    let to_literal = function
+      | `One -> "one"
+      | `All -> "all"
+
+    let get_one_or_all = of_string
+    let set_one_or_all = to_string
+    let one_or_all_to_literal = to_literal
+  end
+
   module Any = Text
 end
 
@@ -226,6 +314,9 @@ let get_column_Text, get_column_Text_nullable = get_column_ty "Text" Text.of_str
 let get_column_Float, get_column_Float_nullable = get_column_ty "Float" Float.of_string
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty "Decimal" Decimal.of_string
 let get_column_Datetime, get_column_Datetime_nullable = get_column_ty "Datetime" Datetime.of_string
+let get_column_Json, get_column_Json_nullable = get_column_ty "Json" Json.of_string
+let get_column_Json_path, get_column_Json_path_nullable = get_column_ty "Json_path" Json_path.of_string
+let get_column_One_or_all, get_column_One_or_all_nullable = get_column_ty "One_or_all" One_or_all.of_string
 let get_column_Any, get_column_Any_nullable = get_column_ty "Any" Any.of_string
 
 let get_column_bool, get_column_bool_nullable = get_column_ty "bool" Bool.get_bool
@@ -234,6 +325,9 @@ let get_column_float, get_column_float_nullable = get_column_ty "float" Float.ge
 let get_column_decimal, get_column_decimal_nullable = get_column_ty "float" Decimal.get_float
 let get_column_datetime, get_column_datetime_nullable = get_column_ty "string" Datetime.get_string
 let get_column_string, get_column_string_nullable = get_column_ty "string" Text.get_string
+let get_column_json, get_column_json_nullable = get_column_ty "json" Json.get_string
+let get_column_json_path, get_column_json_path_nullable = get_column_ty "json_path" Json_path.get_json_path
+let get_column_one_or_all, get_column_one_or_all_nullable = get_column_ty "one_or_all" One_or_all.get_one_or_all
 
 let bind_param data (_,params,index) =
   match data with
@@ -253,6 +347,9 @@ let set_param_Int = set_param_ty Int.to_string
 let set_param_Float = set_param_ty Float.to_string
 let set_param_Decimal = set_param_ty Decimal.to_string
 let set_param_Datetime = set_param_ty Datetime.to_string
+let set_param_Json = set_param_ty Json.to_string
+let set_param_Json_path = set_param_ty Json_path.to_string
+let set_param_One_or_all = set_param_ty One_or_all.to_string
 
 let set_param_string = set_param_ty Text.set_string
 let set_param_bool = set_param_ty Bool.set_bool
@@ -260,8 +357,9 @@ let set_param_int64 = set_param_ty Int.set_int64
 let set_param_float = set_param_ty Float.set_float
 let set_param_decimal = set_param_ty Decimal.set_float
 let set_param_datetime = set_param_ty Datetime.set_float
-
-(* enum support *)
+let set_param_json = set_param_ty Json.set_string
+let set_param_json_path = set_param_ty Json_path.set_json_path
+let set_param_one_or_all = set_param_ty One_or_all.set_one_or_all
 
 module Make_enum (E: Enum) = struct 
 

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -28,6 +28,18 @@ module type Enum = sig
   val proj: t -> string
 end
 
+type json = [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of json list
+  | `Assoc of (string * json) list 
+]
+
+type json_path = Sqlgg_json_path.Ast.t
+type one_or_all = [ `One | `All ]
+
 module type FNS = sig
   (* all types intended for subsitution *)
   type params
@@ -102,6 +114,18 @@ module type M = sig
       include Value
       val float_to_literal : float -> string
     end
+    module Json : sig
+      include Value
+      val json_to_literal : json -> string
+    end
+    module Json_path : sig
+      include Value
+      val json_path_to_literal : json_path -> string
+    end
+    module One_or_all : sig
+      include Value
+      val to_literal : one_or_all -> string
+    end
     module Any : Value
   end
 
@@ -121,6 +145,10 @@ module type M = sig
   val get_column_Float : row -> int -> Float.t
   val get_column_Decimal : row -> int -> Decimal.t
   val get_column_Datetime : row -> int -> Datetime.t
+  val get_column_Json: row -> int -> Json.t
+  val get_column_Json_path: row -> int -> Json_path.t
+  val get_column_One_or_all : row -> int -> One_or_all.t
+
 
   val get_column_Bool_nullable : row -> int -> Bool.t option
   val get_column_Int_nullable : row -> int -> Int.t option
@@ -129,6 +157,10 @@ module type M = sig
   val get_column_Float_nullable : row -> int -> Float.t option
   val get_column_Decimal_nullable : row -> int -> Decimal.t option
   val get_column_Datetime_nullable : row -> int -> Datetime.t option
+  val get_column_Json_nullable : row -> int -> Json.t option
+  val get_column_Json_path_nullable : row -> int -> Json_path.t option
+  val get_column_One_or_all_nullable : row -> int -> One_or_all.t option
+
 
   val get_column_bool : row -> int -> bool
   val get_column_bool_nullable : row -> int -> bool option
@@ -148,6 +180,15 @@ module type M = sig
   val get_column_string : row -> int -> string
   val get_column_string_nullable : row -> int -> string option
 
+  val get_column_json : row -> int -> json
+  val get_column_json_nullable : row -> int -> json option
+
+  val get_column_json_path : row -> int -> json_path
+  val get_column_json_path_nullable : row -> int -> json_path option
+
+  val get_column_one_or_all : row -> int -> one_or_all
+  val get_column_one_or_all_nullable : row -> int -> one_or_all option
+
   val start_params : statement -> int -> params
 
   (** [set_param_* stmt index val]. [index] is 0-based,
@@ -160,6 +201,9 @@ module type M = sig
   val set_param_Float : params -> Float.t -> unit
   val set_param_Decimal : params -> Decimal.t -> unit
   val set_param_Datetime : params -> Datetime.t -> unit
+  val set_param_Json: params -> Json.t -> unit
+  val set_param_Json_path: params -> Json_path.t -> unit
+  val set_param_One_or_all : params -> One_or_all.t -> unit
 
   val set_param_bool : params -> bool -> unit
   val set_param_int64 : params -> int64 -> unit
@@ -167,6 +211,9 @@ module type M = sig
   val set_param_decimal : params -> float -> unit
   val set_param_string : params -> string -> unit
   val set_param_datetime : params -> float -> unit
+  val set_param_json : params -> json -> unit
+  val set_param_json_path : params -> json_path -> unit
+  val set_param_one_or_all : params -> one_or_all -> unit
 
   module Make_enum: functor (E : Enum) -> sig
     (* The type itself is not exposed to provide a user a polymorphic type without aliases. *)

--- a/impl/ocaml/sqlite3/dune
+++ b/impl/ocaml/sqlite3/dune
@@ -1,5 +1,5 @@
 (library
-  (name sqlgg_sqlite3)
-  (public_name sqlgg.sqlite3)
-  (optional)
-  (libraries sqlite3 sqlgg.traits))
+ (name sqlgg_sqlite3)
+ (public_name sqlgg.sqlite3)
+ (optional)
+ (libraries sqlite3 yojson sqlgg.traits))

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -19,6 +19,18 @@ module M = struct
 
 module S = Sqlite3
 
+type json = [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of json list
+  | `Assoc of (string * json) list 
+]
+
+type json_path = Sqlgg_json_path.Ast.t
+type one_or_all = [ `One | `All ]
+
 module Types = struct
   module Bool = struct 
     type t = bool 
@@ -78,6 +90,36 @@ module Types = struct
   (* you probably want better type, e.g. (int*int) or Z.t *)
   module Decimal = Float
   module Datetime = Float (* ? *)
+  
+  module Json = struct
+    type t = Yojson.Basic.t
+
+    let to_literal j = 
+      Text.to_literal (Yojson.Basic.to_string j)
+
+    let json_to_literal = to_literal
+  end
+
+  module Json_path = struct
+    open Sqlgg_json_path
+    type t = json_path
+    
+    let to_literal j = 
+      Text.to_literal (Json_path.string_of_json_path j)
+    
+    let json_path_to_literal = to_literal
+  end
+
+  module One_or_all = struct
+    type t = one_or_all
+
+    let to_literal = function
+      | `One -> "one"
+      | `All -> "all"
+
+    let one_or_all_to_literal = to_literal
+  end
+
   module Any = Text
 end
 
@@ -114,6 +156,22 @@ module Conv = struct
   let decimal = "Decimal", function INT i -> Int64.to_float i | FLOAT x -> x | x -> raise (Type_mismatch x)
 
   let datetime = "Datetime", fun x -> Float.to_string @@ snd float x
+
+  let json = "Json", function
+    | TEXT s -> Yojson.Basic.from_string s
+    | x -> raise (Type_mismatch x)
+
+  let json_path = "Json_path", function
+    | TEXT s -> Sqlgg_json_path.Json_path.parse_json_path s
+    | x -> raise (Type_mismatch x)
+
+  let one_or_all = "One_or_all", function
+    | TEXT s -> 
+      (match String.lowercase_ascii s with
+       | "one" -> `One
+       | "all" -> `All
+       | _ -> raise (Type_mismatch (TEXT s)))
+    | x -> raise (Type_mismatch x)
 end
 
 let get_column_ty (name,conv) =
@@ -133,6 +191,9 @@ let get_column_Any, get_column_Any_nullable = get_column_ty Conv.text
 let get_column_Float, get_column_Float_nullable = get_column_ty Conv.float
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty Conv.decimal
 let get_column_Datetime, get_column_Datetime_nullable = get_column_ty Conv.float
+let get_column_Json, get_column_Json_nullable = get_column_ty Conv.json
+let get_column_Json_path, get_column_Json_path_nullable = get_column_ty Conv.json_path
+let get_column_One_or_all, get_column_One_or_all_nullable = get_column_ty Conv.one_or_all
 
 let get_column_bool, get_column_bool_nullable = (get_column_Bool, get_column_Bool_nullable)
 let get_column_int64, get_column_int64_nullable = (get_column_Int, get_column_Int_nullable)
@@ -140,6 +201,10 @@ let get_column_float, get_column_float_nullable = (get_column_Float, get_column_
 let get_column_decimal, get_column_decimal_nullable = (get_column_Decimal, get_column_Decimal_nullable)
 let get_column_string, get_column_string_nullable = (get_column_Text, get_column_Text_nullable)
 let get_column_datetime, get_column_datetime_nullable = get_column_ty Conv.datetime
+let get_column_json, get_column_json_nullable = (get_column_Json, get_column_Json_nullable)
+let get_column_json_path, get_column_json_path_nullable = (get_column_Json_path, get_column_Json_path_nullable)
+let get_column_one_or_all, get_column_one_or_all_nullable = (get_column_One_or_all, get_column_One_or_all_nullable)
+
 
 module Make_enum (E: Enum) = struct 
 
@@ -173,6 +238,9 @@ let set_param_Int stmt v = bind_param (S.Data.INT v) stmt
 let set_param_Float stmt v = bind_param (S.Data.FLOAT v) stmt
 let set_param_Decimal = set_param_Float
 let set_param_Datetime = set_param_Float
+let set_param_Json stmt v = bind_param (S.Data.TEXT (Yojson.Basic.to_string v)) stmt
+let set_param_Json_path stmt v = bind_param (S.Data.TEXT (Sqlgg_json_path.Json_path.string_of_json_path v)) stmt
+let set_param_One_or_all stmt v = bind_param (S.Data.TEXT (match v with `One -> "one" | `All -> "all")) stmt
 
 let set_param_bool = set_param_Bool
 let set_param_int64 = set_param_Int
@@ -180,6 +248,9 @@ let set_param_float = set_param_Float
 let set_param_decimal = set_param_Float
 let set_param_string = set_param_Text
 let set_param_datetime = set_param_Float
+let set_param_json = set_param_Json
+let set_param_json_path = set_param_Json_path
+let set_param_one_or_all = set_param_One_or_all
 
 let no_params _ = ()
 

--- a/json_path/ast.ml
+++ b/json_path/ast.ml
@@ -1,0 +1,41 @@
+type array_index = 
+  | Index of int
+  | Wildcard
+  | Last
+  | LastOffset of int
+
+type range = {
+  start_idx: array_index;
+  end_idx: array_index;
+}
+
+type path_leg =
+  | Member of string          
+  | ArrayAccess of array_index 
+  | ArrayRange of range        
+  | MemberWildcard            
+  | DoubleWildcard            
+
+type t = {
+  scope: string;              
+  legs: path_leg list;
+}
+
+module Syntax = struct
+  let root = { scope = "$"; legs = [] }
+
+  let (/) path leg = { path with legs = path.legs @ [leg] }
+  let (//) path legs = { path with legs = path.legs @ legs }
+
+  let (~.) name = Member name
+
+  let idx n = ArrayAccess (Index n)                    (* idx 0 *)
+  let any = ArrayAccess Wildcard                       (* any *)
+  let last = ArrayAccess Last                          (* last *)
+  let wildcard = MemberWildcard                        (* wildcard *)
+  let range start end_ = ArrayRange { 
+    start_idx = Index start; 
+    end_idx = Index end_ 
+  }
+  
+end

--- a/json_path/dune
+++ b/json_path/dune
@@ -1,0 +1,17 @@
+(menhir
+ (modules json_path_parser))
+
+(ocamllex json_path_lexer)
+
+(library
+ (name sqlgg_json_path)
+ (public_name sqlgg.json_path)
+ (modules
+  (:standard \ test_json_path))
+ (preprocess
+  (pps ppx_deriving.std)))
+
+(test
+ (name test_json_path)
+ (modules test_json_path)
+ (libraries sqlgg_json_path oUnit))

--- a/json_path/json_path.ml
+++ b/json_path/json_path.ml
@@ -1,0 +1,43 @@
+open Ast
+
+module Lexer = Json_path_lexer
+module Parser =Json_path_parser
+
+let parse_json_path input =
+  let lexbuf = Lexing.from_string input in
+  try
+    Parser.path_expression Lexer.token lexbuf
+  with
+  | Lexer.LexError msg ->
+      failwith ("Lexer error: " ^ msg)
+  | Parser.Error ->
+      let pos = Lexing.lexeme_start_p lexbuf in
+      failwith (Printf.sprintf "Parser error at line %d, column %d" 
+                pos.pos_lnum (pos.pos_cnum - pos.pos_bol))
+
+let is_valid input =
+  try
+    let _ = parse_json_path input in
+    true
+  with
+  | _ -> false
+
+let string_of_array_index = function
+  | Index n -> string_of_int n
+  | Wildcard -> "*"
+  | Last -> "last"
+  | LastOffset n -> "last-" ^ string_of_int n
+
+let string_of_range range =
+  string_of_array_index range.start_idx ^ " to " ^ string_of_array_index range.end_idx
+
+let string_of_path_leg = function
+  | Member key when String.contains key ' ' || String.contains key '-' -> ".\"" ^ key ^ "\""
+  | Member key -> "." ^ key
+  | ArrayAccess idx -> "[" ^ string_of_array_index idx ^ "]"
+  | ArrayRange range -> "[" ^ string_of_range range ^ "]"
+  | MemberWildcard -> ".*"
+  | DoubleWildcard -> "**"
+
+let string_of_json_path path =
+  path.scope ^ String.concat "" (List.map string_of_path_leg path.legs)

--- a/json_path/json_path_lexer.mll
+++ b/json_path/json_path_lexer.mll
@@ -1,0 +1,45 @@
+{
+  open Json_path_parser
+
+  exception LexError of string
+}
+
+let whitespace = [' ' '\t']
+let newline = '\r' | '\n' | "\r\n"
+let digit = ['0'-'9']
+let letter = ['a'-'z' 'A'-'Z']
+let identifier_start = letter | '_' | '$'
+let identifier_char = identifier_start | digit
+
+rule token = parse
+  | whitespace+ { token lexbuf }
+  | newline     { Lexing.new_line lexbuf; token lexbuf }  (* ← используйте встроенную функцию *)
+  | '$'         { DOLLAR }
+  | '.'         { DOT }
+  | '*'         { ASTERISK }
+  | "**"        { DOUBLE_ASTERISK }
+  | '['         { LBRACKET }
+  | ']'         { RBRACKET }
+  | '-'         { MINUS }
+  | "to"        { TO }
+  | "last"      { LAST }
+  | digit+ as n { INTEGER (int_of_string n) }
+  | identifier_start identifier_char* as id { IDENTIFIER id }
+  | '"'         { read_string (Buffer.create 17) lexbuf }
+  | eof         { EOF }
+  | _ as c      { raise (LexError ("Unexpected character: " ^ String.make 1 c)) }
+
+and read_string buf = parse
+  | '"'       { STRING (Buffer.contents buf) }
+  | '\\' '"'  { Buffer.add_char buf '"'; read_string buf lexbuf }
+  | '\\' '\\' { Buffer.add_char buf '\\'; read_string buf lexbuf }
+  | '\\' 'n'  { Buffer.add_char buf '\n'; read_string buf lexbuf }
+  | '\\' 't'  { Buffer.add_char buf '\t'; read_string buf lexbuf }
+  | '\\' 'r'  { Buffer.add_char buf '\r'; read_string buf lexbuf }
+  | '\\' _    { Buffer.add_char buf '\\'; read_string buf lexbuf }
+  | newline   { Lexing.new_line lexbuf; Buffer.add_char buf '\n'; read_string buf lexbuf }
+  | eof       { raise (LexError "Unterminated string") }
+  | _ as c    { Buffer.add_char buf c; read_string buf lexbuf }
+
+{
+}

--- a/json_path/json_path_parser.mly
+++ b/json_path/json_path_parser.mly
@@ -1,0 +1,51 @@
+%{
+  open Ast
+%}
+
+%token <int> INTEGER
+%token <string> IDENTIFIER
+%token <string> STRING
+%token DOLLAR
+%token DOT
+%token ASTERISK
+%token DOUBLE_ASTERISK
+%token LBRACKET
+%token RBRACKET
+%token MINUS
+%token TO
+%token LAST
+%token EOF
+
+%start <t> path_expression
+%%
+
+path_expression:
+  | DOLLAR legs = list(path_leg) EOF { { scope = "$"; legs } }
+
+path_leg:
+  | member { $1 }
+  | array_location { $1 }
+  | DOUBLE_ASTERISK { DoubleWildcard }
+
+member:
+  | DOT key_name = key_name { Member key_name }
+  | DOT ASTERISK { MemberWildcard }
+
+key_name:
+  | id = IDENTIFIER { id }
+  | s = STRING { s }
+
+array_location:
+  | LBRACKET idx = array_index RBRACKET { ArrayAccess idx }
+  | LBRACKET range = array_range RBRACKET { ArrayRange range }
+
+array_index:
+  | n = INTEGER { Index n }
+  | ASTERISK { Wildcard }
+  | LAST { Last }
+  | LAST MINUS n = INTEGER { LastOffset n }
+
+array_range:
+  | start = array_index TO end_idx = array_index { { start_idx = start; end_idx } }
+
+%%

--- a/json_path/test_json_path.ml
+++ b/json_path/test_json_path.ml
@@ -1,0 +1,313 @@
+open Printf
+open OUnit
+open Sqlgg_json_path
+open Ast
+
+let cmp_path_leg l1 l2 = match l1, l2 with
+  | Member s1, Member s2 -> s1 = s2
+  | ArrayAccess idx1, ArrayAccess idx2 -> idx1 = idx2
+  | ArrayRange r1, ArrayRange r2 -> r1.start_idx = r2.start_idx && r1.end_idx = r2.end_idx
+  | MemberWildcard, MemberWildcard | DoubleWildcard, DoubleWildcard -> true
+  | _ -> false
+
+let cmp_json_path p1 p2 = 
+  p1.scope = p2.scope && 
+  (try List.for_all2 cmp_path_leg p1.legs p2.legs with _ -> false)
+
+let parse_path input =
+  try
+    Json_path.parse_json_path input
+  with
+  | Failure msg -> assert_failure @@ sprintf "failed to parse: %s : %s" msg input
+
+let test_path input expected_legs =
+  let expected = { scope = "$"; legs = expected_legs } in
+  let parsed = parse_path input in
+  assert_equal 
+    ~msg:("path: " ^ input)
+    ~cmp:cmp_json_path 
+    ~printer:Json_path.string_of_json_path
+    expected 
+    parsed
+
+let tt input expected_legs =
+  let test () = test_path input expected_legs in
+  input >:: test
+
+let wrong input =
+  input >:: (fun () -> 
+    ("Expected error in: " ^ input) @? 
+    (try ignore (parse_path input); false with _ -> true))
+
+let test_basic = [
+  tt "$" [];
+  tt "$.name" [Member "name"];
+  tt "$[0]" [ArrayAccess (Index 0)];
+  tt "$[*]" [ArrayAccess Wildcard];
+  tt "$[last]" [ArrayAccess Last];
+  tt "$[last-1]" [ArrayAccess (LastOffset 1)];
+  tt "$.*" [MemberWildcard];
+  tt "$**" [DoubleWildcard];
+]
+
+let test_complex = [
+  tt "$.user.name" [Member "user"; Member "name"];
+  tt "$.items[0].price" [Member "items"; ArrayAccess (Index 0); Member "price"];
+  tt "$.users[*].email" [Member "users"; ArrayAccess Wildcard; Member "email"];
+  tt "$[1 to 3]" [ArrayRange { start_idx = Index 1; end_idx = Index 3 }];
+  tt "$.\"quoted key\"" [Member "quoted key"];
+  tt "$**.name" [DoubleWildcard; Member "name"];
+]
+
+let test_ranges = [
+  tt "$[0 to 5]" [ArrayRange { start_idx = Index 0; end_idx = Index 5 }];
+  tt "$[last-3 to last]" [ArrayRange { start_idx = LastOffset 3; end_idx = Last }];
+  tt "$[* to last]" [ArrayRange { start_idx = Wildcard; end_idx = Last }];
+]
+
+let test_errors = [
+  wrong "";
+  wrong "name";
+  wrong "$.";
+  wrong "$[";
+  wrong "$]";
+  wrong "$[abc]";
+  wrong "$.123invalid";
+  wrong "$[1 to]";
+  wrong "$[to 5]";
+]
+
+let test_combinators = [
+  "root" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root in
+    let from_parser = parse_path "$" in
+    let expected = { scope = "$"; legs = [] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "simple member" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / ~."name" in
+    let from_parser = parse_path "$.name" in
+    let expected = { scope = "$"; legs = [Member "name"] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "chained" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / ~."user" / ~."email" in
+    let from_parser = parse_path "$.user.email" in
+    let expected = { scope = "$"; legs = [Member "user"; Member "email"] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "with functions" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / ~."items" / any / ~."price" in
+    let from_parser = parse_path "$.items[*].price" in
+    let expected = { scope = "$"; legs = [Member "items"; ArrayAccess Wildcard; Member "price"] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "array index" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / idx 5 in
+    let from_parser = parse_path "$[5]" in
+    let expected = { scope = "$"; legs = [ArrayAccess (Index 5)] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "last element" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / last in
+    let from_parser = parse_path "$[last]" in
+    let expected = { scope = "$"; legs = [ArrayAccess Last] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "member wildcard" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / wildcard in
+    let from_parser = parse_path "$.*" in
+    let expected = { scope = "$"; legs = [MemberWildcard] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "range" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / range 1 5 in
+    let from_parser = parse_path "$[1 to 5]" in
+    let expected = { scope = "$"; legs = [ArrayRange { start_idx = Index 1; end_idx = Index 5 }] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "complex chain" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root / ~."data" / any / ~."users" / last / ~."settings" in
+    let from_parser = parse_path "$.data[*].users[last].settings" in
+    let expected = { scope = "$"; legs = [
+      Member "data";
+      ArrayAccess Wildcard;
+      Member "users";
+      ArrayAccess Last;
+      Member "settings"
+    ] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+  
+  "multiple legs operator" >:: (fun () ->
+    let open Syntax in
+    let from_combinator = root // [~."api"; ~."v1"; idx 0; ~."data"] in
+    let from_parser = parse_path "$.api.v1[0].data" in
+    let expected = { scope = "$"; legs = [
+      Member "api";
+      Member "v1";
+      ArrayAccess (Index 0);
+      Member "data"
+    ] } in
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path expected from_combinator;
+    assert_equal ~cmp:cmp_json_path ~printer:Json_path.string_of_json_path from_combinator from_parser
+  );
+]
+let test_round_trip = [
+  "round trip basic" >:: (fun () ->
+    let inputs = ["$"; "$.name"; "$[0]"; "$.user.email"; "$[1 to 3]"] in
+    List.iter (fun input ->
+      let parsed = parse_path input in
+      let serialized = Json_path.string_of_json_path parsed in
+      assert_equal ~msg:("round trip: " ^ input) input serialized
+    ) inputs
+  );
+]
+
+let test_serialization = [
+  "serialize basic paths" >:: (fun () ->
+    let test_cases = [
+      ({ scope = "$"; legs = [] }, "$");
+      ({ scope = "$"; legs = [Member "name"] }, "$.name");
+      ({ scope = "$"; legs = [ArrayAccess (Index 0)] }, "$[0]");
+      ({ scope = "$"; legs = [ArrayAccess Wildcard] }, "$[*]");
+      ({ scope = "$"; legs = [ArrayAccess Last] }, "$[last]");
+      ({ scope = "$"; legs = [ArrayAccess (LastOffset 1)] }, "$[last-1]");
+      ({ scope = "$"; legs = [MemberWildcard] }, "$.*");
+      ({ scope = "$"; legs = [DoubleWildcard] }, "$**");
+    ] in
+    List.iter (fun (path, expected) ->
+      let result = Json_path.string_of_json_path path in
+      assert_equal ~msg:("serialize: " ^ expected) expected result
+    ) test_cases
+  );
+  
+  "serialize complex paths" >:: (fun () ->
+    let test_cases = [
+      ({ scope = "$"; legs = [Member "user"; Member "name"] }, "$.user.name");
+      ({ scope = "$"; legs = [Member "items"; ArrayAccess (Index 0); Member "price"] }, "$.items[0].price");
+      ({ scope = "$"; legs = [ArrayRange { start_idx = Index 1; end_idx = Index 3 }] }, "$[1 to 3]");
+      ({ scope = "$"; legs = [ArrayRange { start_idx = LastOffset 3; end_idx = Last }] }, "$[last-3 to last]");
+      ({ scope = "$"; legs = [DoubleWildcard; Member "name"] }, "$**.name");
+    ] in
+    List.iter (fun (path, expected) ->
+      let result = Json_path.string_of_json_path path in
+      assert_equal ~msg:("serialize: " ^ expected) expected result
+    ) test_cases
+  );
+  
+  "serialize edge cases" >:: (fun () ->
+    let test_cases = [
+      ({ scope = "$"; legs = [Member ""] }, "$.");
+      ({ scope = "$"; legs = [ArrayAccess (Index 999)] }, "$[999]");
+      ({ scope = "$"; legs = [ArrayAccess (LastOffset 100)] }, "$[last-100]");
+      ({ scope = "$"; legs = [ArrayRange { start_idx = Wildcard; end_idx = Last }] }, "$[* to last]");
+    ] in
+    List.iter (fun (path, expected) ->
+      let result = Json_path.string_of_json_path path in
+      assert_equal ~msg:("serialize: " ^ expected) expected result
+    ) test_cases
+  );
+]
+
+let test_bidirectional = [
+  "parse then serialize" >:: (fun () ->
+    let inputs = [
+      "$"; "$.name"; "$[0]"; "$[*]"; "$[last]"; "$[last-1]"; "$.*"; "$**";
+      "$.user.name"; "$.items[0].price"; "$.users[*].email"; 
+      "$[1 to 3]"; "$[0 to 5]"; "$[last-3 to last]"; "$[* to last]";
+      "$**.name"; "$.\"quoted key\"";
+    ] in
+    List.iter (fun input ->
+      let parsed = parse_path input in
+      let serialized = Json_path.string_of_json_path parsed in
+      assert_equal ~msg:("bidirectional: " ^ input) input serialized
+    ) inputs
+  );
+  
+  "serialize then parse" >:: (fun () ->
+    let paths = [
+      { scope = "$"; legs = [] };
+      { scope = "$"; legs = [Member "test"] };
+      { scope = "$"; legs = [ArrayAccess (Index 42)] };
+      { scope = "$"; legs = [Member "data"; ArrayAccess Wildcard; Member "value"] };
+      { scope = "$"; legs = [ArrayRange { start_idx = Index 5; end_idx = Index 10 }] };
+    ] in
+    List.iter (fun original_path ->
+      let serialized = Json_path.string_of_json_path original_path in
+      let parsed_back = parse_path serialized in
+      assert_equal 
+        ~cmp:cmp_json_path 
+        ~printer:Json_path.string_of_json_path
+        ~msg:("serialize->parse: " ^ serialized)
+        original_path 
+        parsed_back
+    ) paths
+  );
+]
+
+let test_validation = [
+  "is_valid positive cases" >:: (fun () ->
+    let valid_inputs = [
+      "$"; "$.name"; "$[0]"; "$[*]"; "$[last]"; "$[last-1]"; "$.*"; "$**";
+      "$.user.name"; "$.items[0].price"; "$[1 to 3]"; "$**.field";
+    ] in
+    List.iter (fun input ->
+      assert_bool ("should be valid: " ^ input) (Json_path.is_valid input)
+    ) valid_inputs
+  );
+  
+  "is_valid negative cases" >:: (fun () ->
+    let invalid_inputs = [
+      ""; "name"; "$."; "$["; "$]"; "$[abc]"; "$.123invalid"; 
+      "$[1 to]"; "$[to 5]"; "$[1 to 3 to 5]"; "$$"; "$..";
+    ] in
+    List.iter (fun input ->
+      assert_bool ("should be invalid: " ^ input) (not (Json_path.is_valid input))
+    ) invalid_inputs
+  );
+]
+
+let run () =
+  let tests = [
+    "basic" >::: test_basic;
+    "complex" >::: test_complex;
+    "ranges" >::: test_ranges;
+    "errors" >::: test_errors;
+    "combinators" >::: test_combinators;
+    "serialization" >::: test_serialization;
+    "bidirectional" >::: test_bidirectional;
+    "validation" >::: test_validation;
+    "round_trip" >::: test_round_trip;
+  ] in
+  let test_suite = "JSON Path Parser" >::: tests in
+  let results = run_test_tt test_suite in
+  exit @@ if List.exists (function RFailure _ | RError _ -> true | _ -> false) results then 1 else 0
+
+let _ = run ()

--- a/lib/dune
+++ b/lib/dune
@@ -1,9 +1,11 @@
-(menhir (modules sql_parser))
+(menhir
+ (modules sql_parser))
+
 (ocamllex sql_lexer)
 
 (library
-  (name sqlgg)
-  (public_name sqlgg.lib)
-  (libraries extlib)
-  (preprocess (pps ppx_deriving.std))
-)
+ (name sqlgg)
+ (public_name sqlgg.lib)
+ (libraries extlib yojson sqlgg_json_path)
+ (preprocess
+  (pps ppx_deriving.std)))

--- a/lib/prelude.ml
+++ b/lib/prelude.ml
@@ -13,5 +13,14 @@ let option_list = function Some x -> [x] | None -> []
 
 let fail fmt = Printf.ksprintf failwith fmt
 let failed ~at fmt = Printf.ksprintf (fun s -> raise (At (at, Failure s))) fmt
-let printfn fmt = Printf.ksprintf print_endline fmt
-let eprintfn fmt = Printf.ksprintf prerr_endline fmt
+
+let silent_output = ref false
+
+let printfn fmt = 
+  if !silent_output
+  then Printf.ksprintf ignore fmt
+  else Printf.ksprintf print_endline fmt
+
+let eprintfn fmt = if !silent_output
+  then Printf.ksprintf ignore fmt
+  else Printf.ksprintf prerr_endline fmt

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -218,7 +218,8 @@ let keywords =
   all T_BOOLEAN ["bool";"boolean"];
   all T_FLOAT ["float";"real";"double";"float4";"float8";"int1";"int2";"int3";"int4";"int8"];
   all T_BLOB ["blob";"varbinary";"tinyblob";"mediumblob";"longblob"];
-  all T_TEXT ["text";"char";"varchar";"tinytext";"mediumtext";"longtext";"json"];
+  all T_TEXT ["text";"char";"varchar";"tinytext";"mediumtext";"longtext";];
+  all T_JSON ["json"];
   all T_TEXT ["varchar2"]; (* oracle *)
   all T_DATETIME ["datetime"];
   all T_UUID ["uuid"]; (* http://www.postgresql.org/docs/9.4/static/datatype-uuid.html *)

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -51,7 +51,7 @@
        DAY_MICROSECOND DAY_SECOND DAY_MINUTE DAY_HOUR
        YEAR_MONTH FALSE TRUE DUPLICATE
 %token NUM_DIV_OP NUM_EQ_OP NUM_CMP_OP PLUS MINUS NOT_DISTINCT_OP NUM_BIT_SHIFT NUM_BIT_OR NUM_BIT_AND
-%token T_INTEGER T_BLOB T_TEXT T_FLOAT T_BOOLEAN T_DATETIME T_UUID T_DECIMAL
+%token T_INTEGER T_BLOB T_TEXT T_FLOAT T_BOOLEAN T_DATETIME T_UUID T_DECIMAL T_JSON
 
 (*
 %left COMMA_JOIN
@@ -573,6 +573,7 @@ sql_type_flavor: T_INTEGER UNSIGNED? ZEROFILL? { Int }
                | T_BOOLEAN { Bool }
                | T_DATETIME | YEAR | DATE | TIME | TIMESTAMP { Datetime }
                | T_UUID { Blob }
+               | T_JSON { Json }
 
 binary: T_BLOB | BINARY | BINARY VARYING { }
 text: T_TEXT | T_TEXT LPAREN INTEGER RPAREN | CHARACTER { }
@@ -599,6 +600,7 @@ compound_op:
 
 strict_type:
     | T_TEXT     { Text }
+    | T_JSON     { Json }
     | T_BLOB     { Blob }
     | T_INTEGER  { Int }
     | T_FLOAT    { Float }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -319,7 +319,50 @@ let rec resolve_columns env expr =
   let rec each e =
     match e with
     | Value x -> ResValue x
-    | Column col -> ResValue (resolve_column ~env col).attr.domain
+    | Column col ->
+      let attr = (resolve_column ~env col).attr in
+      let json_null_kind = Meta.find_opt attr.meta "json_null_kind" in
+      let text_as_json = Meta.find_opt attr.meta "text_as_json" in
+      let domain = match json_null_kind, text_as_json, attr.domain with
+        | v, _, ({ t = Json; nullability } as d)
+        | v, Some "true", ({ t = Text; nullability } as d) -> 
+          (*
+            Determines whether JSON null is allowed as a valid value in the column.
+
+            JSON null (i.e. the literal `null` in a JSON document) is distinct from SQL NULL.
+            - JSON null is an actual value in JSON and can appear inside arrays or objects.
+            - SQL NULL means "no value at all" and causes most JSON functions to return NULL
+              if encountered as an argument (e.g. JSON_ARRAY_APPEND returns NULL if any argument is SQL NULL).
+
+            Standard SQL DDL (e.g. CREATE TABLE) does not allow expressing whether JSON null is allowed
+            for JSON columns — it only covers SQL NULL via NOT NULL constraints.
+
+            To bridge this semantic gap, we introduce a custom meta-attribute `json_null_kind`:
+              - "true" or "auto" → JSON null is allowed (treated as a Nullable domain)
+              - "false"          → JSON null is disallowed (treated as Strict)
+
+            Additionally, if `text_as_json` is set and the underlying type is `Text`,
+            we apply the same logic (since JSON is serialized into text in that case).
+
+            The resulting domain is:
+              - Nullable → JSON null is allowed in values
+              - Strict   → JSON null is rejected during validation
+
+            This impacts how JSON expressions are parsed, validated, and how DDL is generated.
+          *)
+          let nullability = match v, nullability with 
+          | Some "false", Type.Strict -> Type.Strict
+          | _ -> Type.Nullable
+          in
+          { Type.t = d.t; nullability; }
+        | _, Some _, _ -> 
+          fail "Column %s has text_as_json meta, but its type is not Text" col.cname  
+        | Some _, _, _ -> 
+          fail "Column %s has json_null_kind meta, but its type is not Json or Text" col.cname
+        | None, _, _ -> 
+          attr.domain
+      in
+      ResValue domain
     | OptionActions { choice; pos; kind } ->
       let choice_id = match bool_choice_id choice with
       | Some choice_id -> choice_id
@@ -467,7 +510,8 @@ and assign_types env expr =
             (* Since we have string literals, we can check if the enums are already exhausted or if a default case is required *)
             let values = Type.Enum_kind.Ctors.of_list @@ List.filter_map (function ResValue { t = StringLiteral v; _ } -> Some v | _ -> None) whens_e in
             Type.Enum_kind.Ctors.compare values ctors = 0
-          | Unit _ | Int | Text | Blob | Float | Datetime | Decimal | Any | StringLiteral _ | Bool -> false in
+          | Unit _ | Int | Text | Blob | Float | Datetime 
+          | Decimal | Any | One_or_all | Json | StringLiteral _ | Json_path | Bool -> false in
         let exhaust_checked = if is_exhausted then types else List.map Type.make_nullable types in  
         match Type.common_supertype @@ Option.map_default (fun else_t -> types @ [get_or_failwith else_t]) exhaust_checked else_t with
         | None -> failwith "no common supertype for all case then branches"
@@ -533,7 +577,32 @@ and assign_types env expr =
         let consider_agg_nullability typ = if (env.query_has_grouping || is_over_clause) && is_strict typ then typ else make_nullable typ in
 
         let rec infer_fn func types = match func, types with
-        | Multi (ret, each_arg), t -> infer_fn (F (ret, types_to_arg each_arg)) t
+        | Multi { ret; fixed_args = []; repeating_pattern = [each_arg] }, t -> 
+          infer_fn (F (ret, types_to_arg each_arg)) t
+        | Multi { ret; fixed_args; repeating_pattern }, t->
+          let fixed_count = List.length fixed_args in
+          let pattern_length = List.length repeating_pattern in
+          let total_args = List.length types in
+
+          if total_args < fixed_count then
+            fail "function %s requires at least %d arguments, got %d" 
+              (show_func ()) fixed_count total_args
+          else if Stdlib.(pattern_length = 0) then (
+            if total_args <> fixed_count then
+              fail "function %s requires exactly %d arguments, got %d" 
+          (show_func ()) fixed_count total_args
+            else
+              infer_fn (F (ret, fixed_args)) t
+          ) else if (total_args - fixed_count) mod pattern_length <> 0 then
+            fail "function %s requires %d fixed args + multiples of %d args, got %d" 
+              (show_func ()) fixed_count pattern_length total_args
+          else
+            let remaining_count = total_args - fixed_count in
+            let repeating_cycles = remaining_count / pattern_length in
+            let repeated_args =
+              List.flatten (List.init repeating_cycles (Fun.const repeating_pattern))
+            in
+            infer_fn (F (ret, fixed_args @ repeated_args)) t
         | Agg Count, ([] (* asterisk *) | [_]) -> strict Int, types
         | Agg Avg, [_] -> consider_agg_nullability @@ nullable Float, types
         | Agg Self, [typ] -> consider_agg_nullability typ, types

--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -12,6 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.6.0"}
   "dune" {>= "2.7"}
   "menhir" {>= "20180523"}
   "mybuild" {> "3"}

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -130,7 +130,7 @@ let main () =
     "-dialect", Arg.String set_dialect, "mysql|sqlite|postgresql|tidb Set SQL dialect - will only allow this dialect's features in SQL queries";
     "-no-check", Arg.String set_no_check, "{all|<feature>{,<feature>}+} Disable dialect feature checks (possible features: collation|join_on_subquery|create_table_as_select) - do not enforce dialect feature checks";
     "-", Arg.Unit (fun () -> work "-"), " Read sql from stdin";
-    "-test", Arg.Unit Test.run, " Run unit tests";
+    "-test", Arg.Unit (fun () -> Prelude.silent_output := true; Test.run ()), " Run unit tests";
   ]
   in
   Arg.parse args work usage_msg;

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -141,6 +141,9 @@ module L = struct
   | { t = Datetime; _ }
   | { t = Decimal; _ }
   | { t = Union _; _ }
+  | { t = Json; _ }
+  | { t = Json_path; _ }
+  | { t = One_or_all; _ } 
   | { t = Any; _ } as t -> type_name t
 
   let as_runtime_repr_name = function
@@ -148,6 +151,7 @@ module L = struct
   | { t = Text; _ }
   | { t = Any; _ }
   | { t = Union _; _ }
+  | { t = Json_path; _ }
   | { t = StringLiteral _; _ } -> "string"
   | { t = Unit _; _ } -> "unit"
   | { t = Int; _ } -> "int64"
@@ -155,6 +159,8 @@ module L = struct
   | { t = Bool; _ } -> "bool"
   | { t = Datetime; _ }
   | { t = Decimal; _ } -> "float"
+  | { t = Json; _ } -> "json"
+  | { t = One_or_all; _ } -> "text"
 
 
   let as_api_type = as_lang_type
@@ -631,7 +637,8 @@ let generate_enum_modules stmts =
 
   let get_enum typ = match typ.Sql.Type.t with 
     | Union { ctors; _ } -> Some ctors
-    | Unit _ | Int | Text | Blob | Float | Bool  | Datetime | Decimal | Any | StringLiteral  _ -> None
+    | Unit _ | Int | Text | Blob | Float | Bool | Json
+    | Datetime | Decimal | Any | StringLiteral  _ | Json_path | One_or_all -> None
   in
 
   let schemas_to_enums schemas = schemas |> List.filter_map (fun { domain; _ } -> get_enum domain) in

--- a/src/gen_csharp.ml
+++ b/src/gen_csharp.ml
@@ -42,9 +42,12 @@ let as_api_type t =
   | Decimal -> "Decimal"
   | Datetime -> "Datetime"
   | Any -> "String"
-  | Union _
   | StringLiteral _ -> "String"
-  | Unit _ -> assert false
+  | Union _
+  | Json_path
+  | One_or_all
+  | Json
+  | Unit _  -> assert false
 
 let as_lang_type = as_api_type
 

--- a/src/gen_java.ml
+++ b/src/gen_java.ml
@@ -44,6 +44,9 @@ let as_lang_type t =
   | Datetime -> "Timestamp"
   | StringLiteral _ -> "String"
   | Union _
+  | Json
+  | One_or_all 
+  | Json_path
   | Unit _ -> assert false
 
 let as_api_type = String.capitalize_ascii $ as_lang_type

--- a/src/test.ml
+++ b/src/test.ml
@@ -1594,7 +1594,123 @@ let test_multi_functions = [
   tt "SELECT CONCAT('prefix:', (SELECT txt1 FROM test_multi LIMIT 1)) as result"
     [attr' ~nullability:(Nullable) "result" Text] [];
 ]
+
+let test_json_and_fixed_then_pairs_fn_kind  = [
+  tt "CREATE TABLE test46 ( id INT AUTO_INCREMENT PRIMARY KEY, data JSON)" [][];
+  tt "UPDATE test46 SET data = JSON_ARRAY_APPEND(data, '$', '\"new_val\"') WHERE id = 3" [] [];
+  tt "UPDATE test46 SET data = JSON_ARRAY_APPEND(data, '$[0][1][2].three.four.five', 'false') WHERE id = 3" [] [];
+  tt {| SELECT JSON_ARRAY_APPEND(
+       data, 
+       '$[0].items',     123,          
+       '$[1].props',     '"hello"',       
+       '$[2].flags',     true,          
+       '$[3].meta',      null,         
+       '$[4].nested',    JSON_OBJECT('x', 'y')
+     ) as result FROM test46 WHERE id = 3 
+    |} [ attr' ~nullability:Nullable "result" Json ] [];
+  wrong "UPDATE test46 SET data = JSON_ARRAY_APPEND('NOT_A_VALID_JSON', '$[0][1][2].three.four.five', 'this is a string') WHERE id = 3";
+  tt {| UPDATE test46 SET data = JSON_ARRAY_APPEND(data, @path, @data :: Text) WHERE id = 3 |} [] [
+    named "path" Json_path;
+    named "data" Text;
+  ];
+  tt "SELECT JSON_REMOVE(@json, '$[1]') as result" [ attr' "result" Json ][ named "json" Json;];
+  wrong "SELECT JSON_REMOVE(@json, 'invalid path') as result";
+  tt "SELECT JSON_REMOVE(@json, @path) as result" [ attr' "result" Json ][ named "json" Json; named "path" Json_path;];
   
+  tt "SELECT JSON_REMOVE(@json, '$.field1', '$.field2', '$.nested.prop') as result" 
+    [ attr' "result" Json ] [ named "json" Json ];
+  tt "UPDATE test46 SET data = JSON_REMOVE(data, '$.old_field') WHERE id = 1" [] [];
+  tt "UPDATE test46 SET data = JSON_SET(data, '$.name', 'John') WHERE id = 1" [] [];
+  tt {| UPDATE test46 SET data = JSON_SET(
+        data, 
+        '$.name',     'Alice',
+        '$.age',      25,
+        '$.active',   true,
+        '$.balance',  null
+      ) WHERE id = 2 
+    |} [] [];
+  tt {| SELECT JSON_SET(
+        data,
+        '$.user.name',    'Bob',
+        '$.user.props',   JSON_OBJECT('theme', 'dark'),
+        '$.user.count',   42
+      ) as result FROM test46 WHERE id = 1
+    |} [ attr' ~nullability:Nullable "result" Json ] [];
+  tt {| UPDATE test46 SET data = JSON_SET(data, @path, @value :: Text, '$.timestamp', @time :: Int) WHERE id = 3 |} 
+  [] [
+    named "path" Json_path;
+    named "value" Text;
+    named "time" Int;
+  ];
+  wrong "UPDATE test46 SET data = JSON_SET('INVALID_JSON', '$.field', 'value') WHERE id = 1";
+  tt "SELECT JSON_OBJECT() as result" [ attr' "result" Json ] [];
+  tt "SELECT JSON_OBJECT('name', 'John') as result" [ attr' "result" Json ] [];
+  tt "SELECT JSON_OBJECT('name', 'Alice', 'age', 25, 'active', true) as result" 
+    [ attr' "result" Json ] [];
+  tt "UPDATE test46 SET data = JSON_OBJECT('user', JSON_OBJECT('id', 1, 'name', 'Bob')) WHERE id = 1" [] [];
+  tt "SELECT JSON_OBJECT(@key, @value :: Text) as result" 
+    [ attr' "result" Json ] [ named "key" Text; named "value" Text ];
+  tt "SELECT JSON_OBJECT('meta', JSON_EXTRACT(data, '$.info')) as result FROM test46" 
+    [ attr' "result" Json ] [];
+  tt "SELECT JSON_ARRAY() as result" [ attr' "result" Json ] [];
+  tt "SELECT JSON_ARRAY(1, 'hello', true, null) as result" [ attr' "result" Json ] [];
+  tt "UPDATE test46 SET data = JSON_ARRAY(JSON_OBJECT('id', 1), JSON_OBJECT('id', 2)) WHERE id = 1" [] [];
+  tt "SELECT JSON_ARRAY(@val1 :: Int, @val2 :: Text, @val3 :: Bool) as result" 
+    [ attr' "result" Json ] [ 
+      named "val1" Int; 
+      named "val2" Text; 
+      named "val3" Bool 
+    ];
+  tt "SELECT JSON_CONTAINS(@json :: Json, @search) as result" 
+    [ attr' ~nullability:Nullable  "result" Bool ] [ named "json" Json; named "search" Json ];
+  tt {| SELECT JSON_CONTAINS(data, '"target_value"') as found FROM test46 |}
+    [ attr' ~nullability:Nullable "found" Bool ] [];
+  wrong "SELECT JSON_CONTAINS(@json, @search :: Int, @path) as result";
+  
+  tt "SELECT JSON_CONTAINS(data, JSON_OBJECT('key', 'value'), '$.objects') as found FROM test46" 
+    [ attr' ~nullability:Nullable "found" Bool ] [];
+  wrong "SELECT JSON_CONTAINS('INVALID_JSON', 'search') as result";
+  wrong "SELECT JSON_CONTAINS('{\"a\": 2}', 'INVALID') as result";
+  (* tt "SELECT JSON_CONTAINS('{\"a\": 2}', NULL) as result" [][]; *)
+  tt "SELECT JSON_UNQUOTE(@json_val) as result" 
+    [ attr' "result" Text ] [ named "json_val" Json ];
+  tt "SELECT JSON_UNQUOTE(JSON_EXTRACT(data, '$.name')) as name FROM test46" 
+    [ attr' ~nullability:Nullable "name" Text ] [];
+  wrong "SELECT JSON_UNQUOTE('not a json value') as result";
+  tt "SELECT JSON_SEARCH(@json, 'one', @pattern) as result" 
+    [ attr' ~nullability:Nullable "result" Json ] [ 
+      named "json" Json; 
+      named "pattern" Text 
+    ];
+  tt "SELECT JSON_SEARCH(data, 'all', 'search%', '\\\\', '$.users') as paths FROM test46" 
+    [ attr' ~nullability:Nullable "paths" Json ] [];
+  tt "SELECT JSON_SEARCH(@json, 'one', @pattern, @escape, @path1, @path2) as result" 
+    [ attr' ~nullability:Nullable "result" Json ] [ 
+      named "json" Json; 
+      named "pattern" Text;
+      named "escape" Text;
+      named "path1" Json_path;
+      named "path2" Json_path;
+    ];
+  tt {| UPDATE test46 SET data = JSON_SET(
+        data,
+        '$.processed', JSON_ARRAY(
+          JSON_OBJECT('id', 1, 'status', 'active'),
+          JSON_OBJECT('id', 2, 'status', 'inactive')
+        ),
+        '$.meta', JSON_OBJECT('version', 2, 'updated', true)
+      ) WHERE id = 1 |} [] [];
+  tt {| SELECT 
+        JSON_UNQUOTE(JSON_EXTRACT(data, '$.name')) as name,
+        JSON_CONTAINS(data, '"admin"', '$.roles') as is_admin,
+        JSON_SEARCH(data, 'one', 'test%') as test_path
+      FROM test46 WHERE id = 1 |} [
+        attr' ~nullability:Nullable "name" Text;
+        attr' ~nullability:Nullable "is_admin" Bool; 
+        attr' ~nullability:Nullable "test_path" Json;
+      ] [];
+]
+
 
 let run () =
   Gen.params_mode := Some Named;
@@ -1629,6 +1745,7 @@ let run () =
     "test_type_mapping_params" >:: test_type_mapping_params;
     "test_meta_insert_update" >:: test_meta_insert_update;
     "test_multi_functions" >::: test_multi_functions;
+    "test_json_and_fixed_then_pairs_fn_kind" >::: test_json_and_fixed_then_pairs_fn_kind;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -3,4 +3,6 @@
   %{bin:sqlgg}
   (glob_files *.sql)
   (glob_files *.compare.ml)
+  (source_tree test_build_json_functions)
+  (glob_files print_ocaml_impl.ml)
   sqlgg_test.sh))

--- a/test/cram/json_functions.compare.ml
+++ b/test/cram/json_functions.compare.ml
@@ -1,0 +1,198 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_people db  =
+    T.execute db ("CREATE TABLE people (\n\
+  id INT AUTO_INCREMENT PRIMARY KEY,\n\
+  data JSON\n\
+)") T.no_params
+
+  let create_people_data_json_kind_never_null_but_col_nullable db  =
+    T.execute db ("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
+  id INT AUTO_INCREMENT PRIMARY KEY,\n\
+  data JSON\n\
+)") T.no_params
+
+  let create_people_data_json_kind_never_null_and_col_strict db  =
+    T.execute db ("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
+  id INT AUTO_INCREMENT PRIMARY KEY,\n\
+  data JSON NOT NULL\n\
+)") T.no_params
+
+  let one db  =
+    T.execute db ("INSERT INTO people (data) VALUES\n\
+  (JSON_OBJECT(\n\
+    'name', 'Alice',\n\
+    'age', 30,\n\
+    'skills', JSON_ARRAY('SQL', 'Python'),\n\
+    'address', JSON_OBJECT('city', 'Paris', 'zip', '75000')\n\
+  )),\n\
+  (JSON_OBJECT(\n\
+    'name', 'Bob',\n\
+    'age', 25,\n\
+    'skills', JSON_ARRAY('JavaScript'),\n\
+    'address', JSON_OBJECT('city', 'Berlin', 'zip', '10115')\n\
+  )),\n\
+  (JSON_OBJECT(\n\
+    'name', 'Charlie',\n\
+    'age', 35,\n\
+    'skills', JSON_ARRAY(),\n\
+    'address', JSON_OBJECT('city', 'New York', 'zip', '10001')\n\
+  )),\n\
+  (JSON_OBJECT(\n\
+    'name', NULL,\n\
+    'age', NULL\n\
+  ))") T.no_params
+
+  let two db  callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~name:(T.get_column_Json_nullable stmt 1)
+    in
+    T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+FROM people\n\
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params invoke_callback
+
+  let three db  callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~data_with_active:(T.get_column_Json_nullable stmt 1)
+    in
+    T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people") T.no_params invoke_callback
+
+  let four db  callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~data_with_active:(T.get_column_Json_nullable stmt 1)
+    in
+    T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_but_col_nullable") T.no_params invoke_callback
+
+  let five db  callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~data_with_active:(T.get_column_Json stmt 1)
+    in
+    T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_and_col_strict") T.no_params invoke_callback
+
+  module Fold = struct
+    let two db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+FROM people\n\
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let three db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let four db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let five db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json stmt 1)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_and_col_strict") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let two db  callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+FROM people\n\
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let three db  callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let four db  callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json_nullable stmt 1)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let five db  callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~data_with_active:(T.get_column_Json stmt 1)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT\n\
+  id,\n\
+  JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
+FROM people_data_json_kind_never_null_and_col_strict") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/json_functions.sql
+++ b/test/cram/json_functions.sql
@@ -1,0 +1,64 @@
+CREATE TABLE people (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  data JSON
+);
+
+CREATE TABLE people_data_json_kind_never_null_but_col_nullable (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+-- [sqlgg] json_null_kind=false
+  data JSON
+);
+
+CREATE TABLE people_data_json_kind_never_null_and_col_strict (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+-- [sqlgg] json_null_kind=false
+  data JSON NOT NULL
+);
+
+-- @one
+INSERT INTO people (data) VALUES
+  (JSON_OBJECT(
+    'name', 'Alice',
+    'age', 30,
+    'skills', JSON_ARRAY('SQL', 'Python'),
+    'address', JSON_OBJECT('city', 'Paris', 'zip', '75000')
+  )),
+  (JSON_OBJECT(
+    'name', 'Bob',
+    'age', 25,
+    'skills', JSON_ARRAY('JavaScript'),
+    'address', JSON_OBJECT('city', 'Berlin', 'zip', '10115')
+  )),
+  (JSON_OBJECT(
+    'name', 'Charlie',
+    'age', 35,
+    'skills', JSON_ARRAY(),
+    'address', JSON_OBJECT('city', 'New York', 'zip', '10001')
+  )),
+  (JSON_OBJECT(
+    'name', NULL,
+    'age', NULL
+  ));
+
+-- @two
+SELECT id, JSON_EXTRACT(data, '$.name') AS name
+FROM people
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris';
+
+-- @three
+SELECT
+  id,
+  JSON_SET(data, '$.active', TRUE) AS data_with_active
+FROM people;
+
+-- @four
+SELECT
+  id,
+  JSON_SET(data, '$.active', TRUE) AS data_with_active
+FROM people_data_json_kind_never_null_but_col_nullable;
+
+-- @five
+SELECT
+  id,
+  JSON_SET(data, '$.active', TRUE) AS data_with_active
+FROM people_data_json_kind_never_null_and_col_strict;

--- a/test/cram/print_ocaml_impl.ml
+++ b/test/cram/print_ocaml_impl.ml
@@ -1,0 +1,391 @@
+open Printf
+
+module M = struct
+
+type json = [ `Null
+  | `String of string
+  | `Float of float
+  | `Int of int
+  | `Bool of bool
+  | `List of json list
+  | `Assoc of (string * json) list 
+]
+
+type json_path = Sqlgg_json_path.Ast.t
+type one_or_all = [ `One | `All ]
+
+type mock_value = [ `Bool of bool | `Int of int64 | `Text of string | `Float of float | `Json of json | `Null ]
+
+type mock_row_data = {
+  values: (int * mock_value) array;
+}
+
+type mock_response = 
+  | MockSelect of mock_row_data list
+  | MockSelectOne of mock_row_data option
+  | MockExecute of { affected_rows: int64; insert_id: int64 option }
+
+let response_queue : mock_response list ref = ref []
+let current_row : mock_row_data option ref = ref None
+
+let setup_select_response (rows : mock_row_data list) : unit =
+  response_queue := MockSelect rows :: !response_queue
+
+let setup_select_one_response (row_opt : mock_row_data option) : unit =
+  response_queue := MockSelectOne row_opt :: !response_queue
+
+let setup_execute_response ~(affected_rows : int64) ?(insert_id : int64 option = None) () : unit =
+  response_queue := MockExecute { affected_rows; insert_id } :: !response_queue
+
+let clear_mock_responses () : unit =
+  response_queue := [];
+  current_row := None
+
+let get_next_response () : mock_response =
+  match !response_queue with
+  | [] -> failwith "No more mock responses available"
+  | response :: rest ->
+    response_queue := rest;
+    response
+
+let make_mock_row (values : mock_value list) : mock_row_data =
+  { values = Array.of_list (List.mapi (fun i v -> (i, v)) values) }
+
+let mock_bool (v : bool) : mock_value = `Bool v
+let mock_int (v : int64) : mock_value = `Int v  
+let mock_text (v : string) : mock_value = `Text v
+let mock_float (v : float) : mock_value = `Float v
+let mock_json (v : json) : mock_value = `Json v
+let mock_null : mock_value = `Null
+
+module Types = struct
+  module Bool = struct 
+    type t = bool 
+    let to_literal = string_of_bool
+    let bool_to_literal = to_literal
+  end
+  module Int = struct 
+    include Int64 
+    let to_literal = to_string
+    let int64_to_literal = to_literal
+  end
+  module Text = struct
+    type t = string
+    let to_literal s = sprintf "'%s'" (String.escaped s)
+    let string_to_literal = to_literal
+  end
+  module Blob = struct
+    type t = string
+    let to_literal s = 
+      let hex = String.to_seq s 
+               |> Seq.map (fun c -> sprintf "%02X" (Char.code c))
+               |> List.of_seq 
+               |> String.concat "" in
+      sprintf "X'%s'" hex
+  end
+  module Float = struct 
+    type t = float 
+    let to_literal = string_of_float
+    let float_to_literal = to_literal
+  end
+  module Decimal = Float
+  module Datetime = struct
+    type t = float
+    let to_literal t = sprintf "'%s'" (string_of_float t)
+    let float_to_literal = to_literal
+  end
+  
+  module Json = struct
+    type t = Yojson.Basic.t
+    let to_literal j = Text.to_literal (Yojson.Basic.to_string j)
+    let json_to_literal = to_literal
+  end
+
+  module Json_path = struct
+    open Sqlgg_json_path
+    type t = json_path
+    let to_literal j = Text.to_literal (Json_path.string_of_json_path j)
+    let json_path_to_literal = to_literal
+  end
+
+  module One_or_all = struct
+    type t = one_or_all
+    let to_literal = function
+      | `One -> "one"
+      | `All -> "all"
+    let one_or_all_to_literal = to_literal
+  end
+
+  module Any = Text
+end
+
+module type Enum = sig 
+  type t
+  val inj: string -> t
+  val proj: t -> string
+end
+
+type statement = string * int
+type 'a connection = string
+type params = string * string list ref * int ref * int
+type row = mock_row_data
+type result = unit
+type execute_response = { affected_rows: int64; insert_id: int64 option }
+
+type num = int64
+type text = string
+type any = string
+type datetime = float
+
+exception Oops of string
+
+let get_mock_value (row : mock_row_data) (index : int) : mock_value =
+  if index < Array.length row.values then
+    let (_, value) = row.values.(index) in
+    value
+  else
+    `Null
+
+let get_column_Bool (row : mock_row_data) (index : int) : bool = 
+  match get_mock_value row index with
+  | `Bool v -> printf "[MOCK] get_column_Bool[%d] = %b\n" index v; v
+  | _ -> printf "[MOCK] get_column_Bool[%d] = false (default)\n" index; false
+
+let get_column_Int (row : mock_row_data) (index : int) : int64 = 
+  match get_mock_value row index with
+  | `Int v -> printf "[MOCK] get_column_Int[%d] = %Ld\n" index v; v
+  | _ -> printf "[MOCK] get_column_Int[%d] = 0L (default)\n" index; 0L
+
+let get_column_Text (row : mock_row_data) (index : int) : string = 
+  match get_mock_value row index with
+  | `Text v -> printf "[MOCK] get_column_Text[%d] = \"%s\"\n" index v; v
+  | _ -> printf "[MOCK] get_column_Text[%d] = \"mock_text\" (default)\n" index; "mock_text"
+
+let get_column_Float (row : mock_row_data) (index : int) : float = 
+  match get_mock_value row index with
+  | `Float v -> printf "[MOCK] get_column_Float[%d] = %f\n" index v; v
+  | _ -> printf "[MOCK] get_column_Float[%d] = 0.0 (default)\n" index; 0.0
+
+let get_column_Json (row : mock_row_data) (index : int) : json = 
+  match get_mock_value row index with
+  | `Json v -> printf "[MOCK] get_column_Json[%d] = %s\n" index (Yojson.Basic.to_string v); v
+  | _ -> printf "[MOCK] get_column_Json[%d] = null (default)\n" index; `Null
+
+let get_column_Any = get_column_Text
+let get_column_Decimal = get_column_Float
+let get_column_Datetime = get_column_Float
+
+let mock_json_path = 
+  try 
+    Sqlgg_json_path.Json_path.parse_json_path "$.mock"
+  with 
+  | _ -> Sqlgg_json_path.Json_path.parse_json_path "$"
+
+let get_column_Json_path (row : mock_row_data) (index : int) : json_path = 
+  printf "[MOCK] get_column_Json_path[%d] = $.mock\n" index;
+  mock_json_path
+
+let get_column_One_or_all (row : mock_row_data) (index : int) : one_or_all = 
+  printf "[MOCK] get_column_One_or_all[%d] = `One\n" index;
+  `One
+
+let get_column_Bool_nullable (row : mock_row_data) (index : int) : bool option = 
+  match get_mock_value row index with
+  | `Bool v -> printf "[MOCK] get_column_Bool_nullable[%d] = Some %b\n" index v; Some v
+  | `Null -> printf "[MOCK] get_column_Bool_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_Bool_nullable[%d] = Some false (default)\n" index; Some false
+
+let get_column_Int_nullable (row : mock_row_data) (index : int) : int64 option = 
+  match get_mock_value row index with
+  | `Int v -> printf "[MOCK] get_column_Int_nullable[%d] = Some %Ld\n" index v; Some v
+  | `Null -> printf "[MOCK] get_column_Int_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_Int_nullable[%d] = Some 0L (default)\n" index; Some 0L
+
+let get_column_Text_nullable (row : mock_row_data) (index : int) : string option = 
+  match get_mock_value row index with
+  | `Text v -> printf "[MOCK] get_column_Text_nullable[%d] = Some \"%s\"\n" index v; Some v
+  | `Null -> printf "[MOCK] get_column_Text_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_Text_nullable[%d] = Some \"mock_text\" (default)\n" index; Some "mock_text"
+
+let get_column_Float_nullable (row : mock_row_data) (index : int) : float option = 
+  match get_mock_value row index with
+  | `Float v -> printf "[MOCK] get_column_Float_nullable[%d] = Some %f\n" index v; Some v
+  | `Null -> printf "[MOCK] get_column_Float_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_Float_nullable[%d] = Some 0.0 (default)\n" index; Some 0.0
+
+let get_column_Json_nullable (row : mock_row_data) (index : int) : json option = 
+  match get_mock_value row index with
+  | `Json v -> printf "[MOCK] get_column_Json_nullable[%d] = Some %s\n" index (Yojson.Basic.to_string v); Some v
+  | `Null -> printf "[MOCK] get_column_Json_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_Json_nullable[%d] = Some null (default)\n" index; Some `Null
+
+let get_column_Any_nullable = get_column_Text_nullable
+let get_column_Decimal_nullable = get_column_Float_nullable
+let get_column_Datetime_nullable = get_column_Float_nullable
+
+let get_column_Json_path_nullable (row : mock_row_data) (index : int) : json_path option = 
+  printf "[MOCK] get_column_Json_path_nullable[%d] = Some $.mock\n" index;
+  Some mock_json_path
+
+let get_column_One_or_all_nullable (row : mock_row_data) (index : int) : one_or_all option = 
+  printf "[MOCK] get_column_One_or_all_nullable[%d] = Some `One\n" index;
+  Some `One
+
+let get_column_bool = get_column_Bool
+let get_column_bool_nullable = get_column_Bool_nullable
+let get_column_int64 = get_column_Int
+let get_column_int64_nullable = get_column_Int_nullable
+let get_column_float = get_column_Float
+let get_column_float_nullable = get_column_Float_nullable
+let get_column_decimal = get_column_Decimal
+let get_column_decimal_nullable = get_column_Decimal_nullable
+let get_column_string = get_column_Text
+let get_column_string_nullable = get_column_Text_nullable
+let get_column_datetime (row : mock_row_data) (index : int) : string = 
+  string_of_float (get_column_Float row index)
+let get_column_datetime_nullable (row : mock_row_data) (index : int) : string option = 
+  match get_column_Float_nullable row index with
+  | Some f -> Some (string_of_float f)
+  | None -> None
+let get_column_json = get_column_Json
+let get_column_json_nullable = get_column_Json_nullable
+let get_column_json_path = get_column_Json_path
+let get_column_json_path_nullable = get_column_Json_path_nullable
+let get_column_one_or_all = get_column_One_or_all
+let get_column_one_or_all_nullable = get_column_One_or_all_nullable
+
+let substitute_params sql params =
+  let param_array = Array.of_list params in
+  let param_index = ref 0 in
+  String.to_seq sql
+  |> Seq.map (function
+    | '?' when !param_index < Array.length param_array ->
+        let param = param_array.(!param_index) in
+        incr param_index;
+        param
+    | c -> String.make 1 c)
+  |> Seq.fold_left (^) ""
+
+let bind_param value_str (sql, params, index, total) =
+  params := value_str :: !params;
+  incr index
+
+let start_params (sql, param_count) n = 
+  (sql, ref [], ref 0, n)
+
+let finish_params (sql, params, index, total) = 
+  let final_sql = substitute_params sql (List.rev !params) in
+  printf "[SQL] %s\n" final_sql;
+  flush stdout;
+  ()
+
+let set_param_null params = bind_param "NULL" params
+let set_param_Text params v = bind_param (sprintf "'%s'" (String.escaped v)) params
+let set_param_Any = set_param_Text
+let set_param_Bool params v = bind_param (if v then "TRUE" else "FALSE") params
+let set_param_Int params v = bind_param (Int64.to_string v) params
+let set_param_Float params v = bind_param (Float.to_string v) params
+let set_param_Decimal = set_param_Float
+let set_param_Datetime = set_param_Float
+let set_param_Json params v = bind_param (sprintf "'%s'" (String.escaped (Yojson.Basic.to_string v))) params
+let set_param_Json_path params v = bind_param (sprintf "'%s'" (String.escaped (Sqlgg_json_path.Json_path.string_of_json_path v))) params
+let set_param_One_or_all params v = bind_param (match v with `One -> "'one'" | `All -> "'all'") params
+
+let set_param_bool = set_param_Bool
+let set_param_int64 = set_param_Int
+let set_param_float = set_param_Float
+let set_param_decimal = set_param_Float
+let set_param_string = set_param_Text
+let set_param_datetime = set_param_Float
+let set_param_json = set_param_Json
+let set_param_json_path = set_param_Json_path
+let set_param_one_or_all = set_param_One_or_all
+
+let no_params (sql, _) = 
+  printf "[SQL] %s\n" sql;
+  flush stdout;
+  ()
+
+module Make_enum (E: Enum) = struct 
+  include E
+
+  let get_column (row : mock_row_data) (index : int) : E.t = E.inj "mock_enum"
+  let get_column_nullable (row : mock_row_data) (index : int) : E.t option = None
+  let set_param params v = bind_param (sprintf "'%s'" (E.proj v)) params
+  let to_literal = E.proj
+end
+
+let select (db : string) (sql : string) (set_params : statement -> unit) (callback : mock_row_data -> unit) : unit =
+  printf "[MOCK SELECT] Connection: %s\n" db;
+  let stmt = (sql, 0) in
+  set_params stmt;
+  match get_next_response () with
+  | MockSelect rows ->
+    printf "[MOCK] Returning %d rows\n" (List.length rows);
+    List.iteri (fun i row ->
+      printf "  Row %d: " i;
+      Array.iteri (fun j (_, value) ->
+        let val_str = match value with
+          | `Bool b -> string_of_bool b
+          | `Int i -> Int64.to_string i
+          | `Text s -> s
+          | `Float f -> string_of_float f
+          | `Json j -> Yojson.Basic.to_string j
+          | `Null -> "NULL"
+        in
+        printf "col%d=%s " j val_str
+      ) row.values;
+      printf "\n";
+      callback row
+    ) rows;
+    flush stdout
+  | _ -> failwith "Expected MockSelect response"
+
+let execute (db : string) (sql : string) (set_params : statement -> unit) : execute_response =
+  printf "[MOCK EXECUTE] Connection: %s\n" db;
+  let stmt = (sql, 0) in
+  set_params stmt;
+  match get_next_response () with
+  | MockExecute { affected_rows; insert_id } ->
+    printf "[MOCK] Execute result: affected_rows=%Ld, insert_id=%s\n" 
+      affected_rows
+      (match insert_id with Some id -> Int64.to_string id | None -> "None");
+    flush stdout;
+    { affected_rows; insert_id }
+  | _ -> failwith "Expected MockExecute response"
+
+let select_one_maybe (db : string) (sql : string) (set_params : statement -> unit) (convert : mock_row_data -> 'a) : 'a option =
+  printf "[MOCK SELECT_ONE_MAYBE] Connection: %s\n" db;
+  let stmt = (sql, 0) in
+  set_params stmt;
+  match get_next_response () with
+  | MockSelectOne (Some row) ->
+    printf "[MOCK] Returning one row\n";
+    flush stdout;
+    Some (convert row)
+  | MockSelectOne None ->
+    printf "[MOCK] Returning no rows\n";
+    flush stdout;
+    None
+  | _ -> failwith "Expected MockSelectOne response"
+
+let select_one (db : string) (sql : string) (set_params : statement -> unit) (convert : mock_row_data -> 'a) : 'a =
+  printf "[MOCK SELECT_ONE] Connection: %s\n" db;
+  let stmt = (sql, 0) in
+  set_params stmt;
+  match get_next_response () with
+  | MockSelectOne (Some row) ->
+    printf "[MOCK] Returning one row\n";
+    flush stdout;
+    convert row
+  | MockSelectOne None ->
+    failwith "Expected one row but got none"
+  | _ -> failwith "Expected MockSelectOne response"
+
+end
+
+let () =
+  let module Test = (M : Sqlgg_traits.M) in 
+  ignore (Test.Oops "Testing implementation ready")
+
+include M

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -263,3 +263,131 @@ Test TiDB dialect with CREATE TABLE AS SELECT (should fail):
   Feature CreateTableAsSelect is not supported for dialect TiDB (supported by: MySQL, PostgreSQL, SQLite) at CREATE TABLE summary AS SELECT id, name FROM users
   Errors encountered, no code generated
   [1]
+
+
+Test Json functions:
+  $ /bin/sh ./sqlgg_test.sh json_functions.sql json_functions.compare.ml  
+  $ echo $?
+  0
+
+Test Json functions and ocaml compiles:
+  $ cd test_build_json_functions
+  $ cat "json_functions.sql" | sqlgg -no-header -gen caml_io -params unnamed -gen caml - > output.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -c output.ml
+  $ cp ../print_ocaml_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_ocaml_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c test_run.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -linkpkg -o test_run.exe output.ml print_ocaml_impl.ml test_run.ml
+  $ ./test_run.exe
+  Starting JSON Path Tests with Inline Mock Implementation
+  ============================================================
+  === Starting JSON Path Tests with Inline Mocking ===
+  
+  Running all tests...
+  
+  [TEST 1] Testing JSON parameter with nested structure
+  [MOCK SELECT_ONE] Connection: test_connection
+  [SQL] SELECT JSON_SEARCH('{\"users\":[{\"id\":1,\"settings\":{\"themes\":[\"dark\"]}}]}', 'one', 'dark')
+  [MOCK] Returning one row
+  [MOCK] get_column_Json_nullable[0] = Some "$.users[0].settings.themes[0]"
+  [TEST 1] Result: completed
+  
+  [TEST 2] Testing JSON path parameter with combinators
+  [MOCK SELECT_ONE] Connection: test_connection
+  [SQL] SELECT JSON_ARRAY_APPEND('["a", ["b", "c"], "d"]', '$.data[*].users[last].settings', 1)
+  [MOCK] Returning one row
+  [MOCK] get_column_Json[0] = {"theme":"dark","language":"en"}
+  [TEST 2] Result: completed
+  
+  [TEST 3] Testing SELECT with JSON path extraction
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT JSON_EXTRACT(col1, '$.name') FROM table1 WHERE id = 1
+  [MOCK] Returning 2 rows
+    Row 0: col0=1 col1=Alice col2=Alice Johnson 
+  [MOCK] get_column_Json_nullable[0] = Some null (default)
+    -> Callback executed for test3 with result
+    Row 1: col0=2 col1=Bob col2=Bob Smith 
+  [MOCK] get_column_Json_nullable[0] = Some null (default)
+    -> Callback executed for test3 with result
+  [TEST 3] Result: completed
+  
+  [TEST 4] Testing SELECT with nested JSON path
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT JSON_UNQUOTE(JSON_EXTRACT(col1, '$.user.email')) FROM table1 WHERE id = 2
+  [MOCK] Returning 1 rows
+    Row 0: col0=2 col1=user@example.com 
+  [MOCK] get_column_Text_nullable[0] = Some "mock_text" (default)
+    -> Callback executed for test4 with result
+  [TEST 4] Result: completed
+  
+  [TEST 5] Testing SELECT ONE with JSON path
+  [MOCK EXECUTE] Connection: test_connection
+  [SQL] UPDATE table1 SET col1 = JSON_SET(col1, '$.last_login', NOW()) WHERE id = 3
+  [MOCK] Execute result: affected_rows=1, insert_id=5
+  [TEST 5] Result: completed
+  
+  [TEST 6] Testing simple SELECT with callback
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT JSON_CONTAINS(col1, '"value"') FROM table1 WHERE id = 4
+  [MOCK] Returning 1 rows
+    Row 0: col0=4 col1=active 
+  [MOCK] get_column_Bool_nullable[0] = Some false (default)
+    -> Callback executed for test6 with result
+  [TEST 6] Result: completed
+  
+  [TEST 7] Testing SELECT with JSON path filter
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT id, name FROM table2 WHERE JSON_EXTRACT(col1, '$.metadata.category') = '\"electronics\"'
+  [MOCK] Returning 2 rows
+    Row 0: col0=101 col1=Laptop 
+  [MOCK] get_column_Text_nullable[1] = Some "Laptop"
+  [MOCK] get_column_Int[0] = 101
+    -> Callback executed for test7 with id and name
+    Row 1: col0=102 col1=Phone 
+  [MOCK] get_column_Text_nullable[1] = Some "Phone"
+  [MOCK] get_column_Int[0] = 102
+    -> Callback executed for test7 with id and name
+  [TEST 7] Result: completed
+  
+  [TEST 8] Testing complex SELECT with multiple JSON paths
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT 
+  id,
+  JSON_EXTRACT(col1, '$.profile.name') as user_name,
+  JSON_EXTRACT(col2, '$.settings.theme') as theme
+  FROM table1 
+  WHERE JSON_EXTRACT(col1, '$.profile.active') = 'true'
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=John Doe col2=dark 
+  [MOCK] get_column_Json_nullable[2] = Some null (default)
+  [MOCK] get_column_Json_nullable[1] = Some null (default)
+  [MOCK] get_column_Int[0] = 1
+    -> Callback executed for test8 with id, user_name, theme
+  [TEST 8] Result: completed
+  
+  [TEST 9] Testing UPDATE with JSON path conditions
+  [MOCK EXECUTE] Connection: test_connection
+  [SQL] UPDATE table2 
+  SET col2 = JSON_SET(col2, '$.timestamps.last_update', NOW())
+  WHERE JSON_EXTRACT(col1, '$.user.role') = '\"admin\"'
+  [MOCK] Execute result: affected_rows=3, insert_id=42
+  [TEST 9] Result: affected_rows=3, insert_id=42
+  
+  [TEST 10] Testing search with text parameter
+  [MOCK SELECT] Connection: test_connection
+  [SQL] SELECT JSON_SEARCH(col1, 'one', 'admin') FROM table1 WHERE id = 5
+  [MOCK] Returning 1 rows
+    Row 0: col0="$.test[0]" 
+  [MOCK] get_column_Json_nullable[0] = Some "$.test[0]"
+    -> Callback executed for test10 with result
+  [TEST 10] Result: completed
+  
+  === All JSON Path Tests Completed Successfully ===
+  Summary:
+  - Tests 1-8, 10: completed with inline mocked data
+  - Test 9: returned execute_response with affected_rows=3
+  - All SQL queries were logged
+  - Each test setup its own mock data
+  
+  ============================================================
+  All tests executed successfully!

--- a/test/cram/test_build_json_functions/json_functions.sql
+++ b/test/cram/test_build_json_functions/json_functions.sql
@@ -1,0 +1,50 @@
+CREATE TABLE table1 (
+    id INT PRIMARY KEY,
+    col1 JSON,
+    col2 JSON,
+    col3 JSON
+);
+
+CREATE TABLE table2 (
+    id INT PRIMARY KEY,
+    name VARCHAR(255),
+    col1 JSON,
+    col2 JSON
+);
+
+-- @test1
+SELECT JSON_SEARCH(@json, @one, 'dark');
+
+-- @test2
+SELECT JSON_ARRAY_APPEND('["a", ["b", "c"], "d"]', @path, 1);
+
+-- @test3
+SELECT JSON_EXTRACT(col1, @name_path) FROM table1 WHERE id = @id;
+
+-- @test4
+SELECT JSON_UNQUOTE(JSON_EXTRACT(col1, @email_path)) FROM table1 WHERE id = @id;
+
+-- @test5
+UPDATE table1 SET col1 = JSON_SET(col1, @login_path, NOW()) WHERE id = @id;
+
+-- @test6
+SELECT JSON_CONTAINS(col1, '"value"') FROM table1 WHERE id = @id;
+
+-- @test7
+SELECT id, name FROM table2 WHERE JSON_EXTRACT(col1, @category_path) = @category;
+
+-- @test8
+SELECT 
+    id,
+    JSON_EXTRACT(col1, @name_path) as user_name,
+    JSON_EXTRACT(col2, @theme_path) as theme
+FROM table1 
+WHERE JSON_EXTRACT(col1, @active_path) = 'true';
+
+-- @test9
+UPDATE table2 
+SET col2 = JSON_SET(col2, @update_path, NOW())
+WHERE JSON_EXTRACT(col1, @role_path) = @role;
+
+-- @test10
+SELECT JSON_SEARCH(col1, 'one', @search_value) FROM table1 WHERE id = @id;

--- a/test/cram/test_build_json_functions/test_run.ml
+++ b/test/cram/test_build_json_functions/test_run.ml
@@ -1,0 +1,223 @@
+(* test_run.ml - Inline mocking version *)
+
+open Printf
+
+module M (T: Sqlgg_traits.M with type Types.Json.t = Yojson.Basic.t and
+  type Types.Json_path.t = Sqlgg_json_path.Ast.t and
+  type Types.Int.t = int64 and
+  type Types.Text.t = string and
+  type Types.One_or_all.t = [`One | `All]) = struct
+
+  module Sql = Output.Sqlgg(T)
+
+  let test_call connection = 
+    printf "[TEST 1] Testing JSON parameter with nested structure\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_one_response (Some (
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_json (`String "$.users[0].settings.themes[0]")]
+    ));
+    
+    let result = Sql.test1 ~json:
+      (`Assoc
+         [ "users",
+           `List
+             [ `Assoc
+                 [ "id", `Int 1;
+                   "settings",
+                   `Assoc [ "themes", `List [ `String "dark" ] ]
+                 ]
+             ]
+         ])
+    ~one:`One connection in
+    printf "[TEST 1] Result: completed\n\n";
+    result
+
+  let test_call2 connection =
+    printf "[TEST 2] Testing JSON path parameter with combinators\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_one_response (Some (
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_json (`Assoc [("theme", `String "dark"); ("language", `String "en")])]
+    ));
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let from_combinator = root / ~."data" / any / ~."users" / last / ~."settings" in
+    let result = Sql.test2 ~path:from_combinator connection in
+    printf "[TEST 2] Result: completed\n\n";
+    result
+
+  let test_call3 connection =
+    printf "[TEST 3] Testing SELECT with JSON path extraction\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 1L; Print_ocaml_impl.mock_text "Alice"; Print_ocaml_impl.mock_text "Alice Johnson"];
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 2L; Print_ocaml_impl.mock_text "Bob"; Print_ocaml_impl.mock_text "Bob Smith"];
+    ];
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let name_path = root / ~."name" in
+    let result = Sql.test3 ~id:1L ~name_path connection (fun ~r -> 
+      printf "  -> Callback executed for test3 with result\n"
+    ) in
+    printf "[TEST 3] Result: completed\n\n";
+    result
+
+  let test_call4 connection =
+    printf "[TEST 4] Testing SELECT with nested JSON path\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 2L; Print_ocaml_impl.mock_text "user@example.com"];
+    ];
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in  
+    let email_path = root / ~."user" / ~."email" in
+    let result = Sql.test4 ~id:2L ~email_path connection (fun ~r -> 
+      printf "  -> Callback executed for test4 with result\n"
+    ) in
+    printf "[TEST 4] Result: completed\n\n";
+    result
+
+  let test_call5 connection =
+    printf "[TEST 5] Testing SELECT ONE with JSON path\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_execute_response ~affected_rows:1L ~insert_id:(Some 5L) ();
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let login_path = root / ~."last_login" in
+    let result = Sql.test5 ~id:3L ~login_path connection in
+    printf "[TEST 5] Result: completed\n\n";
+    result
+
+  let test_call6 connection =
+    printf "[TEST 6] Testing simple SELECT with callback\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 4L; Print_ocaml_impl.mock_text "active"];
+    ];
+    
+    let result = Sql.test6 ~id:4L connection (fun ~r -> 
+      printf "  -> Callback executed for test6 with result\n"
+    ) in
+    printf "[TEST 6] Result: completed\n\n";
+    result
+
+  let test_call7 connection =
+    printf "[TEST 7] Testing SELECT with JSON path filter\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 101L; Print_ocaml_impl.mock_text "Laptop"];
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 102L; Print_ocaml_impl.mock_text "Phone"];
+    ];
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let category_path = root / ~."metadata" / ~."category" in
+    let result = Sql.test7 ~category_path ~category:(`String "electronics") connection (fun ~id ~name -> 
+      printf "  -> Callback executed for test7 with id and name\n"
+    ) in
+    printf "[TEST 7] Result: completed\n\n";
+    result
+
+  let test_call8 connection =
+    printf "[TEST 8] Testing complex SELECT with multiple JSON paths\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_int 1L; Print_ocaml_impl.mock_text "John Doe"; Print_ocaml_impl.mock_text "dark"];
+    ];
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let name_path = root / ~."profile" / ~."name" in
+    let theme_path = root / ~."settings" / ~."theme" in
+    let active_path = root / ~."profile" / ~."active" in
+    let result = Sql.test8 ~name_path ~theme_path ~active_path connection (fun ~id ~user_name ~theme -> 
+      printf "  -> Callback executed for test8 with id, user_name, theme\n"
+    ) in
+    printf "[TEST 8] Result: completed\n\n";
+    result
+
+  let test_call9 connection =
+    printf "[TEST 9] Testing UPDATE with JSON path conditions\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_execute_response ~affected_rows:3L ~insert_id:(Some 42L) ();
+    
+    let open Sqlgg_json_path in
+    let open Ast.Syntax in
+    let update_path = root / ~."timestamps" / ~."last_update" in
+    let role_path = root / ~."user" / ~."role" in
+    let result = Sql.test9 ~update_path ~role_path ~role:(`String "admin") connection in
+    printf "[TEST 9] Result: affected_rows=%Ld, insert_id=%s\n\n" 
+      result.affected_rows 
+      (match result.insert_id with Some id -> Int64.to_string id | None -> "None");
+    result
+
+  let test_call10 connection =
+    printf "[TEST 10] Testing search with text parameter\n";
+    
+    Print_ocaml_impl.clear_mock_responses ();
+    Print_ocaml_impl.setup_select_response [
+      Print_ocaml_impl.make_mock_row [Print_ocaml_impl.mock_json (`String "$.test[0]")];
+    ];
+    
+    let result = Sql.test10 ~search_value:"admin" ~id:5L connection (fun ~r -> 
+      printf "  -> Callback executed for test10 with result\n"
+    ) in
+    printf "[TEST 10] Result: completed\n\n";
+    result
+
+  let run_all_tests connection =
+    printf "=== Starting JSON Path Tests with Inline Mocking ===\n\n";
+    
+    try
+      printf "Running all tests...\n\n";
+      
+      let _ = test_call connection in
+      let _ = test_call2 connection in
+      let _ = test_call3 connection in
+      let _ = test_call4 connection in
+      let _ = test_call5 connection in
+      let _ = test_call6 connection in
+      let _ = test_call7 connection in
+      let _ = test_call8 connection in
+      let result9 = test_call9 connection in
+      let _ = test_call10 connection in
+      
+      printf "=== All JSON Path Tests Completed Successfully ===\n";
+      printf "Summary:\n";
+      printf "- Tests 1-8, 10: completed with inline mocked data\n";
+      printf "- Test 9: returned execute_response with affected_rows=%Ld\n" result9.affected_rows;
+      printf "- All SQL queries were logged\n";
+      printf "- Each test setup its own mock data\n";
+      
+      ()
+      
+    with
+    | exn -> 
+      printf "\n=== Test Failed with Exception: %s ===\n" (Printexc.to_string exn);
+      raise exn
+end
+
+module Test = M(Print_ocaml_impl)
+
+let () = 
+  let con = "test_connection" in
+  
+  printf "Starting JSON Path Tests with Inline Mock Implementation\n";
+  printf "%s\n" (String.make 60 '=');
+  
+  Test.run_all_tests con;
+  
+  printf "\n%s\n" (String.make 60 '=');
+  printf "All tests executed successfully!\n"

--- a/test/out/json.xml
+++ b/test/out/json.xml
@@ -8,42 +8,42 @@
  <stmt name="select_1" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <stmt name="select_2" sql="SELECT JSON_REMOVE('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','$.c')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT JSON_ARRAY('a','b','c')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <stmt name="select_4" sql="SELECT JSON_SET('{&quot;a&quot;:1,&quot;b&quot;:2,&quot;c&quot;:3}','$.b','foo')" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <stmt name="select_5" sql="SELECT JSON_ARRAY()" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <stmt name="select_6" sql="SELECT JSON_OBJECT()" category="DQL" kind="select" cardinality="1">
   <in/>
   <out>
-   <value name="_0" type="Text"/>
+   <value name="_0" type="Json"/>
   </out>
  </stmt>
  <table name="test">
   <schema>
-   <value name="foo" type="Text" nullable="true"/>
+   <value name="foo" type="Json" nullable="true"/>
   </schema>
  </table>
 </sqlgg>


### PR DESCRIPTION
# JSON Support for sqlgg

This pull request adds comprehensive JSON support to sqlgg - a typed SQL interface generator for OCaml.

## Key Changes

### 1. New Data Types
- **`Json`** - for storing JSON data
- **`Json_path`** - for JSON paths (e.g., `$.user.name`)  
- **`One_or_all`** - for search parameters (`'one'` or `'all'`)

### 2. JSON Path Parser
Added a complete JSON path parser (`json_path/`) supporting:
- Basic paths: `$.name`, `$[0]`, `$[*]`
- Complex expressions: `$.users[*].email`, `$[1 to 3]`
- Special operators: `last`, `**` (recursive search)
- Combinators for programmatic path construction

### 3. MySQL JSON Functions
Implemented MySQL JSON functions with proper typing:

```sql
-- Data extraction
SELECT JSON_EXTRACT(data, '$.name') FROM users;

-- JSON modification
UPDATE users SET data = JSON_SET(data, '$.active', true);

-- JSON search
SELECT JSON_SEARCH(data, 'one', 'pattern%');

-- JSON creation
SELECT JSON_OBJECT('name', 'Alice', 'age', 30);
```

### 4. Enhanced Type System
- **Static validation**: JSON literals are validated at compile time
- **Variadic functions with grouped arguments**: Support for pattern `JSON_SET(json, path, value, path, value, ...)` where arguments come in fixed groups rather than simple repetition like `CONCAT(a, b, c, ...)`
- **Nullable semantics**: Distinction between SQL NULL and JSON null

### 5. Key Features

#### Type Safety
```ocaml
(* JSON correctness is statically verified *)
JSON_SET(data, '$.name', "valid")  (* ✓ *)
JSON_SET(data, 'invalid path', x)  (* ✗ compile error *)
```

#### Path Combinators
```ocaml
let open Sqlgg_json_path.Ast.Syntax in
let path = root / ~."users" / any / ~."settings" in
(* Equivalent to "$.users[*].settings" *)
```

#### Meta Attributes
Support for special DDL annotations:
```sql
-- [sqlgg] json_null_kind=false
data JSON NOT NULL
```
This is a way to specify that your json will not include null kind. not to be confused with nullability of the column itself. Since in sql itself there is no way to specify that json kind null will be included or not, this flag is added