### PR TITLE
Fix Multi(vararg) function nullability inference

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -680,7 +680,7 @@ let () =
   "ifnull" |> add 2 (F (Var 0, [Var 1; Var 0]));
   ["least";"greatest";] ||> multi_polymorphic;
   "strftime" |> exclude 1; (* requires at least 2 arguments *)
-  ["concat";"concat_ws";"strftime"] ||> multi ~ret:(Typ text) (Typ text);
+  ["concat";"concat_ws";"strftime"] ||> multi ~ret:(Typ (depends Text)) (Typ (depends Text));
   "date" |> monomorphic datetime [datetime];
   "time" |> monomorphic text [datetime];
   "julianday" |> multi ~ret:(Typ float) (Typ text);

--- a/test/out/inargument.xml
+++ b/test/out/inargument.xml
@@ -40,7 +40,7 @@
  <stmt name="find_with_bar" sql="SELECT * FROM foo&#x0A;WHERE CONCAT(foo, @suffix) IN @@foos_with_suffix" category="DQL" kind="select" cardinality="n">
   <in>
    <value name="suffix" type="Text"/>
-   <value name="foos_with_suffix" type="set(Text)"/>
+   <value name="foos_with_suffix" type="set(Text)" nullable="true"/>
   </in>
   <out>
    <value name="id" type="Int"/>

--- a/test/out/money.xml
+++ b/test/out/money.xml
@@ -27,7 +27,7 @@
  <stmt name="calc_total" sql="SELECT CONCAT(name,' ',surname) AS fullname, SUM(amount) as total FROM person JOIN money ON src = id GROUP BY id" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="fullname" type="Text"/>
+   <value name="fullname" type="Text" nullable="true"/>
    <value name="total" type="Int" nullable="true"/>
   </out>
  </stmt>


### PR DESCRIPTION
### Description
`convert_args` was doing `common_type` unification for `Typ` arguments but then throwing away the result and returning the original types. Now it actually saves and uses the unified types.

Before: unify types → ignore result → return original types
After: unify types → save result → return unified types

This broke when Multi functions got converted to `F` because they started using the wrong types for nullability calculation.