### PR TITLE
Fix numbering of PostgreSQL params across reusable queries

### DIFF
--- a/src/gen.ml
+++ b/src/gen.ml
@@ -90,7 +90,7 @@ and sql_dynamic_ctor = {
 let substitute_vars s vars subst_param =
   let rec loop s acc i parami vars =
     match vars with
-    | [] -> acc, i
+    | [] -> acc, i, parami
     | Sql.Single (param, _) :: tl ->
       let (i1,i2) = param.id.pos in
       assert (i2 > i1);
@@ -116,7 +116,7 @@ let substitute_vars s vars subst_param =
       assert (i2 > i1);
       assert (i1 > i);
       let acc =
-        DynamicIn (name, kind, List.rev @@ fst @@ loop s [] i1 0 vars) ::
+        DynamicIn (name, kind, (let acc, _, _ = loop s [] i1 0 vars in List.rev acc)) ::
         Static (String.slice ~first:i ~last:i1 s) ::
         acc
       in
@@ -161,7 +161,7 @@ let substitute_vars s vars subst_param =
       assert ((c2 = 0 && c1 = 1) || c2 > c1);
       assert (c1 > i);
       let pieces =
-        let (acc, last) = loop s [] c1 0 vars in
+        let (acc, last, _) = loop s [] c1 0 vars in
         let s_choice = 
           let sql = [Static " ( "] @ List.rev(Static (String.slice ~first:last ~last:c2 s) :: acc)  @ [Static " ) "]in
           let ctor = Sql.{ value=Some("Some"); pos=(0, 0); } in
@@ -181,7 +181,7 @@ let substitute_vars s vars subst_param =
         assert (i2 > i1);
         assert (i1 > i);
         let shared_sql, (_: Sql.select_full) = Shared_queries.get id.value in
-        let raw_processed = loop_and_squash shared_sql shared_vars in
+        let raw_processed, parami = loop_and_squash ~parami shared_sql shared_vars in
         let processed_shared = [Static "("] @ raw_processed @ [Static ")"] in
         loop s (List.rev processed_shared @ Static (String.slice ~first:i ~last:i1 s) :: acc) i2 parami tl
     | DynamicSelect (name,ctors) :: tl ->
@@ -191,7 +191,7 @@ let substitute_vars s vars subst_param =
           let sql = match args with
             | None | Some [] -> [Static (String.slice ~first:c1 ~last:c2 s)]
             | Some l ->
-              let (acc, last) = loop s [] (c1 - 1) 0 l in
+              let (acc, last, _) = loop s [] (c1 - 1) 0 l in
               let pieces = List.rev (Static (String.slice ~first:last ~last:c2 s) :: acc) in
               begin match pieces with
               | Static hd :: rest -> Static (String.slice ~first:1 hd) :: rest
@@ -217,7 +217,7 @@ let substitute_vars s vars subst_param =
           match args with
           | None -> [Static ""]
           | Some l ->
-            let (acc, last) = loop s [] c1 0 l in
+            let (acc, last, _) = loop s [] c1 0 l in
             let body = List.rev (Static (String.slice ~first:last ~last:c2 s) :: acc) in
             squash [] ((Static " (" :: body) @ [Static ") "])
         in
@@ -225,17 +225,17 @@ let substitute_vars s vars subst_param =
       | Verbatim (n, v) ->
         { ctor = { value = Some n; pos = (0,0) }; args = Some []; sql = [Static v]; is_poly }
     end
-  and loop_and_squash sql vars =
-    let acc, last = loop sql [] 0 0 vars in
+  and loop_and_squash ?(parami=0) sql vars =
+    let acc, last, parami = loop sql [] 0 parami vars in
     let acc = List.rev (Static (String.slice ~first:last sql) :: acc) in
-    squash [] acc
+    squash [] acc, parami
   and squash acc = function
     | [] -> List.rev acc
     | Static "" :: tl -> squash acc tl
     | Static s1 :: Static s2 :: tl -> squash acc (Static (s1 ^ s2) :: tl)
     | x::xs -> squash (x::acc) xs
   in
-  loop_and_squash s vars
+  fst (loop_and_squash s vars)
 
 let subst_named index p = "@" ^ (show_param_name p index)
 let subst_oracle index p = ":" ^ (show_param_name p index)

--- a/src/gen.ml
+++ b/src/gen.ml
@@ -88,53 +88,59 @@ and sql_dynamic_ctor = {
 }
 
 let substitute_vars s vars subst_param =
-  let rec loop s acc i parami vars =
+  let static st = `Sql (Static st) in
+  let subst_params l =
+    let rec go index acc = function
+      | [] -> List.rev acc
+      | `Param (param, original) :: tl ->
+        go (index + 1) (Static (Option.map_default (fun subst -> subst index param) original subst_param) :: acc) tl
+      | `Sql x :: tl -> go index (x :: acc) tl
+    in
+    go 0 [] l
+  in
+  let rec loop s acc i vars =
     match vars with
-    | [] -> acc, i, parami
+    | [] -> acc, i
     | Sql.Single (param, _) :: tl ->
       let (i1,i2) = param.id.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc, parami =
-        match subst_param with
-        | None -> Static (String.slice ~first:i ~last:i2 s) :: acc, parami
-        | Some subst ->
-          Static (subst parami param) ::
-          Static (String.slice ~first:i ~last:i1 s) ::
-          acc,
-          parami + 1
+      let acc =
+        `Param (param, String.slice ~first:i1 ~last:i2 s) ::
+        static (String.slice ~first:i ~last:i1 s) ::
+        acc
       in
-      loop s acc i2 parami tl
+      loop s acc i2 tl
     | SingleIn (param,m ):: tl ->
       let (i1,i2) = param.id.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = SubstIn (param, m) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (SubstIn (param, m)) :: static (String.slice ~first:i ~last:i1 s) :: acc in
+      loop s acc i2 tl
     | ChoiceIn { param = name; kind; vars } :: tl ->
       let (i1,i2) = name.pos in
       assert (i2 > i1);
       assert (i1 > i);
       let acc =
-        DynamicIn (name, kind, (let acc, _, _ = loop s [] i1 0 vars in List.rev acc)) ::
-        Static (String.slice ~first:i ~last:i1 s) ::
+        `Sql (DynamicIn (name, kind, subst_params (List.rev @@ fst @@ loop s [] i1 vars))) ::
+        static (String.slice ~first:i ~last:i1 s) ::
         acc
       in
-      loop s acc i2 parami tl
+      loop s acc i2 tl
     | Choice (name,ctors) :: tl ->
       let dyn = process_ctors ~is_poly:true s i ctors in
       let (i1,i2) = name.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (Dynamic (name, dyn)) :: static (String.slice ~first:i ~last:i1 s) :: acc in
+      loop s acc i2 tl
     | DynamicSelectJoin { pid = name; pos = (j1, j2); _ } :: tl ->
       assert (j2 > j1);
       assert (j1 > i);
       let join_text = " " ^ String.trim (String.slice ~first:j1 ~last:j2 s) in
       let rec lead k = if k > i && String.contains " \t\n\r" s.[k - 1] then lead (k - 1) else k in
-      let acc = Cond (Dep_selected (name, j1), [Static join_text]) :: Static (String.slice ~first:i ~last:(lead j1) s) :: acc in
-      loop s acc j2 parami tl
+      let acc = `Sql (Cond (Dep_selected (name, j1), [Static join_text])) :: static (String.slice ~first:i ~last:(lead j1) s) :: acc in
+      loop s acc j2 tl
     | TupleList (id, Where_in { value = (types, in_not_in); pos = (j1, j2) }) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);
@@ -142,28 +148,28 @@ let substitute_vars s vars subst_param =
       assert (j2 > j1);
       assert (j1 > i); 
       let sub = [Static (String.slice ~first:j1 ~last:i1 s); SubstTuple (id, Where_in { value = (types, in_not_in); pos = (j1, j2) })] in
-      let acc = DynamicIn (id, in_not_in, sub) :: Static (String.slice ~first:i ~last:j1 s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (DynamicIn (id, in_not_in, sub)) :: static (String.slice ~first:i ~last:j1 s) :: acc in
+      loop s acc i2 tl
     | TupleList (id, ValueRows x) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = SubstTuple (id, ValueRows x) :: Static (String.slice ~first:i ~last:x.values_start_pos s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (SubstTuple (id, ValueRows x)) :: static (String.slice ~first:i ~last:x.values_start_pos s) :: acc in
+      loop s acc i2 tl
     | TupleList (id, kind) :: tl ->
       let (i1,i2) = id.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = SubstTuple (id, kind) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (SubstTuple (id, kind)) :: static (String.slice ~first:i ~last:i1 s) :: acc in
+      loop s acc i2 tl
     (* Resuse Dynamic to avoid of making a new substitution constructor. *)  
     | OptionActionChoice (name, vars, ((f1, f2), (c1, c2)), kind) :: tl ->
       assert ((c2 = 0 && c1 = 1) || c2 > c1);
       assert (c1 > i);
       let pieces =
-        let (acc, last, _) = loop s [] c1 0 vars in
+        let (acc, last) = loop s [] c1 vars in
         let s_choice = 
-          let sql = [Static " ( "] @ List.rev(Static (String.slice ~first:last ~last:c2 s) :: acc)  @ [Static " ) "]in
+          let sql = subst_params ([static " ( "] @ List.rev(static (String.slice ~first:last ~last:c2 s) :: acc)  @ [static " ) "]) in
           let ctor = Sql.{ value=Some("Some"); pos=(0, 0); } in
           let args = Some(vars) in
           {ctor; args; sql; is_poly=false} in
@@ -174,16 +180,16 @@ let substitute_vars s vars subst_param =
           {ctor; args; sql=[sql]; is_poly=false} in
         [s_choice; n]
       in
-      let acc = Dynamic (name, pieces) :: Static (String.slice ~first:i ~last:f1 s) :: acc in
-       loop s acc f2 parami tl
+      let acc = `Sql (Dynamic (name, pieces)) :: static (String.slice ~first:i ~last:f1 s) :: acc in
+       loop s acc f2 tl
     | SharedVarsGroup (shared_vars, id) :: tl ->
         let (i1,i2) = id.pos in
         assert (i2 > i1);
         assert (i1 > i);
         let shared_sql, (_: Sql.select_full) = Shared_queries.get id.value in
-        let raw_processed, parami = loop_and_squash ~parami shared_sql shared_vars in
-        let processed_shared = [Static "("] @ raw_processed @ [Static ")"] in
-        loop s (List.rev processed_shared @ Static (String.slice ~first:i ~last:i1 s) :: acc) i2 parami tl
+        let raw_processed = loop_all shared_sql shared_vars in
+        let processed_shared = [static "("] @ raw_processed @ [static ")"] in
+        loop s (List.rev processed_shared @ static (String.slice ~first:i ~last:i1 s) :: acc) i2 tl
     | DynamicSelect (name,ctors) :: tl ->
       let dyn = ctors |> List.map begin function
         | Sql.Simple (ctor, args) ->
@@ -191,8 +197,8 @@ let substitute_vars s vars subst_param =
           let sql = match args with
             | None | Some [] -> [Static (String.slice ~first:c1 ~last:c2 s)]
             | Some l ->
-              let (acc, last, _) = loop s [] (c1 - 1) 0 l in
-              let pieces = List.rev (Static (String.slice ~first:last ~last:c2 s) :: acc) in
+              let (acc, last) = loop s [] (c1 - 1) l in
+              let pieces = subst_params (List.rev (static (String.slice ~first:last ~last:c2 s) :: acc)) in
               begin match pieces with
               | Static hd :: rest -> Static (String.slice ~first:1 hd) :: rest
               | _ -> pieces
@@ -205,8 +211,8 @@ let substitute_vars s vars subst_param =
       let (i1,i2) = name.pos in
       assert (i2 > i1);
       assert (i1 > i);
-      let acc = Dynamic (name, dyn) :: Static (String.slice ~first:i ~last:i1 s) :: acc in
-      loop s acc i2 parami tl
+      let acc = `Sql (Dynamic (name, dyn)) :: static (String.slice ~first:i ~last:i1 s) :: acc in
+      loop s acc i2 tl
   and process_ctors ~is_poly s i ctors =
     ctors |> List.map begin function
       | Sql.Simple (ctor, args) ->
@@ -217,25 +223,26 @@ let substitute_vars s vars subst_param =
           match args with
           | None -> [Static ""]
           | Some l ->
-            let (acc, last, _) = loop s [] c1 0 l in
-            let body = List.rev (Static (String.slice ~first:last ~last:c2 s) :: acc) in
-            squash [] ((Static " (" :: body) @ [Static ") "])
+            let (acc, last) = loop s [] c1 l in
+            let body = List.rev (static (String.slice ~first:last ~last:c2 s) :: acc) in
+            squash [] (subst_params ((static " (" :: body) @ [static ") "]))
         in
         { ctor; sql; args; is_poly }
       | Verbatim (n, v) ->
         { ctor = { value = Some n; pos = (0,0) }; args = Some []; sql = [Static v]; is_poly }
     end
-  and loop_and_squash ?(parami=0) sql vars =
-    let acc, last, parami = loop sql [] 0 parami vars in
-    let acc = List.rev (Static (String.slice ~first:last sql) :: acc) in
-    squash [] acc, parami
+  and loop_all sql vars =
+    let acc, last = loop sql [] 0 vars in
+    List.rev (static (String.slice ~first:last sql) :: acc)
+  and loop_and_squash sql vars =
+    squash [] (subst_params (loop_all sql vars))
   and squash acc = function
     | [] -> List.rev acc
     | Static "" :: tl -> squash acc tl
     | Static s1 :: Static s2 :: tl -> squash acc (Static (s1 ^ s2) :: tl)
     | x::xs -> squash (x::acc) xs
   in
-  fst (loop_and_squash s vars)
+  loop_and_squash s vars
 
 let subst_named index p = "@" ^ (show_param_name p index)
 let subst_oracle index p = ":" ^ (show_param_name p index)

--- a/test/cram/reusable_queries_postgresql_params.t
+++ b/test/cram/reusable_queries_postgresql_params.t
@@ -42,7 +42,7 @@ PostgreSQL parameter numbering in reusable queries, distinct parameters:
   SELECT *\n\
   FROM \"user\"\n\
   JOIN person ON person.user_id = \"user\".id\n\
-  WHERE \"user\".id > $1") set_params invoke_callback
+  WHERE \"user\".id > $2") set_params invoke_callback
 
 PostgreSQL parameter numbering in reusable queries, shared parameter:
 
@@ -97,8 +97,8 @@ PostgreSQL parameter numbering in reusable queries, shared parameter:
   FROM \"user\"\n\
   JOIN person ON person.user_id = \"user\".id\n\
   WHERE\n\
-    username LIKE $1\n\
-    AND \"user\".id > $2") set_params invoke_callback
+    username LIKE $3\n\
+    AND \"user\".id > $4") set_params invoke_callback
 
 PostgreSQL parameter numbering with two reusable queries in one outer query:
 
@@ -135,10 +135,10 @@ PostgreSQL parameter numbering with two reusable queries in one outer query:
         T.set_param_Int p min_id;
         T.finish_params p
       in
-      T.select db ("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $1)\n\
+      T.select db ("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $2)\n\
   SELECT p.id, a.username\n\
   FROM p JOIN a ON a.id = p.user_id\n\
-  WHERE p.id > $1") set_params invoke_callback
+  WHERE p.id > $3") set_params invoke_callback
 
 PostgreSQL parameter numbering with reusable queries threaded into each other:
 
@@ -172,5 +172,5 @@ PostgreSQL parameter numbering with reusable queries threaded into each other:
         T.finish_params p
       in
       T.select db ("WITH p AS (WITH inner_p AS (SELECT * FROM person WHERE name LIKE $1)\n\
-  SELECT * FROM inner_p WHERE inner_p.id > $1)\n\
-  SELECT * FROM p WHERE p.user_id > $1") set_params invoke_callback
+  SELECT * FROM inner_p WHERE inner_p.id > $2)\n\
+  SELECT * FROM p WHERE p.user_id > $3") set_params invoke_callback

--- a/test/cram/reusable_queries_postgresql_params.t
+++ b/test/cram/reusable_queries_postgresql_params.t
@@ -1,0 +1,176 @@
+PostgreSQL parameter numbering in reusable queries, distinct parameters:
+
+  $ sqlgg -no-header -gen caml -params postgresql -dialect postgresql - <<'EOF' 2>/dev/null | awk '/^  let get_users/{p=1} p&&/^$/{exit} p{print}'
+  > CREATE TABLE person (
+  >     id INT PRIMARY KEY,
+  >     user_id INT NOT NULL,
+  >     name TEXT NOT NULL
+  > );
+  > CREATE TABLE "user" (
+  >     id INT PRIMARY KEY,
+  >     username TEXT NOT NULL
+  > );
+  > -- @get_persons | include: reuse
+  > SELECT *
+  > FROM person
+  > WHERE name LIKE @name;
+  > -- @get_users
+  > WITH person AS &get_persons
+  > SELECT *
+  > FROM "user"
+  > JOIN person ON person.user_id = "user".id
+  > WHERE "user".id > @min_id;
+  > EOF
+    let get_users db ~name ~min_id callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~username:(T.get_column_Text stmt 1)
+          ~id0:(T.get_column_Int stmt 2)
+          ~user_id:(T.get_column_Int stmt 3)
+          ~name:(T.get_column_Text stmt 4)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_Text p name;
+        T.set_param_Int p min_id;
+        T.finish_params p
+      in
+      T.select db ("WITH person AS (SELECT *\n\
+  FROM person\n\
+  WHERE name LIKE $1)\n\
+  SELECT *\n\
+  FROM \"user\"\n\
+  JOIN person ON person.user_id = \"user\".id\n\
+  WHERE \"user\".id > $1") set_params invoke_callback
+
+PostgreSQL parameter numbering in reusable queries, shared parameter:
+
+  $ sqlgg -no-header -gen caml -params postgresql -dialect postgresql - <<'EOF' 2>/dev/null | awk '/^  let get_users/{p=1} p&&/^$/{exit} p{print}'
+  > CREATE TABLE person (
+  >     id INT PRIMARY KEY,
+  >     user_id INT NOT NULL,
+  >     name TEXT NOT NULL
+  > );
+  > CREATE TABLE "user" (
+  >     id INT PRIMARY KEY,
+  >     username TEXT NOT NULL
+  > );
+  > -- @get_persons | include: reuse
+  > SELECT *
+  > FROM person
+  > WHERE
+  >   name LIKE @name
+  >   AND person.id > @min_id;
+  > -- @get_users
+  > WITH person AS &get_persons
+  > SELECT *
+  > FROM "user"
+  > JOIN person ON person.user_id = "user".id
+  > WHERE
+  >   username LIKE @username
+  >   AND "user".id > @min_id;
+  > EOF
+    let get_users db ~name ~username ~min_id callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~username:(T.get_column_Text stmt 1)
+          ~id0:(T.get_column_Int stmt 2)
+          ~user_id:(T.get_column_Int stmt 3)
+          ~name:(T.get_column_Text stmt 4)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (4) in
+        T.set_param_Text p name;
+        T.set_param_Int p min_id;
+        T.set_param_Text p username;
+        T.set_param_Int p min_id;
+        T.finish_params p
+      in
+      T.select db ("WITH person AS (SELECT *\n\
+  FROM person\n\
+  WHERE\n\
+    name LIKE $1\n\
+    AND person.id > $2)\n\
+  SELECT *\n\
+  FROM \"user\"\n\
+  JOIN person ON person.user_id = \"user\".id\n\
+  WHERE\n\
+    username LIKE $1\n\
+    AND \"user\".id > $2") set_params invoke_callback
+
+PostgreSQL parameter numbering with two reusable queries in one outer query:
+
+  $ sqlgg -no-header -gen caml -params postgresql -dialect postgresql - <<'EOF' 2>/dev/null | awk '/^  let two_ctes/{p=1} p&&/^$/{exit} p{print}'
+  > CREATE TABLE person (
+  >     id INT PRIMARY KEY,
+  >     user_id INT NOT NULL,
+  >     name TEXT NOT NULL
+  > );
+  > CREATE TABLE "user" (
+  >     id INT PRIMARY KEY,
+  >     username TEXT NOT NULL
+  > );
+  > -- @get_persons | include: reuse
+  > SELECT * FROM person WHERE name LIKE @name;
+  > -- @get_admins | include: reuse
+  > SELECT * FROM "user" WHERE username LIKE @admin;
+  > -- @two_ctes
+  > WITH p AS &get_persons, a AS &get_admins
+  > SELECT p.id, a.username
+  > FROM p JOIN a ON a.id = p.user_id
+  > WHERE p.id > @min_id;
+  > EOF
+    let two_ctes db ~name ~admin ~min_id callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~username:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (3) in
+        T.set_param_Text p name;
+        T.set_param_Text p admin;
+        T.set_param_Int p min_id;
+        T.finish_params p
+      in
+      T.select db ("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $1)\n\
+  SELECT p.id, a.username\n\
+  FROM p JOIN a ON a.id = p.user_id\n\
+  WHERE p.id > $1") set_params invoke_callback
+
+PostgreSQL parameter numbering with reusable queries threaded into each other:
+
+  $ sqlgg -no-header -gen caml -params postgresql -dialect postgresql - <<'EOF' 2>/dev/null | awk '/^  let outer_q/{p=1} p&&/^$/{exit} p{print}'
+  > CREATE TABLE person (
+  >     id INT PRIMARY KEY,
+  >     user_id INT NOT NULL,
+  >     name TEXT NOT NULL
+  > );
+  > -- @get_persons | include: reuse
+  > SELECT * FROM person WHERE name LIKE @name;
+  > -- @wrap_persons | include: reuse
+  > WITH inner_p AS &get_persons
+  > SELECT * FROM inner_p WHERE inner_p.id > @inner_min;
+  > -- @outer_q
+  > WITH p AS &wrap_persons
+  > SELECT * FROM p WHERE p.user_id > @outer_min;
+  > EOF
+    let outer_q db ~name ~inner_min ~outer_min callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~user_id:(T.get_column_Int stmt 1)
+          ~name:(T.get_column_Text stmt 2)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (3) in
+        T.set_param_Text p name;
+        T.set_param_Int p inner_min;
+        T.set_param_Int p outer_min;
+        T.finish_params p
+      in
+      T.select db ("WITH p AS (WITH inner_p AS (SELECT * FROM person WHERE name LIKE $1)\n\
+  SELECT * FROM inner_p WHERE inner_p.id > $1)\n\
+  SELECT * FROM p WHERE p.user_id > $1") set_params invoke_callback


### PR DESCRIPTION
When a reusable query (`-- @foo | include: reuse`) is spliced into an outer query as a CTE via `WITH x AS &ref`, the reused query's parameters and the outer query's parameters end up in a single generated statement, bound positionally by `set_params`.

With `-params postgresql`, the positional counter was reset to `0` for the spliced fragment and left unchanged when the outer query resumed, so both fragments numbered their `$N` placeholders starting from `$1`. The outer parameters therefore collided with the reused ones. Example:

``` sql
-- @get_persons | include: reuse
SELECT * FROM person WHERE name LIKE @name;

-- @get_users 
WITH person AS &get_persons
SELECT * FROM "user" JOIN person ON person.user_id = "user".id
WHERE "user".id > @min_id;
```

On such an input, `-params postgresql` generated:

``` sql
WITH person AS (... WHERE name LIKE $1)
SELECT ... WHERE "user".id > $1
```

Note the `$1` used twice.

(This was actually caught by PostgreSQL because `set_params` still supplies a value for every position, so I got “bind message supplies N parameters, but prepared statement requires M”.)

I checked this only affects the `postgresql` parameter style; others use names (`named` and `oracle`) or use positional `?` (`unnamed`).

A first commit adds tests exhibiting this behaviour; a second threads the positional counter through the shared-query splice in `substitute_vars`.