### PR TITLE
Also attach column `[sqlgg]` metadata to quoted identifiers

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -171,21 +171,24 @@ let extract_statement' tokens =
     let answer () = Buffer.contents b, !props in
 
     let internal_props = ref Props.empty in
-    
+
+    let flush_internal_props () =
+      if List.length !internal_props > 0 then (
+        Parser_state.Stmt_metadata.add (Buffer.length b) !internal_props;
+        internal_props := Props.empty;
+      )
+    in
+
     let rec loop smth =
       match Enum.get tokens with
       | None -> if smth then Some (answer ()) else None
       | Some x ->
         begin match x with
         | `Comment _ -> loop smth
-        | `Char c -> 
-          if List.length !internal_props > 0 then (
-            Parser_state.Stmt_metadata.add (Buffer.length b) !internal_props;
-            internal_props := Props.empty;
-          );
-          Buffer.add_char b c; loop true
+        | `Char c -> flush_internal_props (); Buffer.add_char b c; loop true
+        | `Token s -> flush_internal_props (); Buffer.add_string b s; loop true
         | `Space _ when smth = false -> loop smth
-        | `Token s | `Space s -> Buffer.add_string b s; loop true
+        | `Space s -> Buffer.add_string b s; loop true
         | `Props p when smth -> internal_props := Props.set_all p !internal_props; loop smth
         | `Props p -> props := Props.set_all p !props; loop smth
         | `Semicolon -> Some (answer ())

--- a/src/main.ml
+++ b/src/main.ml
@@ -173,7 +173,7 @@ let extract_statement' tokens =
     let internal_props = ref Props.empty in
 
     let flush_internal_props () =
-      if List.length !internal_props > 0 then (
+      if not (List.is_empty !internal_props) then (
         Parser_state.Stmt_metadata.add (Buffer.length b) !internal_props;
         internal_props := Props.empty;
       )

--- a/src/test.ml
+++ b/src/test.ml
@@ -1141,6 +1141,19 @@ let test_meta_propagation = [
     attr' ~extra:[NotNull;] "col_2" Int;
   ] [];
 
+  tt {|
+    CREATE TABLE "table_39" (
+      -- [sqlgg] module=HelloWorld
+      "col_1" INT PRIMARY KEY,
+      "col_2" INT NOT NULL
+    )
+  |} [] [];
+
+  tt {|SELECT "col_1", "col_2" FROM "table_39"|} [
+    attr' ~extra:[PrimaryKey;] ~meta:["module", "HelloWorld"] "col_1" Int;
+    attr' ~extra:[NotNull;] "col_2" Int;
+  ] [];
+
   tt "SELECT col_1 + 1 as col_1_with_plus_1, col_2 FROM table_37" [
     attr' ~meta:[] "col_1_with_plus_1" Int;
     attr' ~extra:[NotNull;] "col_2" Int;


### PR DESCRIPTION
The `-- [sqlgg] key=value` annotation placed before a column was lost whenever the column name was a quoted identifier (`"id"`, `'id'`, `$tag$..`).

The statement splitter (`ruleStatement` in `sql_lexer.mll`) emits quoted identifiers as a single `` `Token ``, whereas unquoted names arrive as a stream of `` `Char ``. `extract_statement'` only flushed the pending column metadata in the `` `Char `` branch, so for a quoted column the metadata was recorded at the offset of the *next* `` `Char `` (e.g. the column type) and never matched the column's `$startpos` in the parser — silently dropping the annotation.

Flush the pending metadata in the `` `Token `` branch too (factored into `flush_internal_props`). This notably fixes `module=` type mappings for PostgreSQL schemas, which conventionally double-quote every identifier.