### PR TITLE
Fix ocaml keyword columns in multi-row `INSERT`

### DIFF
--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -102,6 +102,9 @@ end
 
 let inline_values = String.concat " "
 
+let idents_of_attrs ~prefix attrs =
+  Name.idents ~prefix (List.map (fun a -> a.Sql.name) attrs)
+
 let quote = String.replace_chars (function '\n' -> "\\n\\\n" | '\r' -> "" | '"' -> "\\\"" | c -> String.make 1 c)
 let quote s = "\"" ^ quote s ^ "\""
 
@@ -219,7 +222,7 @@ let output_schema_binder_labeled _ schema =
   let attrs = schema_to_attrs schema in
   let name = "invoke_callback" in
   output "let %s stmt =" name;
-  let args = Name.idents ~prefix:"r" (List.map (fun a -> a.Sql.name) attrs) in
+  let args = idents_of_attrs ~prefix:"r" attrs in
   let values = List.mapi get_column attrs in
   indented (fun () ->
     output "callback";
@@ -643,7 +646,7 @@ let gen_in_substitution meta var =
     (Option.get var.id.value)
 
 let gen_tuple_printer ~is_row _label schema =
-  let params = List.map (fun { name; _ } -> name) schema in
+  let params = idents_of_attrs ~prefix:"col" schema in
   let open_paren = if is_row then {|then "ROW(" else ", ROW("|} else {|then "(" else ", ("|} in
   sprintf
     {|(fun _sqlgg_idx (%s) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 %s); %s Buffer.add_char _sqlgg_b ')')|}
@@ -651,15 +654,15 @@ let gen_tuple_printer ~is_row _label schema =
     open_paren
     (String.concat " " @@
      List.mapi
-     (fun idx attr ->
-        let { name; domain; meta; _ } = attr in
+     (fun idx (name, attr) ->
+        let { domain; meta; _ } = attr in
         (if idx = 0 then "" else {|Buffer.add_string _sqlgg_b ", "; |}) ^
         sprintf {|Buffer.add_string _sqlgg_b (%s);|}
           (let to_literal = sprintf "%s %s" (make_to_literal meta domain) in
            if is_attr_nullable attr then 
            (sprintf {|match %s with None -> "NULL" | Some v -> %s|} name (to_literal "v") )
            else to_literal name))
-     schema)
+     (List.combine params schema))
 
 let resolve_tuple_label id = match id.value with
 | None -> failwith "empty label in tuple param"

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -1169,6 +1169,23 @@ Test INSERT (.. ) VALUES @rows with non_nullifiable column (NULL allowed on inse
   
   end (* module Sqlgg *)
 
+Test INSERT (..) VALUES @rows with columns whose names are OCaml keywords (must escape tuple binders):
+  $ sqlgg -gen caml -no-header -params named -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE kw_rows (type INTEGER, val TEXT);
+  > INSERT INTO kw_rows (type, val) VALUES @rows;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_kw_rows db  =
+      T.execute db ("CREATE TABLE kw_rows (type INTEGER, val TEXT)") T.no_params
+  
+    let insert_kw_rows_1 db ~rows =
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db ("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) T.no_params )
+  
+  end (* module Sqlgg *)
+
 Test non_nullifiable with multi-table UPDATE (param must be non-nullable):
   $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' >/dev/null
   > CREATE TABLE nn_multi_t1 (


### PR DESCRIPTION
### Description

This PR fixes invalid code generated for `INSERT ... VALUES @rows` when a column is named after an ocaml keyword:

```sql
CREATE TABLE demo (type INTEGER);
INSERT INTO demo (type) VALUES @rows;
```