### PR TITLE
Fix: use comma-separated list for ON CONFLICT(...) clause

### DIFF
--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -283,7 +283,7 @@ conflict_algo: CONFLICT_ALGO | REPLACE { }
 conflict_clause: 
   | ON DUPLICATE KEY UPDATE ss=commas(set_column) 
     { Dialect_feature.set_on_duplicate_key ($startofs, $endofs); On_duplicate, ss }
-  | ON CONFLICT LPAREN attrs=nonempty_list(attr_name) RPAREN DO UPDATE SET ss=commas(set_column) 
+  | ON CONFLICT LPAREN attrs=separated_nonempty_list(COMMA, attr_name) RPAREN DO UPDATE SET ss=commas(set_column) 
     { Dialect_feature.set_on_conflict ($startofs, $endofs); On_conflict attrs, ss }
 
 select_type: DISTINCT | ALL { }


### PR DESCRIPTION
```
INSERT INTO tasks (id, run_id, name, start_time, end_time, attempts, state)
VALUES @tasks
 ON CONFLICT(id, run_id) DO UPDATE SET
 state = excluded.state,
 start_time = excluded.start_time,
 end_time = excluded.end_time,
 attempts = excluded.attempts;
```
will get a parsing error at `, run_id)`
```
INSERT INTO tasks (id, run_id, name, start_time, end_time, attempts, state)
VALUES @tasks
 ON CONFLICT(id run_id) DO UPDATE SET
 state = excluded.state,
 start_time = excluded.start_time,
 end_time = excluded.end_time,
 attempts = excluded.attempts;
 ```
will parse.

This PR makes a small change to the parser to correctly handle comma-separated column lists in the `ON CONFLICT` clause as per [Sqlite3 upsert](https://sqlite.org/lang_upsert.html) and [PostgreSQL upsert](https://wiki.postgresql.org/wiki/UPSERT) specifications.