### PR TITLE
Add non-nullifiable column meta and enforce strict nullability on assignments

### DIFF
--- a/lib/dialect.ml
+++ b/lib/dialect.ml
@@ -138,4 +138,6 @@ let get_row_locking pos = only RowLocking [PostgreSQL; MySQL; TiDB] pos
 
 module Semantic = struct 
   let is_where_aliases_dialect () = !selected = SQLite
+
+  let is_non_strict_mode_is_exists () = List.mem !selected [MySQL; TiDB; SQLite]
 end

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -297,7 +297,7 @@ on_conflict_action:
   | NOTHING { Do_nothing }
 
 conflict_clause: 
-  | ON DUPLICATE KEY UPDATE ss=commas(set_column) 
+  | ON DUPLICATE KEY UPDATE ss=commas(set_column)
     { Dialect_feature.set_on_duplicate_key ($startofs, $endofs); On_duplicate ss }
   | ON CONFLICT LPAREN attrs=separated_nonempty_list(COMMA, attr_name) RPAREN DO action=on_conflict_action
     { Dialect_feature.set_on_conflict ($startofs, $endofs); On_conflict (action, attrs) }
@@ -468,7 +468,7 @@ expr:
     | INTERVAL e=expr interval_unit { Fun { kind = (fixed Datetime [Int]); parameters = [e]; is_over_clause = false } }
     | LPAREN e=expr RPAREN { e }
     | a=attr_name collate? { Column a }
-    | VALUES LPAREN n=IDENT RPAREN { Inserted n }
+    | VALUES LPAREN n=IDENT RPAREN { Of_values n }
     | v=literal_value | v=datetime_value { v }
     | INTERVAL_UNIT { Value (strict Datetime) }
     | e1=expr mnot(IN) l=sequence(expr) { poly (depends Bool) (e1::l) }

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -1,5 +1,8 @@
 
-val debug : bool ref
+module Config: sig
+  val debug : bool ref
+  val allow_write_notnull_null : bool ref
+end
 
 val parse : string -> string * Sql.Schema.t * Sql.var list * Stmt.kind * Dialect.dialect_support list
 

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -126,6 +126,7 @@ let main () =
     "-static-header", Arg.Unit (fun () -> Sqlgg_config.gen_header := Some `Static), "only output short static header without version/timestamp";
     "-show-tables", Arg.Unit Tables.print_all, " Show all current tables";
     "-show-table", Arg.String Tables.print1, "<name> Show specified table";
+    "-allow-write-notnull-null", Arg.Unit (fun () -> Sqlgg_config.allow_write_notnull_null true), "Treat writing NULL to NOT NULL columns as error";
     "-enum-poly-variant", Arg.Unit (fun () -> Sqlgg_config.enum_as_poly_variant := true), " Represent enums as variants in generated code";
     "-dialect", Arg.String set_dialect, "mysql|sqlite|postgresql|tidb Set SQL dialect - will only allow this dialect's features in SQL queries";
     "-no-check", Arg.String set_no_check, "{all|<feature>{,<feature>}+} Disable dialect feature checks (possible features: collation|join_on_subquery|create_table_as_select) - do not enforce dialect feature checks";

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -9,7 +9,7 @@ let debug_level = ref 0
 
 let set_debug_level n =
   debug_level := n;
-  if n > 1 then Syntax.debug := true
+  if n > 1 then Syntax.Config.debug := true
 
 let debug1 () = !debug_level > 0
 
@@ -22,3 +22,5 @@ let enum_as_poly_variant = ref false
 let no_check_features: Dialect.feature list ref = ref []
 
 let set_no_check_features l = no_check_features := l
+
+let allow_write_notnull_null b = Syntax.Config.allow_write_notnull_null := b


### PR DESCRIPTION
### Description

- Introduces a [non_nullifiable](https://github.com/ygrek/sqlgg/issues/203) meta for columns.
- Prevents assigning NULL to NOT NULL cols (including `ON DUPLICATE KEY`)

Semantics:

- INSERT: NULL is allowed according to the declared column type (e.g., nullable columns). The non_nullifiable flag does not block NULLs on initial insert.
- UPDATE / ON DUPLICATE KEY UPDATE: assigning NULL to a non_nullifiable column will error; assigning a nullable expression to a NOT NULL column will error.
- VALUES(col) is supported in MySQL upsert expressions and is now typed from the collected VALUES. Using it outside of that context produces a clear error.

Examples:


```sql
-- DDL: columns marked as non_nullifiable
-- Meaning: NULL is allowed on initial INSERT, but assigning NULL is forbidden on UPDATE/UPSERT
CREATE TABLE nn_upsert_multi (
    id INT PRIMARY KEY,
    -- [sqlgg] non_nullifiable=true
    column1 INT NULL,
    -- [sqlgg] non_nullifiable=true
    column2 VARCHAR(255) NULL
);

-- Multi-row INSERT: at least one NULL in column1 -> VALUES(column1) becomes nullable
-- Result: UPDATE side rejects only column1; column2 stays non-nullable (OK)
INSERT INTO nn_upsert_multi (id, column1, column2)
VALUES
  (1, @v1 :: Int, @t1 :: Text),  -- both non-NULL
  (2, NULL,           'b');      -- NULL in column1 -> aggregated VALUES(column1) is nullable
ON DUPLICATE KEY UPDATE
  column1 = VALUES(column1),     -- rejected: nullable assigned to non_nullifiable
  column2 = VALUES(column2);     -- OK: all INSERT rows were non-NULL for column2

-- Fixed: protect only columns whose VALUES(...) may be NULL
INSERT INTO nn_upsert_multi (id, column1, column2)
VALUES
  (1, @v1 :: Int, @t1 :: Text),
  (2, NULL,           'b');
ON DUPLICATE KEY UPDATE
  column1 = COALESCE(VALUES(column1), column1),  -- guard against NULL
  column2 = VALUES(column2);                      -- no guard needed (non-NULL)

-- If any INSERT row has NULL for column2, aggregate makes VALUES(column2) nullable too:
INSERT INTO nn_upsert_multi (id, column1, column2)
VALUES
  (1, @v1 :: Int, @t1 :: Text),
  (2, NULL,           NULL);  -- now column2 becomes nullable as well
ON DUPLICATE KEY UPDATE
  column1 = COALESCE(VALUES(column1), column1),
  column2 = COALESCE(VALUES(column2), column2);
```

```sql
-- DDL
CREATE TABLE nn_demo (
    id INT PRIMARY KEY,
    -- [sqlgg] non_nullifiable=true
    updated_at DATETIME NULL,
    name TEXT NOT NULL
);

-- UPDATE (will error: assigning NULL to a non_nullifiable column)
UPDATE nn_demo SET updated_at = NULL WHERE id = 1;

-- INSERT (OK: NULL allowed on initial insert for a nullable column)
INSERT INTO nn_demo (id, updated_at, name) VALUES (1, NULL, 'a');
```