### PR TITLE
Don't ignore `get_column` and `set_param` work when `enum_poly_variant` is enabled

### DIFF
--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -182,18 +182,22 @@ module L = struct
   let as_api_type = as_lang_type
 end
 
+let codec_get_column, codec_set_param =
+  let codec name meta =
+    match Sql.Meta.find_opt meta "module", Sql.Meta.find_opt meta name with
+    | Some m, fn -> Some (sprintf "%s.%s" m (Option.default name fn))
+    | None, fn -> fn
+  in
+  codec "get_column", codec "set_param"
+
 let format_get_column ~row ~idx attr =
   let null_suffix = if is_attr_nullable attr then "_nullable" else "" in
   let format_t_get_column type_name =
     sprintf "T.get_column_%s%s %s %s" type_name null_suffix row idx
   in
-  match Sql.Meta.find_opt attr.meta "module" with
-  | Some m ->
-      let runtime_repr_name = L.as_runtime_repr_name attr.domain in
-      let inner_get_column_expr = sprintf "(T.get_column_%s%s %s %s)" runtime_repr_name null_suffix row idx in
-      let get_column = "get_column" in
-      let get_column_name = get_column |> Sql.Meta.find_opt attr.meta |> Option.default get_column in
-      sprintf "%s.%s%s %s" m get_column_name null_suffix inner_get_column_expr
+  match codec_get_column attr.meta with
+  | Some getter ->
+      sprintf "%s%s (%s)" getter null_suffix (format_t_get_column (L.as_runtime_repr_name attr.domain))
   | None ->
       begin match attr.domain with
       | { t = Union { ctors; _ }; _ } ->
@@ -362,16 +366,10 @@ let set_param ~meta index param =
   let pname = show_param_name param index in
   let ptype = show_param_type param in
   let set_param_nullable v r = output "begin match %s with None -> T.set_param_null p | Some %s -> %s end;" pname v r in
-  let module_ = Sql.Meta.find_opt meta "module" in
-  match module_ with
-  | Some m ->
-      let set_param = "set_param" in
-      let set_param_name = set_param |> Sql.Meta.find_opt meta |> Option.default set_param in
-      let runtime_repr_name = L.as_runtime_repr_name param.typ in
-      if nullable then
-        set_param_nullable pname @@ sprintf "T.set_param_%s p (%s);" runtime_repr_name (sprintf "%s.%s %s" m set_param_name pname)
-      else
-        output "T.set_param_%s p (%s);" runtime_repr_name (sprintf "%s.%s %s" m set_param_name pname)
+  match codec_set_param meta with
+  | Some setter ->
+      let set = sprintf "T.set_param_%s p (%s %s);" (L.as_runtime_repr_name param.typ) setter pname in
+      if nullable then set_param_nullable pname set else output "%s" set
   | None ->
       match param with
       | { typ = { t=(Union { ctors; _ }); _ }; _ } when nullable ->
@@ -628,12 +626,10 @@ let output_params_binder index vars =
 
 
 let make_to_literal meta typ =
-  match Sql.Meta.find_opt meta "module" with
-  | Some m ->
-    let set_param = "set_param" in
-    let set_param_name = set_param |> Sql.Meta.find_opt meta |> Option.default set_param in
+  match codec_set_param meta with
+  | Some setter ->
     let trait_type_name = match typ.Type.t with | Union _ -> "Text" | StringLiteral _ -> "Text" | _ -> L.as_lang_type typ in
-    sprintf "(fun v -> T.Types.%s.%s_to_literal (%s.%s v))" trait_type_name (L.as_runtime_repr_name typ) m set_param_name
+    sprintf "(fun v -> T.Types.%s.%s_to_literal (%s v))" trait_type_name (L.as_runtime_repr_name typ) setter
   | None ->
     match typ.Type.t with
     | Union { ctors; _ } -> sprintf "%s.to_literal" (get_enum_name ctors)
@@ -959,19 +955,19 @@ let generate_enum_modules stmts =
     | Datetime | Decimal _ | FloatingLiteral _ | Any | StringLiteral  _ | Json_path | One_or_all -> None
   in
 
-  let meta_has_module m = Sql.Meta.mem m "module" in
+  let enum_unless_codec codec typ meta =
+    match codec meta with Some _ -> None | None -> get_enum typ
+  in
 
   let schemas_to_enums schemas =
     List.filter_map (fun ({ domain; meta; _ } : Sql.attr) ->
-      if meta_has_module meta then None else get_enum domain
+      enum_unless_codec codec_set_param domain meta
     ) schemas
   in
   
 
   let schema_columns_to_enums schema_cols =
-    let attr_enum attr = 
-      if meta_has_module attr.meta then [] else option_list (get_enum attr.domain)
-    in
+    let attr_enum attr = option_list (enum_unless_codec codec_get_column attr.domain attr.meta) in
     List.concat_map (function
       | Sql.Attr attr -> attr_enum attr
       | Dynamic (_, fields) -> List.concat_map (fun (_, attr) -> attr_enum attr) fields
@@ -980,7 +976,7 @@ let generate_enum_modules stmts =
 
   let rec vars_to_enums vars =
     let enum_opt typ = typ |> get_enum |> option_list in
-    let enum_opt_with_meta typ meta = if meta_has_module meta then [] else enum_opt typ in
+    let enum_opt_with_meta typ meta = option_list (enum_unless_codec codec_set_param typ meta) in
     List.concat_map (function
       | Single ({ typ; _ }, meta)
       | SingleIn ({ typ; _ }, meta) -> enum_opt_with_meta typ meta

--- a/test/cram/meta_codec.t
+++ b/test/cram/meta_codec.t
@@ -1,0 +1,538 @@
+Standalone fully qualified get_column=/set_param= without module= on an ENUM column:
+codec is used for reads and writes over the string representation,
+no dead Enum_N module is emitted:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] get_column=Order_status.of_db
+  >   -- [sqlgg] set_param=Order_status.to_db
+  >   status ENUM('new','paid','shipped') NOT NULL
+  > );
+  > -- @get_status
+  > SELECT status FROM orders WHERE id = @id;
+  > -- @set_status
+  > UPDATE orders SET status = @status WHERE id = @id;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_orders db  =
+      T.execute db ("CREATE TABLE orders (\n\
+    id INT NOT NULL,\n\
+        status ENUM('new','paid','shipped') NOT NULL\n\
+  )") T.no_params
+  
+    let get_status db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~status:(Order_status.of_db (T.get_column_string stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.select db ("SELECT status FROM orders WHERE id = ?") set_params invoke_callback
+  
+    let set_status db ~status ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_string p (Order_status.to_db status);
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.execute db ("UPDATE orders SET status = ? WHERE id = ?") set_params
+  
+    module Fold = struct
+      let get_status db ~id callback acc =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT status FROM orders WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_status db ~id callback =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT status FROM orders WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+Same codec, IN-parameter: to_literal goes through set_param= codec:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders_in (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] get_column=Order_status.of_db
+  >   -- [sqlgg] set_param=Order_status.to_db
+  >   status ENUM('new','paid','shipped') NOT NULL
+  > );
+  > -- @find_orders
+  > SELECT id FROM orders_in WHERE status IN @statuses;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_orders_in db  =
+      T.execute db ("CREATE TABLE orders_in (\n\
+    id INT NOT NULL,\n\
+        status ENUM('new','paid','shipped') NOT NULL\n\
+  )") T.no_params
+  
+    let find_orders db ~statuses callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match statuses with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      T.select db ("SELECT id FROM orders_in WHERE " ^ (match statuses with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Order_status.to_db v)) statuses) ^ ")")) set_params invoke_callback
+  
+    module Fold = struct
+      let find_orders db ~statuses callback acc =
+        let invoke_callback stmt =
+          callback
+            ~id:(T.get_column_Int stmt 0)
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match statuses with [] -> 0 | _ :: _ -> 0)) in
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT id FROM orders_in WHERE " ^ (match statuses with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Order_status.to_db v)) statuses) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let find_orders db ~statuses callback =
+        let invoke_callback stmt =
+          callback
+            ~id:(T.get_column_Int stmt 0)
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match statuses with [] -> 0 | _ :: _ -> 0)) in
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT id FROM orders_in WHERE " ^ (match statuses with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Order_status.to_db v)) statuses) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+Partial codec on ENUM: only set_param= is customized, reads still need Enum_N,
+so it is emitted and referenced by get_column, while writes go through the codec:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders_partial (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] set_param=Order_status.to_db
+  >   status ENUM('new','paid','shipped') NOT NULL
+  > );
+  > -- @get_status
+  > SELECT status FROM orders_partial WHERE id = @id;
+  > -- @set_status
+  > UPDATE orders_partial SET status = @status WHERE id = @id;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+      module Enum_0 = T.Make_enum(struct
+        type t = [`New | `Paid | `Shipped]
+        let inj = function | "new" -> `New | "paid" -> `Paid | "shipped" -> `Shipped | s -> failwith (Printf.sprintf "Invalid enum value: %s" s)
+        let proj = function  | `New -> "new"| `Paid -> "paid"| `Shipped -> "shipped"
+      end)
+  
+    let create_orders_partial db  =
+      T.execute db ("CREATE TABLE orders_partial (\n\
+    id INT NOT NULL,\n\
+      status ENUM('new','paid','shipped') NOT NULL\n\
+  )") T.no_params
+  
+    let get_status db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~status:(Enum_0.get_column stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.select db ("SELECT status FROM orders_partial WHERE id = ?") set_params invoke_callback
+  
+    let set_status db ~status ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_string p (Order_status.to_db status);
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.execute db ("UPDATE orders_partial SET status = ? WHERE id = ?") set_params
+  
+    module Fold = struct
+      let get_status db ~id callback acc =
+        let invoke_callback stmt =
+          callback
+            ~status:(Enum_0.get_column stmt 0)
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_partial WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_status db ~id callback =
+        let invoke_callback stmt =
+          callback
+            ~status:(Enum_0.get_column stmt 0)
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_partial WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+Partial codec on ENUM, reverse: only get_column= is customized, reads go through
+the codec, writes still need Enum_N, so it is emitted and referenced by set_param:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders_partial2 (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] get_column=Order_status.of_db
+  >   status ENUM('new','paid','shipped') NOT NULL
+  > );
+  > -- @get_status
+  > SELECT status FROM orders_partial2 WHERE id = @id;
+  > -- @set_status
+  > UPDATE orders_partial2 SET status = @status WHERE id = @id;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+      module Enum_0 = T.Make_enum(struct
+        type t = [`New | `Paid | `Shipped]
+        let inj = function | "new" -> `New | "paid" -> `Paid | "shipped" -> `Shipped | s -> failwith (Printf.sprintf "Invalid enum value: %s" s)
+        let proj = function  | `New -> "new"| `Paid -> "paid"| `Shipped -> "shipped"
+      end)
+  
+    let create_orders_partial2 db  =
+      T.execute db ("CREATE TABLE orders_partial2 (\n\
+    id INT NOT NULL,\n\
+      status ENUM('new','paid','shipped') NOT NULL\n\
+  )") T.no_params
+  
+    let get_status db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~status:(Order_status.of_db (T.get_column_string stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.select db ("SELECT status FROM orders_partial2 WHERE id = ?") set_params invoke_callback
+  
+    let set_status db ~status ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        Enum_0.set_param p status;
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.execute db ("UPDATE orders_partial2 SET status = ? WHERE id = ?") set_params
+  
+    module Fold = struct
+      let get_status db ~id callback acc =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_partial2 WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_status db ~id callback =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_partial2 WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+Standalone fully qualified codec on a non-ENUM column works over the runtime
+representation (int64 for INT):
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE items (
+  >   -- [sqlgg] get_column=Item_id.of_int
+  >   -- [sqlgg] set_param=Item_id.to_int
+  >   id INT NOT NULL
+  > );
+  > -- @get_item
+  > SELECT id FROM items;
+  > -- @insert_item
+  > INSERT INTO items (id) VALUES (@id);
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_items db  =
+      T.execute db ("CREATE TABLE items (\n\
+        id INT NOT NULL\n\
+  )") T.no_params
+  
+    let get_item db  callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(Item_id.of_int (T.get_column_int64 stmt 0))
+      in
+      T.select db ("SELECT id FROM items") T.no_params invoke_callback
+  
+    let insert_item db ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_int64 p (Item_id.to_int id);
+        T.finish_params p
+      in
+      T.execute db ("INSERT INTO items (id) VALUES (?)") set_params
+  
+    module Fold = struct
+      let get_item db  callback acc =
+        let invoke_callback stmt =
+          callback
+            ~id:(Item_id.of_int (T.get_column_int64 stmt 0))
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT id FROM items") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_item db  callback =
+        let invoke_callback stmt =
+          callback
+            ~id:(Item_id.of_int (T.get_column_int64 stmt 0))
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT id FROM items") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+module= with get_column=/set_param= renames still works as before:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders_mod (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] module=Order_status
+  >   -- [sqlgg] get_column=of_db
+  >   -- [sqlgg] set_param=to_db
+  >   status ENUM('new','paid','shipped') NOT NULL
+  > );
+  > -- @get_status
+  > SELECT status FROM orders_mod WHERE id = @id;
+  > -- @set_status
+  > UPDATE orders_mod SET status = @status WHERE id = @id;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_orders_mod db  =
+      T.execute db ("CREATE TABLE orders_mod (\n\
+    id INT NOT NULL,\n\
+          status ENUM('new','paid','shipped') NOT NULL\n\
+  )") T.no_params
+  
+    let get_status db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~status:(Order_status.of_db (T.get_column_string stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.select db ("SELECT status FROM orders_mod WHERE id = ?") set_params invoke_callback
+  
+    let set_status db ~status ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_string p (Order_status.to_db status);
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.execute db ("UPDATE orders_mod SET status = ? WHERE id = ?") set_params
+  
+    module Fold = struct
+      let get_status db ~id callback acc =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_mod WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_status db ~id callback =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db (T.get_column_string stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_mod WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+
+Nullable ENUM column with standalone codec: _nullable suffix is appended
+to the codec function on reads, writes unwrap the option before the codec:
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF' 2>&1
+  > CREATE TABLE orders_null (
+  >   id INT NOT NULL,
+  >   -- [sqlgg] get_column=Order_status.of_db
+  >   -- [sqlgg] set_param=Order_status.to_db
+  >   status ENUM('new','paid','shipped') NULL
+  > );
+  > -- @get_status
+  > SELECT status FROM orders_null WHERE id = @id;
+  > -- @set_status
+  > UPDATE orders_null SET status = @status WHERE id = @id;
+  > EOF
+  module Sqlgg (T : Sqlgg_traits.M) = struct
+  
+    module IO = Sqlgg_io.Blocking
+  
+    let create_orders_null db  =
+      T.execute db ("CREATE TABLE orders_null (\n\
+    id INT NOT NULL,\n\
+        status ENUM('new','paid','shipped') NULL\n\
+  )") T.no_params
+  
+    let get_status db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~status:(Order_status.of_db_nullable (T.get_column_string_nullable stmt 0))
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.select db ("SELECT status FROM orders_null WHERE id = ?") set_params invoke_callback
+  
+    let set_status db ~status ~id =
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        begin match status with None -> T.set_param_null p | Some status -> T.set_param_string p (Order_status.to_db status); end;
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      T.execute db ("UPDATE orders_null SET status = ? WHERE id = ?") set_params
+  
+    module Fold = struct
+      let get_status db ~id callback acc =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db_nullable (T.get_column_string_nullable stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_null WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        (fun () -> IO.return !r_acc)
+  
+    end (* module Fold *)
+    
+    module List = struct
+      let get_status db ~id callback =
+        let invoke_callback stmt =
+          callback
+            ~status:(Order_status.of_db_nullable (T.get_column_string_nullable stmt 0))
+        in
+        let set_params stmt =
+          let p = T.start_params stmt (1) in
+          T.set_param_Int p id;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db ("SELECT status FROM orders_null WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+  
+    end (* module List *)
+  end (* module Sqlgg *)
+


### PR DESCRIPTION
### Description

This PR makes `get_column` and `set_param` metas work without `module` meta specification.
 Before this they were just ignored if `module=` was not set for enum columns with the enabled `enum_poly_variant` flag, now they can be used on their own to set a codec for a column.

For example:

```sql
CREATE TABLE orders (
  id INT NOT NULL,
  -- [sqlgg] get_column=Order_status.of_db
  -- [sqlgg] set_param=Order_status.to_db
  status ENUM('new','paid','shipped') NOT NULL
);

-- @set_status
UPDATE orders SET status = @status WHERE id = @id;
```

Was generated

```ocaml
module Enum_0 = T.Make_enum(struct
  type t = [`New | `Paid | `Shipped]
  ...
end)
...
Enum_0.set_param p status;
```

Now:

```ocaml
~status:(Order_status.of_db (T.get_column_string stmt 0))
T.set_param_string p (Order_status.to_db status);
T.Types.Text.string_to_literal (Order_status.to_db v)  (* IN and literals *)
```