### PR TITLE
Fix closed enum type checking for string literals

### DIFF
--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -586,8 +586,10 @@ and resolve_types env expr =
     assign_types env expr
   with
     exn ->
-      eprintfn "resolve_types failed with %s at:" (Printexc.to_string exn);
-      eprintfn "%s" (show_res_expr expr);
+      if !debug then begin
+        eprintfn "resolve_types failed with %s at:" (Printexc.to_string exn);
+        eprintfn "%s" (show_res_expr expr)
+      end;
       raise exn
 
 and infer_schema env columns =


### PR DESCRIPTION
### Description
This PR fixes problem that closed enums go through super type against string literal.
For example:
For given DDL
```sql
CREATE TABLE devices (
  id INT AUTO_INCREMENT PRIMARY KEY,
  name VARCHAR(100) NOT NULL,
  status ENUM('online', 'offline', 'maintenance') NOT NULL DEFAULT 'offline'
);
```
This isn't compiled  (as expected)

```sql
SELECT * FROM devices
WHERE status BETWEEN 'testing' AND 'offline';
```

But this is compiled (not expected)

```sql
SELECT * FROM devices
WHERE status BETWEEN 'offline' AND 'testing';
```