### PR TITLE
Split IO into two separate ones: cached stmts io and base io

### DIFF
--- a/impl/ocaml/sqlgg_io.ml
+++ b/impl/ocaml/sqlgg_io.ml
@@ -18,6 +18,10 @@ module type M = sig
   val return : 'a -> 'a future
   val (>>=) : 'a future -> ('a -> 'b future) -> 'b future
   val bracket : 'a future -> ('a -> unit future) -> ('a -> 'b future) -> 'b future
+end
+
+module type M_control = sig 
+  include M
   val catch : (unit -> 'a future) -> (exn -> 'a future) -> 'a future
   val try_bind : (unit -> 'a future) -> ('a -> 'b future) -> (exn -> 'b future) -> 'b future
   val async : (unit -> unit future) -> unit
@@ -27,7 +31,7 @@ module type M = sig
   end
 end
 
-module Blocking : M with type 'a future = 'a = struct
+module Blocking : M_control with type 'a future = 'a = struct
 
   type 'a future = 'a
 

--- a/impl/ocaml/sqlgg_stmt_cache.ml
+++ b/impl/ocaml/sqlgg_stmt_cache.ml
@@ -6,7 +6,7 @@ module Async_lru = struct
     val on_evict : value -> unit future
   end
 
-  module Make (IO : Sqlgg_io.M) (Evict : Evict with type 'a future = 'a IO.future) = struct
+  module Make (IO : Sqlgg_io.M_control) (Evict : Evict with type 'a future = 'a IO.future) = struct
   
     open IO
 
@@ -129,7 +129,8 @@ module Async_lru = struct
 end
 
 module type Cached_m = sig
-  include Sqlgg_traits.M_io
+  include Sqlgg_traits.M_control_io
+
 
   val prepare : 'a connection -> string -> statement IO.future
   val close_stmt : statement -> unit IO.future

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -241,6 +241,23 @@ module type M_io = sig
 
 end
 
+module type M_control_io = sig 
+
+  include M
+
+  module IO : Sqlgg_io.M_control
+
+  include FNS
+    with type params := params
+    with type result := result
+    with type 'a io_future := 'a IO.future
+    with type 'a connection := 'a connection
+    with type statement := statement
+    with type row := row
+    with type execute_response := execute_response
+
+end
+
 module type M_default_types = M with type Types.Bool.t = bool
   and type Types.Int.t = int64
   and type Types.Float.t = float


### PR DESCRIPTION
### Description
This PR split IO into two parts: one for prepared cashed stmts and base