### PR TITLE
Fix missing version in pin-depends

### DIFF
--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -41,7 +41,7 @@ conflicts: [
 ]
 
 pin-depends: [
-  [ "mariadb"
+  [ "mariadb.dev"
     "git+https://github.com/ocaml-community/ocaml-mariadb.git#e9f9ac750abd5adebb589da5e553e5c45d8ec066"
   ]
 ]


### PR DESCRIPTION
Without it, all `opam` commands print:

```
error  3: File format error in 'pin-depends' at line 44, column 4: while expecting versioned package:
          OpamPackage.of_string
```