### PR TITLE
Support functions that accept an `ORDER BY` as argument  syntax, implement `GROUP_CONCAT`

### DIFF
--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -89,6 +89,7 @@ let keywords =
    "function", FUNCTION;
    "global",GLOBAL;
    "group",GROUP;
+   "group_concat", GROUP_CONCAT;
    "having",HAVING;
    "hour_microsecond", HOUR_MICROSECOND;
    "hour_minute", HOUR_MINUTE;
@@ -150,6 +151,7 @@ let keywords =
    "second_microsecond", SECOND_MICROSECOND;
    "select",SELECT;
    "set",SET;
+   "separator", SEPARATOR;
    "share", SHARE;
    "some",SOME;
    "spatial", SPATIAL;


### PR DESCRIPTION
### Description

Added support for functions that accept an `ORDER BY` as argument. Mainly for `GROUP_CONCAT`, but I'll update it later with the rest similar functions. There are other such functions, but I've already implemented a generalized version.
The `ORDER BY` itself is not limited and is no different from existing standard support, meaning it can be parameterized.
 demonstrative tests:
https://github.com/ygrek/sqlgg/pull/236/files#diff-09ec84d73f56369793195956d0fb9443c68d232496660c6894a90e4f429d30ac