### PR TITLE
Support UInt64 type

### DIFF
--- a/impl/ocaml/dune
+++ b/impl/ocaml/dune
@@ -2,4 +2,4 @@
  (wrapped false)
  (name sqlgg_traits)
  (public_name sqlgg.traits)
- (libraries sqlgg_json_path))
+ (libraries integers sqlgg_json_path))

--- a/impl/ocaml/mariadb/dune
+++ b/impl/ocaml/mariadb/dune
@@ -2,4 +2,4 @@
  (name sqlgg_mariadb)
  (public_name sqlgg.mariadb)
  (optional)
- (libraries mariadb yojson sqlgg.traits))
+ (libraries mariadb integers yojson sqlgg.traits))

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -41,6 +41,12 @@ module type Types = sig
     val bool_to_literal : bool -> string
   end
   module Int : Int
+  module UInt64 : sig
+    include Value
+    val get_uint64 : string -> Unsigned.UInt64.t
+    val set_uint64: Unsigned.UInt64.t -> string
+    val uint64_to_literal : Unsigned.UInt64.t -> string
+  end
   (* you probably want better type, e.g. (int*int) or Z.t *)
   module Float : sig
     include Value
@@ -114,6 +120,15 @@ module Default_types = struct
     let get_int64 = of_string
     let set_int64 = to_string
     let int64_to_literal = to_literal
+  end
+  module UInt64 = struct
+    type t = Unsigned.UInt64.t
+    let of_string _s = failwith "mysql bindings: uint64 is not supported yet"
+    let to_string _v = failwith "mysql bindings: uint64 is not supported yet"
+    let to_literal (x:t) = Unsigned.UInt64.to_string x
+    let get_uint64 = of_string
+    let set_uint64 = to_string
+    let uint64_to_literal = to_literal
   end
   module Text = struct
     type t = string
@@ -309,6 +324,9 @@ let get_column_ty name conv =
 
 let get_column_Bool, get_column_Bool_nullable = get_column_ty "Bool" Bool.of_string
 let get_column_Int, get_column_Int_nullable = get_column_ty "Int" Int.of_string
+let get_column_UInt64, get_column_UInt64_nullable =
+  ((fun _ _ -> oops "get_column_UInt64: mysql bindings do not support uint64 yet"),
+   (fun _ _ -> oops "get_column_UInt64_nullable: mysql bindings do not support uint64 yet"))
 let get_column_Text, get_column_Text_nullable = get_column_ty "Text" Text.of_string
 let get_column_Float, get_column_Float_nullable = get_column_ty "Float" Float.of_string
 let get_column_Decimal, get_column_Decimal_nullable = get_column_ty "Decimal" Decimal.of_string
@@ -320,6 +338,9 @@ let get_column_Any, get_column_Any_nullable = get_column_ty "Any" Any.of_string
 
 let get_column_bool, get_column_bool_nullable = get_column_ty "bool" Bool.get_bool
 let get_column_int64, get_column_int64_nullable = get_column_ty "int64" Int.get_int64
+let get_column_uint64, get_column_uint64_nullable =
+  ((fun _ _ -> oops "get_column_uint64: mysql bindings do not support uint64 yet"),
+   (fun _ _ -> oops "get_column_uint64_nullable: mysql bindings do not support uint64 yet"))
 let get_column_float, get_column_float_nullable = get_column_ty "float" Float.get_float
 let get_column_decimal, get_column_decimal_nullable = get_column_ty "float" Decimal.get_float
 let get_column_datetime, get_column_datetime_nullable = get_column_ty "string" Datetime.get_string
@@ -343,6 +364,7 @@ let set_param_Text = set_param_ty Text.to_string
 let set_param_Any = set_param_ty Any.to_string
 let set_param_Bool = set_param_ty Bool.to_string
 let set_param_Int = set_param_ty Int.to_string
+let set_param_UInt64 _ _ = oops "set_param_UInt64: mysql bindings do not support uint64 yet"
 let set_param_Float = set_param_ty Float.to_string
 let set_param_Decimal = set_param_ty Decimal.to_string
 let set_param_Datetime = set_param_ty Datetime.to_string
@@ -353,6 +375,7 @@ let set_param_One_or_all = set_param_ty One_or_all.to_string
 let set_param_string = set_param_ty Text.set_string
 let set_param_bool = set_param_ty Bool.set_bool
 let set_param_int64 = set_param_ty Int.set_int64
+let set_param_uint64 _ _ = oops "set_param_uint64: mysql bindings do not support uint64 yet"
 let set_param_float = set_param_ty Float.set_float
 let set_param_decimal = set_param_ty Decimal.set_float
 let set_param_datetime = set_param_ty Datetime.set_float

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -87,6 +87,10 @@ module type M = sig
       include Value
       val int64_to_literal : int64 -> string
     end
+    module UInt64 : sig 
+      include Value
+      val uint64_to_literal : Unsigned.UInt64.t -> string
+    end
     module Float : sig
       include Value
       val float_to_literal : float -> string
@@ -130,6 +134,7 @@ module type M = sig
 
   val get_column_Bool : row -> int -> Bool.t
   val get_column_Int : row -> int -> Int.t
+  val get_column_UInt64 : row -> int -> Unsigned.UInt64.t
   val get_column_Text : row -> int -> Text.t
   val get_column_Any : row -> int -> Any.t
   val get_column_Float : row -> int -> Float.t
@@ -142,6 +147,7 @@ module type M = sig
 
   val get_column_Bool_nullable : row -> int -> Bool.t option
   val get_column_Int_nullable : row -> int -> Int.t option
+  val get_column_UInt64_nullable : row -> int -> Unsigned.UInt64.t option
   val get_column_Text_nullable : row -> int -> Text.t option
   val get_column_Any_nullable : row -> int -> Any.t option
   val get_column_Float_nullable : row -> int -> Float.t option
@@ -157,7 +163,10 @@ module type M = sig
   
   val get_column_int64 : row -> int -> int64
   val get_column_int64_nullable : row -> int -> int64 option
-  
+
+  val get_column_uint64 : row -> int -> Unsigned.UInt64.t
+  val get_column_uint64_nullable : row -> int -> Unsigned.UInt64.t option
+
   val get_column_float : row -> int -> float
   val get_column_float_nullable : row -> int -> float option
   
@@ -188,6 +197,7 @@ module type M = sig
   val set_param_Any : params -> Any.t -> unit
   val set_param_Bool : params -> Bool.t -> unit
   val set_param_Int : params -> Int.t -> unit
+  val set_param_UInt64: params -> Unsigned.UInt64.t -> unit
   val set_param_Float : params -> Float.t -> unit
   val set_param_Decimal : params -> Decimal.t -> unit
   val set_param_Datetime : params -> Datetime.t -> unit
@@ -197,6 +207,7 @@ module type M = sig
 
   val set_param_bool : params -> bool -> unit
   val set_param_int64 : params -> int64 -> unit
+  val set_param_uint64 : params -> Unsigned.UInt64.t -> unit
   val set_param_float : params -> float -> unit
   val set_param_decimal : params -> float -> unit
   val set_param_string : params -> string -> unit

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -30,6 +30,11 @@ module Types = struct
     let to_literal = to_string
     let int64_to_literal = to_literal
   end
+  module UInt64 = struct
+    type t = Unsigned.UInt64.t
+    let to_literal _ = failwith "uint64 unsupported by sqlite"
+    let uint64_to_literal = to_literal
+  end
   module Text = struct
     type t = string
 
@@ -178,6 +183,9 @@ let get_column_ty (name,conv) =
 
 let get_column_Bool, get_column_Bool_nullable = get_column_ty Conv.bool
 let get_column_Int, get_column_Int_nullable = get_column_ty Conv.int
+let get_column_UInt64, get_column_UInt64_nullable =
+  ((fun _ _ -> raise (Oops "get_column_UInt64: uint64 unsupported by sqlite")),
+   (fun _ _ -> raise (Oops "get_column_UInt64_nullable: uint64 unsupported by sqlite")))
 let get_column_Text, get_column_Text_nullable = get_column_ty Conv.text
 let get_column_Any, get_column_Any_nullable = get_column_ty Conv.text
 let get_column_Float, get_column_Float_nullable = get_column_ty Conv.float
@@ -189,6 +197,9 @@ let get_column_One_or_all, get_column_One_or_all_nullable = get_column_ty Conv.o
 
 let get_column_bool, get_column_bool_nullable = (get_column_Bool, get_column_Bool_nullable)
 let get_column_int64, get_column_int64_nullable = (get_column_Int, get_column_Int_nullable)
+let get_column_uint64, get_column_uint64_nullable =
+  ((fun _ _ -> raise (Oops "get_column_uint64: uint64 unsupported by sqlite")),
+   (fun _ _ -> raise (Oops "get_column_uint64_nullable: uint64 unsupported by sqlite")))
 let get_column_float, get_column_float_nullable = (get_column_Float, get_column_Float_nullable)
 let get_column_decimal, get_column_decimal_nullable = (get_column_Decimal, get_column_Decimal_nullable)
 let get_column_string, get_column_string_nullable = (get_column_Text, get_column_Text_nullable)
@@ -223,6 +234,7 @@ let set_param_Text stmt v = bind_param (S.Data.TEXT v) stmt
 let set_param_Any = set_param_Text
 let set_param_Bool stmt v = bind_param (S.Data.INT (if v then 1L else 0L)) stmt
 let set_param_Int stmt v = bind_param (S.Data.INT v) stmt
+let set_param_UInt64 _ _ = failwith "set_param_UInt64: uint64 unsupported by sqlite"
 let set_param_Float stmt v = bind_param (S.Data.FLOAT v) stmt
 let set_param_Decimal = set_param_Float
 let set_param_Datetime = set_param_Float
@@ -237,6 +249,7 @@ let set_param_One_or_all stmt v = bind_param (S.Data.TEXT (match v with `One -> 
 
 let set_param_bool = set_param_Bool
 let set_param_int64 = set_param_Int
+let set_param_uint64 _ _ = failwith "set_param_uint64: uint64 unsupported by sqlite"
 let set_param_float = set_param_Float
 let set_param_decimal = set_param_Float
 let set_param_string = set_param_Text

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -26,6 +26,7 @@ struct
 
   type kind =
     | Int
+    | UInt64
     | Text
     | Blob
     | Float
@@ -107,6 +108,10 @@ struct
     | Any, t | t, Any -> `Order (t, t)
     | Int, Float | Float, Int -> `Order (Int, Float)
     | Decimal, Int | Int, Decimal -> `Order (Int, Decimal)
+    (* UInt64 cannot be a subtype of Float: double precision only guarantees exact 
+     representation up to 2^53 (~9e15), but UInt64 can hold values up to 2^64-1 (~18e18).
+     Converting large UInt64 values to Float would lose precision *)
+    | UInt64, Int | Int, UInt64 -> `Order (Int, UInt64)
     | Text, Blob | Blob, Text -> `Order (Text, Blob)
     | Int, Datetime | Datetime, Int -> `Order (Int, Datetime)
     | Text, Datetime | Datetime, Text -> `Order (Datetime, Text)

--- a/lib/sql_lexer.mll
+++ b/lib/sql_lexer.mll
@@ -209,7 +209,8 @@ let keywords =
       BOOLEAN,
       DATE, TIME, TIMESTAMP, INTERVAL
     *)
-  all T_INTEGER ["integer";"int";"smallint";"bigint";"tinyint";"mediumint";"middleint";"serial";"identity"];
+  all T_INTEGER ["integer";"int";"smallint";"tinyint";"mediumint";"middleint";"serial";"identity"];
+  all T_BIG_INTEGER ["bigint"];
   all T_DECIMAL ["numeric";"decimal";"dec";"fixed"];
   all T_INTEGER ["number"]; (* oracle *)
   all T_BOOLEAN ["bool";"boolean"];

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -507,7 +507,7 @@ and assign_types env expr =
             (* Since we have string literals, we can check if the enums are already exhausted or if a default case is required *)
             let values = Type.Enum_kind.Ctors.of_list @@ List.filter_map (function ResValue { t = StringLiteral v; _ } -> Some v | _ -> None) whens_e in
             Type.Enum_kind.Ctors.compare values ctors = 0
-          | Int | Text | Blob | Float | Datetime 
+          | Int | UInt64 | Text | Blob | Float | Datetime 
           | Decimal | Any | One_or_all | Json | StringLiteral _ | Json_path | Bool -> false in
         let exhaust_checked = if is_exhausted then types else List.map Type.make_nullable types in  
         match Type.common_supertype @@ Option.map_default (fun else_t -> types @ [get_or_failwith else_t]) exhaust_checked else_t with

--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "yojson" {>= "1.6.0"}
   "dune" {>= "2.7"}
+  "integers" {>= "0.4.0"}
   "menhir" {>= "20180523"}
   "mybuild" {> "3"}
   "ppx_deriving" {>= "4.3"}
@@ -41,6 +42,6 @@ conflicts: [
 
 pin-depends: [
   [ "mariadb"
-    "git+https://github.com/ocaml-community/ocaml-mariadb.git#1993263770048d50696f4e698907dbf6e62800d3"
+    "git+https://github.com/ocaml-community/ocaml-mariadb.git#e9f9ac750abd5adebb589da5e553e5c45d8ec066"
   ]
 ]

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -142,7 +142,8 @@ module L = struct
   | { t = Union _; _ }
   | { t = Json; _ }
   | { t = Json_path; _ }
-  | { t = One_or_all; _ } 
+  | { t = One_or_all; _ }
+  | { t = UInt64; _ }
   | { t = Any; _ } as t -> type_name t
 
   let as_runtime_repr_name = function
@@ -158,6 +159,7 @@ module L = struct
   | { t = Datetime; _ }
   | { t = Decimal; _ } -> "float"
   | { t = Json; _ } -> "json"
+  | { t = UInt64; _ } -> "uint64"
   | { t = One_or_all; _ } -> "text"
 
 
@@ -736,7 +738,7 @@ let generate_enum_modules stmts =
 
   let get_enum typ = match typ.Sql.Type.t with 
     | Union { ctors; _ } -> Some ctors
-    | Int | Text | Blob | Float | Bool | Json
+    | Int | Text | Blob | Float | Bool | Json | UInt64
     | Datetime | Decimal | Any | StringLiteral  _ | Json_path | One_or_all -> None
   in
 

--- a/src/gen_csharp.ml
+++ b/src/gen_csharp.ml
@@ -46,6 +46,7 @@ let as_api_type t =
   | Union _
   | Json_path
   | One_or_all
+  | UInt64
   | Json -> assert false
 
 let as_lang_type = as_api_type

--- a/src/gen_java.ml
+++ b/src/gen_java.ml
@@ -46,6 +46,7 @@ let as_lang_type t =
   | Union _
   | Json
   | One_or_all 
+  | UInt64
   | Json_path -> assert false
 
 let as_api_type = String.capitalize_ascii $ as_lang_type

--- a/src/test.ml
+++ b/src/test.ml
@@ -244,7 +244,7 @@ let test_coalesce = [
 
 let test_primary_strict = [
   tt "CREATE TABLE test9 (x BIGINT UNSIGNED PRIMARY KEY)" [] [];
-  tt "SELECT x FROM test9 WHERE x > 100" [attr' ~extra:[PrimaryKey] ~nullability:Strict "x" Int;] [];
+  tt "SELECT x FROM test9 WHERE x > 100" [attr' ~extra:[PrimaryKey] ~nullability:Strict "x" UInt64;] [];
 ]
 
 let test_not_null_default_field = [

--- a/test/cram/print_ocaml_impl.ml
+++ b/test/cram/print_ocaml_impl.ml
@@ -101,6 +101,11 @@ module Types = struct
     let to_literal = Int64.to_string
     let int64_to_literal = to_literal
   end
+  module UInt64 = struct
+    type t = Unsigned.UInt64.t
+    let to_literal = Unsigned.UInt64.to_string
+    let uint64_to_literal = to_literal
+  end
   module Text = struct
     type t = string
     let to_literal s = sprintf "'%s'" (String.escaped s)
@@ -193,6 +198,10 @@ let get_column_Int (row : mock_row_data) (index : int) : Types.Int.t =
   | `Int v -> printf "[MOCK] get_column_Int[%d] = %Ld\n" index v; v
   | _ -> printf "[MOCK] get_column_Int[%d] = 0L (default)\n" index; 0L
 
+let get_column_UInt64 (row : mock_row_data) (index : int) : Unsigned.UInt64.t =
+  let _ = row, index in
+  printf "[MOCK] get_column_UInt64[%d] = 0 (default)\n" index; Unsigned.UInt64.zero
+
 let get_column_Text (row : mock_row_data) (index : int) : Types.Text.t = 
   match get_mock_value row index with
   | `Text v -> printf "[MOCK] get_column_Text[%d] = \"%s\"\n" index v; v
@@ -252,6 +261,11 @@ let get_column_Int_nullable (row : mock_row_data) (index : int) : Types.Int.t op
   | `Null -> printf "[MOCK] get_column_Int_nullable[%d] = None\n" index; None
   | _ -> printf "[MOCK] get_column_Int_nullable[%d] = Some 0L (default)\n" index; Some 0L
 
+let get_column_UInt64_nullable (row : mock_row_data) (index : int) : Unsigned.UInt64.t option =
+  match get_mock_value row index with
+  | `Null -> printf "[MOCK] get_column_UInt64_nullable[%d] = None\n" index; None
+  | _ -> printf "[MOCK] get_column_UInt64_nullable[%d] = Some 0 (default)\n" index; Some Unsigned.UInt64.zero
+
 let get_column_Text_nullable (row : mock_row_data) (index : int) : Types.Text.t option = 
   match get_mock_value row index with
   | `Text v -> printf "[MOCK] get_column_Text_nullable[%d] = Some \"%s\"\n" index v; Some v
@@ -303,6 +317,8 @@ let get_column_bool = get_column_Bool
 let get_column_bool_nullable = get_column_Bool_nullable
 let get_column_int64 = get_column_Int
 let get_column_int64_nullable = get_column_Int_nullable
+let get_column_uint64 = get_column_UInt64
+let get_column_uint64_nullable = get_column_UInt64_nullable
 let get_column_float = get_column_Float
 let get_column_float_nullable = get_column_Float_nullable
 let get_column_decimal = get_column_Decimal
@@ -367,6 +383,7 @@ let set_param_Text (params : params) (v : Types.Text.t) = bind_param (sprintf "'
 let set_param_Any (params : params) (v : Types.Any.t) = bind_param (sprintf "'%s'" (String.escaped v)) params
 let set_param_Bool (params : params) (v : Types.Bool.t) = bind_param (if v then "TRUE" else "FALSE") params
 let set_param_Int (params : params) (v : Types.Int.t) = bind_param (Int64.to_string v) params
+let set_param_UInt64 (params : params) (v : Unsigned.UInt64.t) = bind_param (Unsigned.UInt64.to_string v) params
 let set_param_Float (params : params) (v : Types.Float.t) = bind_param (Float.to_string v) params
 let set_param_Decimal (params : params) (v : Types.Decimal.t) = bind_param (Float.to_string v) params
 let set_param_Datetime (params : params) (v : Types.Datetime.t) = bind_param (Float.to_string v) params
@@ -376,6 +393,7 @@ let set_param_One_or_all (params : params) (v : Types.One_or_all.t) = bind_param
 
 let set_param_bool (params : params) v = bind_param (if v then "TRUE" else "FALSE") params
 let set_param_int64 (params : params) v = bind_param (Int64.to_string v) params
+let set_param_uint64 (params : params) v = bind_param (Unsigned.UInt64.to_string v) params
 let set_param_float (params : params) v = bind_param (Float.to_string v) params
 let set_param_decimal (params : params) v = bind_param (Float.to_string v) params
 let set_param_string (params : params) v = bind_param (sprintf "'%s'" (String.escaped v)) params


### PR DESCRIPTION
### Description
This PR adds support for `UInt64` for mariadb. For other databases, it's just an error (mysql connector isn't supported yet, sqlite doesn't support this type at all)