### PR TITLE
Support shared `Choices` expr and make Dynamic select compose with `CTE` and `IN` exprs

### DIFF
--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -277,12 +277,13 @@ let dynamic_allowed env =
   | Top_level | From_passthrough -> true
   | Subquery -> false
 
+let dynamic_col_param_name = "col"
+
 let make_dynamic_select ~env columns =
   if not (dynamic_allowed env) then
     columns
   else
     let module S = Set.Make(String) in
-    let dynamic_col_param_name = "col" in
     let unique_name used base =
       if not (S.mem base used) then
         base
@@ -1402,7 +1403,7 @@ and eval_select_full env { select_complete; cte } =
 and eval_cte { cte_items; is_recursive } = 
   let open Schema.Source in
   List.fold_left begin fun (acc_ctes, acc_vars) cte ->
-    let env = { empty_env with ctes = acc_ctes } in
+    let env = { empty_env with ctes = acc_ctes; scope = Subquery } in
     let tbl_name = make_table_name cte.cte_name in
     let a1 = List.map (fun attr -> Attr.{ sources = []; attr }) in
     let s1, p1, _kind =
@@ -1848,50 +1849,131 @@ let rec eval (stmt:Sql.stmt) =
      User_types.drop ~if_exists name;
      ([], [], DropType name)
 
+type var_shape =
+  | Shape_param
+  | Shape_in_param
+  | Shape_tuple of string option
+  | Shape_choice_in of { param : string option; kind : in_or_not_in; vars : var_shape list }
+  | Shape_opt_choice of string option * var_shape list
+  | Shape_shared_group of string * var_shape list
+  | Shape_choice of string option * ctor_shape list
+  | Shape_dyn_select of string option * ctor_shape list
+  | Shape_dyn_join of string option
+and ctor_shape =
+  | Shape_simple of string option * var_shape list
+  | Shape_verbatim of string
+
+let rec var_shape = function
+  | Single _ -> Shape_param
+  | SingleIn _ -> Shape_in_param
+  | TupleList (id, _) -> Shape_tuple id.value
+  | ChoiceIn { param; kind; vars } -> Shape_choice_in { param = param.value; kind; vars = List.map var_shape vars }
+  | OptionActionChoice (id, vars, _, _) -> Shape_opt_choice (id.value, List.map var_shape vars)
+  | SharedVarsGroup (vars, id) -> Shape_shared_group (id.value, List.map var_shape vars)
+  | Choice (id, cs) -> Shape_choice (id.value, List.map ctor_shape cs)
+  | DynamicSelect (id, cs) -> Shape_dyn_select (id.value, List.map ctor_shape cs)
+  | DynamicSelectJoin { pid; _ } -> Shape_dyn_join pid.value
+and ctor_shape = function
+  | Simple (p, args) -> Shape_simple (p.value, List.map var_shape (Option.default [] args))
+  | Verbatim (n, _) -> Shape_verbatim n
+
+module Var_unifier : sig
+  type t
+  val create : unit -> t
+  val note : t -> string -> Type.t -> unit
+  val alias : t -> string -> string -> unit
+  val typ : t -> string -> default:Type.t -> Type.t
+end = struct
+  type node = { name : string; mutable state : state }
+  and state = Root of Type.t option | Link of node
+
+  type t = (string, node) Hashtbl.t
+
+  let create () = Hashtbl.create 10
+
+  let node t name =
+    match Hashtbl.find_opt t name with
+    | Some n -> n
+    | None -> let n = { name; state = Root None } in Hashtbl.add t name n; n
+
+  let rec root n =
+    match n.state with
+    | Root typ -> n, typ
+    | Link p -> let (r, _) as res = root p in if r != p then n.state <- Link r; res
+
+  let unify name t1 t2 =
+    match Type.common_type t1 t2 with
+    | Some x ->
+      if !Config.debug then eprintfn "unify var %s %s %s => %s" name (Type.show t1) (Type.show t2) (Type.show x);
+      x
+    | None -> fail "incompatible types for parameter %S : %s and %s" name (Type.show t1) (Type.show t2)
+
+  let note t name typ =
+    let (r, existing) = root (node t name) in
+    r.state <- Root (Some (Option.map_default (unify name typ) typ existing))
+
+  let alias t n1 n2 =
+    let (r1, _) = root (node t n1) in
+    let (r2, t2) = root (node t n2) in
+    if r1 != r2 then begin
+      Option.may (note t r1.name) t2;
+      r2.state <- Link r1
+    end
+
+  let typ t name ~default =
+    Stdlib.Option.bind (Hashtbl.find_opt t name) (snd $ root)
+    |> Option.default default
+end
+
 (* FIXME unify each choice separately *)
 let unify_params l =
   if !Config.debug then l |> List.iter (fun p -> eprintfn "var %s" (show_var p));
-  let h = Hashtbl.create 10 in
-  let h_choices = Hashtbl.create 10 in
-  let check_choice_name ~sharing_disabled p =
+  let unifier = Var_unifier.create () in
+  let choices = Hashtbl.create 10 in
+  let rec bound_names vars =
+    vars |> List.concat_map (function
+      | Single (p, _) | SingleIn (p, _) -> [p.id.value]
+      | v -> bound_names (sub_vars v))
+  in
+  let register p signature =
     match p.value with
-    | None -> () (* unique *)
-    | Some n when sharing_disabled && Hashtbl.mem h_choices n -> failed ~at:p.pos "sharing choices not implemented"
-    | Some n -> Hashtbl.add h_choices n ()
-  in
-  let remember name t =
-    match name with
     | None -> () (* anonymous ie non-shared *)
-    | Some name ->
-    match Hashtbl.find h name with
-    | exception _ -> Hashtbl.add h name t
-    | t' ->
-    match Type.common_type t t' with
-    | Some x ->
-      if !Config.debug then eprintfn "unify var %s %s %s => %s" name (Type.show t) (Type.show t') (Type.show x);
-      Hashtbl.replace h name x
-    | None -> fail "incompatible types for parameter %S : %s and %s" name (Type.show t) (Type.show t')
+    | Some n ->
+    match Hashtbl.find_opt choices n, signature with
+    | None, _ -> Hashtbl.add choices n signature
+    | Some (`Branches (s1, names1)), `Branches (s2, names2) when s1 = s2 ->
+      List.iter2 (fun n1 n2 -> match n1, n2 with Some n1, Some n2 -> Var_unifier.alias unifier n1 n2 | _ -> ()) names1 names2
+    | Some (`Branches _), `Branches _ -> failed ~at:p.pos "choice %s is used several times with different branches" n
+    | Some `Dynamic, `Dynamic -> failed ~at:p.pos "dynamic select %s occurs several times in one statement (not supported)" n
+    | Some `Dynamic, `Branches _ | Some (`Branches _), `Dynamic ->
+      if n = dynamic_col_param_name then
+        failed ~at:p.pos "dynamic_select reserves the name %s for the column picker, rename choice %s" n n
+      else
+        failed ~at:p.pos "parameter %s is ambiguous : used as both choice and dynamic select" n
   in
-  let rec traverse var =
-    match var with
-    | Single ({ id; typ; }, _)
-    | SingleIn ({ id; typ; _ }, _) -> remember id.value typ
-    | Choice (p, _) | DynamicSelect (p, _) ->
-      check_choice_name ~sharing_disabled:true p;
-      List.iter traverse (sub_vars var)
-    | _ -> List.iter traverse (sub_vars var)
+  let rec collect var =
+    begin match var with
+    | Single ({ id; typ; _ }, _) | SingleIn ({ id; typ; _ }, _) ->
+      Option.may (fun name -> Var_unifier.note unifier name typ) id.value
+    | Choice (p, ctors) ->
+      register p (`Branches (List.map ctor_shape ctors, bound_names (List.concat_map ctor_vars ctors)))
+    | DynamicSelect (p, _) -> register p `Dynamic
+    | TupleList _ | ChoiceIn _ | OptionActionChoice _ | SharedVarsGroup _ | DynamicSelectJoin _ -> ()
+    end;
+    List.iter collect (sub_vars var)
   in
-  let rec map = function
-  | Single ({ id; typ; }, m) ->
-    let typ = match id.value with None -> typ | Some name -> try Hashtbl.find h name with _ -> assert false in
-    Single (make_param ~id ~typ:(Type.undepend typ Strict), m) (* if no other clues - input parameters are strict *)
-  | SingleIn ({ id; typ; }, m) ->
-    let typ = match id.value with None -> typ | Some name -> try Hashtbl.find h name with _ -> assert false in
-    SingleIn (make_param ~id ~typ:(Type.undepend typ Strict), m) (* if no other clues - input parameters are strict *)
-  | v -> map_sub_vars (List.map map) v
+  (* if no other clues - input parameters are strict *)
+  let final { id; typ; _ } =
+    let typ = Option.map_default (Var_unifier.typ unifier ~default:typ) typ id.value in
+    make_param ~id ~typ:(Type.undepend typ Strict)
   in
-  List.iter traverse l;
-  List.map map l
+  let rec rewrite = function
+    | Single (p, m) -> Single (final p, m)
+    | SingleIn (p, m) -> SingleIn (final p, m)
+    | v -> map_sub_vars (List.map rewrite) v
+  in
+  List.iter collect l;
+  List.map rewrite l
 
 let is_alpha = function
 | 'a'..'z' -> true

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -89,14 +89,10 @@ let idents ~prefix l =
     let name = sprintf "%s%d" base n in
     if List.mem name acc then choose acc base (n+1) else name
   in
-  let rec loop acc = function
-  | [] -> List.rev acc
-  | x::xs ->
+  List.fold_left (fun acc x ->
     let x = ident ~prefix x in
-    let x = if List.mem x acc then choose acc x 0 else x in
-    loop (x::acc) xs
-  in
-  loop [] l
+    (if List.mem x acc then choose acc x 0 else x) :: acc) [] l
+  |> List.rev
 
 end
 
@@ -114,8 +110,7 @@ let rec replace_all ~str ~sub ~by =
   | (false,s) -> s
 
 let quote_comment_inline str =
-  let str = replace_all ~str ~sub:"*)" ~by:"* )" in
-  replace_all ~str ~sub:"(*" ~by:"( *"
+  List.fold_left (fun str (sub, by) -> replace_all ~str ~sub ~by) str ["*)", "* )"; "(*", "( *"]
 
 let make_comment str = "(* " ^ (quote_comment_inline str) ^ " *)"
 let comment () fmt = Printf.ksprintf (indent_endline $ make_comment) fmt
@@ -155,22 +150,13 @@ type scoped_field = {
 module L = struct
   open Type
 
-  let as_lang_type = function
-  | { t = Blob; nullability } -> type_name { t = Text; nullability }
-  | { t = StringLiteral _; nullability } -> type_name { t = Text; nullability }
-  | { t = FloatingLiteral _; nullability } -> type_name { t = Float; nullability }
-  | { t = Decimal _; nullability; } -> type_name { t = Decimal { precision = None; scale = None }; nullability } 
-  | { t = Int; _ }
-  | { t = Text; _ }
-  | { t = Float; _ }
-  | { t = Bool; _ }
-  | { t = Datetime; _ }
-  | { t = Union _; _ }
-  | { t = Json; _ }
-  | { t = Json_path; _ }
-  | { t = One_or_all; _ }
-  | { t = UInt64; _ }
-  | { t = Any; _ } as t -> type_name t
+  let as_lang_type t =
+    type_name @@
+    match t with
+    | { t = Blob; nullability } | { t = StringLiteral _; nullability } -> { t = Text; nullability }
+    | { t = FloatingLiteral _; nullability } -> { t = Float; nullability }
+    | { t = Decimal _; nullability } -> { t = Decimal { precision = None; scale = None }; nullability }
+    | t -> t
 
   let as_runtime_repr_name = function
   | { t = Blob; _ }
@@ -201,21 +187,30 @@ let codec_get_column, codec_set_param =
   in
   codec "get_column", codec "set_param"
 
+type codec_impl =
+  | Custom_codec of string
+  | Enum_codec of string
+  | Builtin_codec of Type.t
+let resolve_codec find typ meta =
+  match find meta with
+  | Some f -> Custom_codec f
+  | None ->
+    match typ.Type.t with
+    | Union { ctors; _ } -> Enum_codec (get_enum_name ctors)
+    | _ -> Builtin_codec typ
+
 let format_get_column ~row ~idx attr =
   let null_suffix = if is_attr_nullable attr then "_nullable" else "" in
   let format_t_get_column type_name =
     sprintf "T.get_column_%s%s %s %s" type_name null_suffix row idx
   in
-  match codec_get_column attr.meta with
-  | Some getter ->
-      sprintf "%s%s (%s)" getter null_suffix (format_t_get_column (L.as_runtime_repr_name attr.domain))
-  | None ->
-      begin match attr.domain with
-      | { t = Union { ctors; _ }; _ } ->
-          sprintf "%s.get_column%s %s %s" (get_enum_name ctors) null_suffix row idx
-      | _ ->
-          format_t_get_column (L.as_lang_type attr.domain)
-      end
+  match resolve_codec codec_get_column attr.domain attr.meta with
+  | Custom_codec getter ->
+    sprintf "%s%s (%s)" getter null_suffix (format_t_get_column (L.as_runtime_repr_name attr.domain))
+  | Enum_codec m ->
+    sprintf "%s.get_column%s %s %s" m null_suffix row idx
+  | Builtin_codec t ->
+    format_t_get_column (L.as_lang_type t)
 
 let get_column index attr =
   sprintf "(%s)" (format_get_column ~row:"stmt" ~idx:(string_of_int index) attr)
@@ -233,26 +228,24 @@ let schema_to_attrs schema =
 
 let format_labeled_param name value = sprintf "~%s:%s" name value
 
-let output_schema_binder_labeled _ schema =
-  let attrs = schema_to_attrs schema in
-  let name = "invoke_callback" in
+let emit_row_binder name emit_body =
   output "let %s stmt =" name;
-  let args = idents_of_attrs ~prefix:"r" attrs in
-  let values = List.mapi get_column attrs in
-  indented (fun () ->
-    output "callback";
-    indented (fun () -> List.iter2 (fun arg value -> output "%s" (format_labeled_param arg value)) args values));
+  indented emit_body;
   output "in";
   name
 
+let output_schema_binder_labeled _ schema =
+  let attrs = schema_to_attrs schema in
+  let args = idents_of_attrs ~prefix:"r" attrs in
+  let values = List.mapi get_column attrs in
+  emit_row_binder "invoke_callback" (fun () ->
+    output "callback";
+    indented (fun () -> List.iter2 (fun arg value -> output "%s" (format_labeled_param arg value)) args values))
+
 let output_select1_cb _ schema =
   let attrs = schema_to_attrs schema in
-  let name = "get_row" in
-  output "let %s stmt =" name;
-  indented (fun () ->
-    List.mapi get_column attrs |> String.concat ", " |> indent_endline);
-  output "in";
-  name
+  emit_row_binder "get_row" (fun () ->
+    List.mapi get_column attrs |> String.concat ", " |> indent_endline)
 
 let select_func_of_kind = function
 | Stmt.Select `Zero_one -> "select_one_maybe"
@@ -282,17 +275,12 @@ let supports_module_kind module_kind stmt =
   | `Single -> is_single_row_select stmt
   | `Direct -> true
 
-let emit_module_body name body =
+let emit_module ?(annotate = false) name body =
   output "module %s = struct" name;
-  indented body
+  indented body;
+  if annotate then output "end (* module %s *)" name else output "end"
 
-let emit_module name body =
-  emit_module_body name body;
-  output "end"
-
-let emit_module_annotated name body =
-  emit_module_body name body;
-  output "end (* module %s *)" name
+let emit_module_annotated = emit_module ~annotate:true
 
 let emit_module_kind_variants stmt emit =
   [`Fold; `List] |> List.iter (fun module_kind ->
@@ -330,12 +318,15 @@ let emit_func_header ~name ~extra_params ~has_callback ~format_input ~module_kin
   inc_indent ();
   subst
 
+let format_func_input ~dyn_annot dynamic_names v =
+  if List.mem v dynamic_names then sprintf "(%s : %s)" v (dyn_annot v)
+  else sprintf "~%s" v
+
 let gen_func_signature ~dynamic_infos ~module_kind ~index stmt =
   let dynamic_map = List.map (fun di -> (di.param_name, di.module_name)) dynamic_infos in
-  let dyn_annot module_name = sprintf "_ %s.t" module_name in
-  let format_input v =
-    List.assoc_opt v dynamic_map
-    |> Option.map_default (fun module_name -> sprintf "(%s : %s)" v (dyn_annot module_name)) (sprintf "~%s" v)
+  let format_input =
+    format_func_input (List.map fst dynamic_map)
+      ~dyn_annot:(fun v -> sprintf "_ %s.t" (List.assoc v dynamic_map))
   in
   emit_func_header
     ~name:(choose_name stmt.props stmt.kind index |> String.uncapitalize_ascii)
@@ -343,26 +334,34 @@ let gen_func_signature ~dynamic_infos ~module_kind ~index stmt =
     ~has_callback:(has_row_callback stmt || (module_kind = `Single && dynamic_infos = []))
     ~format_input ~module_kind stmt
 
-let output_r_acc_init = function
-  | `Fold -> output "let r_acc = ref acc in"
-  | `List -> output "let r_acc = ref [] in"
-  | `Direct | `Single -> ()
+type consumer = {
+  c_init : unit -> unit;
+  c_bind : string * string;
+  c_callback : direct:string -> fold:string -> list:string -> string;
+  c_finish : unit -> unit;
+}
 
-let output_r_acc_return = function
-  | `Fold -> output "(fun () -> IO.return !r_acc)"
-  | `List -> output "(fun () -> IO.return (List.rev !r_acc))"
-  | `Direct | `Single -> ()
+let consumer = function
+  | `Direct | `Single ->
+    { c_init = (fun () -> ());
+      c_bind = ("", "");
+      c_callback = (fun ~direct ~fold:_ ~list:_ -> direct);
+      c_finish = (fun () -> ()) }
+  | `Fold ->
+    { c_init = (fun () -> output "let r_acc = ref acc in");
+      c_bind = ("IO.(>>=) (", ")");
+      c_callback = (fun ~direct:_ ~fold ~list:_ -> fold);
+      c_finish = (fun () -> output "(fun () -> IO.return !r_acc)") }
+  | `List ->
+    { c_init = (fun () -> output "let r_acc = ref [] in");
+      c_bind = ("IO.(>>=) (", ")");
+      c_callback = (fun ~direct:_ ~fold:_ ~list -> list);
+      c_finish = (fun () -> output "(fun () -> IO.return (List.rev !r_acc))") }
 
-let complete_func module_kind =
-  output_r_acc_return module_kind;
+let complete_func c =
+  c.c_finish ();
   dec_indent ();
   empty_line ()
-
-let module_kind_consumer module_kind ~direct ~fold ~list =
-  match module_kind with
-  | `Fold -> "IO.(>>=) (", ")", fold
-  | `List -> "IO.(>>=) (", ")", list
-  | `Direct | `Single -> "", "", direct
 
 let make_variant_name i name ~is_poly =
   let prefix = if is_poly then "`" else "" in 
@@ -415,23 +414,18 @@ let match_variant_pattern i name args ~is_poly =
 let set_param ~meta index param =
   let nullable = is_param_nullable param in
   let pname = show_param_name param index in
-  let ptype = show_param_type param in
   let set_param_nullable v r = output "begin match %s with None -> T.set_param_null p | Some %s -> %s end;" pname v r in
-  match codec_set_param meta with
-  | Some setter ->
+  match resolve_codec codec_set_param param.typ meta with
+  | Custom_codec setter ->
       let set = sprintf "T.set_param_%s p (%s %s);" (L.as_runtime_repr_name param.typ) setter pname in
       if nullable then set_param_nullable pname set else output "%s" set
-  | None ->
-      match param with
-      | { typ = { t=(Union { ctors; _ }); _ }; _ } when nullable ->
-          set_param_nullable "v" @@ (get_enum_name ctors) ^ ".set_param p v"
-      | { typ = { t=(Union { ctors; _ }); _ }; _ } ->
-          output "%s.set_param p %s;" (get_enum_name ctors) pname
-      | param' ->
-          if nullable then
-            set_param_nullable "v" @@ sprintf "T.set_param_%s %s" (show_param_type param') "p v"
-          else
-            output "T.set_param_%s p %s;" ptype pname
+  | Enum_codec m ->
+      if nullable then set_param_nullable "v" (m ^ ".set_param p v")
+      else output "%s.set_param p %s;" m pname
+  | Builtin_codec t ->
+      let ptype = show_param_type { param with typ = t } in
+      if nullable then set_param_nullable "v" (sprintf "T.set_param_%s p v" ptype)
+      else output "T.set_param_%s p %s;" ptype pname
 
 type var_class =
   | Bound_param of Sql.Type.t Sql.param * Sql.Meta.t
@@ -464,23 +458,20 @@ let rec has_set_params vars =
 let set_var index var =
   let execute_generators = List.iter (fun f -> f ()) in
   let with_indent action = inc_indent (); action (); dec_indent () in
+  let unless_empty gens use = if gens = [] then None else Some (fun () -> use gens) in
 
   let rec filter_generators index vars = List.filter_map (aux index) vars
-  
-  and aux index var = 
+
+  and aux index var =
     match classify_var var with
     | Bound_param (p, meta) ->
       Some (fun () -> set_param ~meta index p)
     | Substituted | No_params ->
       None
     | Shared_group vars ->
-      let generators = filter_generators index vars in
-      if generators = [] then None
-      else Some (fun () -> execute_generators generators)
+      unless_empty (filter_generators index vars) execute_generators
     | Where_in_group (param, vars) ->
-      let generators = filter_generators index vars in
-      if generators = [] then None
-      else Some (fun () ->
+      unless_empty (filter_generators index vars) (fun generators ->
         output "begin match %s with" (make_param_name index param);
         output "| [] -> ()";
         output "| _ :: _ ->";
@@ -488,31 +479,25 @@ let set_var index var =
           execute_generators generators;
           output "()"
         );
-        output "end;"
-      )
+        output "end;")
     | Option_group (name, vars) ->
-      let generators = filter_generators index vars in
-      if generators = [] then None
-      else Some (fun () ->
-        let seen = Hashtbl.create 16 in
-        let patterns = ref [] in
-        List.iter (fun var ->
-          let use_var = match var with
-            | Single ({ id; _ }, _) | SingleIn ({id; _}, _) | TupleList (id, _) ->
-              (match id.value with
-               | Some name when Hashtbl.mem seen name -> false
-               | Some name -> Hashtbl.add seen name (); true  
-               | None -> true)
-            | _ -> true
-          in
-          if use_var then
-            let pattern = match aux index var with
-              | Some _ -> List.hd (names_of_vars [var])
-              | None -> "_"
+      unless_empty (filter_generators index vars) (fun generators ->
+        let patterns =
+          List.fold_left (fun (seen, acc) var ->
+            let bind_name = match var with
+              | Single ({ id; _ }, _) | SingleIn ({ id; _ }, _) | TupleList (id, _) -> id.value
+              | _ -> None
             in
-            patterns := pattern :: !patterns
-        ) vars;
-        let param_pattern = match List.rev !patterns with
+            match bind_name with
+            | Some n when List.mem n seen -> (seen, acc)
+            | _ ->
+              let seen = Option.map_default (fun n -> n :: seen) seen bind_name in
+              let pattern = if Option.is_some (aux index var) then List.hd (names_of_vars [var]) else "_" in
+              (seen, pattern :: acc)
+          ) ([], []) vars
+          |> snd |> List.rev
+        in
+        let param_pattern = match patterns with
           | [single] -> single
           | many -> "(" ^ String.concat ", " many ^ ")"
         in
@@ -520,63 +505,34 @@ let set_var index var =
         output "| None -> ()";
         output "| Some %s ->" param_pattern;
         with_indent (fun () -> execute_generators generators);
-        output "end;"
-      )
+        output "end;")
     | Choice_group (name, ctors) ->
-      let unit_branches = ref [] in
-      let generator_branches = ref [] in
-      let has_content = ref false in
-      
-      List.iteri (fun i ctor ->
-        match ctor with
-        | Simple (param, args) ->
-          let args_list = Option.default [] args in
-          let inner_generators = filter_generators index args_list in
-          let branch_has_content = inner_generators <> [] in
-          if branch_has_content then has_content := true;
-          
-          let pattern_args = 
-            match args, branch_has_content with
-            | (Some [] | None), false -> ""
-            | (Some [] | None), true ->
-              (match param.value with Some n -> " " ^ n | None -> "")
-            | Some _, false -> " _"
-            | Some l, true -> 
-              " (" ^ String.concat "," (names_of_vars l) ^ ")"
-          in
-          let variant_name = 
-            make_variant_name i param.value ~is_poly:true 
-          in
-          
-          if branch_has_content then
-            generator_branches := (fun () ->
-              output "| %s%s ->" variant_name pattern_args;
-              inc_indent ();
-              execute_generators inner_generators;
-              dec_indent ()
-            ) :: !generator_branches
-          else
-            unit_branches := (fun () ->
-              output "| %s%s -> ()" variant_name pattern_args
-            ) :: !unit_branches
-
+      let branch i = function
         | Verbatim (n, _) ->
-          unit_branches := (fun () -> 
-            output "| %s -> ()" (vname n ~is_poly:true)
-          ) :: !unit_branches
-
-      ) ctors;
-      
-      if not !has_content then None
-      else
-        let all_generators = 
-          List.rev_append !unit_branches (List.rev !generator_branches)
-        in
-        Some (fun () ->
-          output "begin match %s with" (make_param_name index name);
-          execute_generators all_generators;
-          output "end;"
-        )
+          `Unit (fun () -> output "| %s -> ()" (vname n ~is_poly:true))
+        | Simple (param, args) ->
+          let inner = filter_generators index (Option.default [] args) in
+          let variant_name = make_variant_name i param.value ~is_poly:true in
+          let pattern_args =
+            match args, inner with
+            | (Some [] | None), [] -> ""
+            | (Some [] | None), _ -> (match param.value with Some n -> " " ^ n | None -> "")
+            | Some _, [] -> " _"
+            | Some l, _ -> " (" ^ String.concat "," (names_of_vars l) ^ ")"
+          in
+          (match inner with
+          | [] -> `Unit (fun () -> output "| %s%s -> ()" variant_name pattern_args)
+          | inner -> `Gen (fun () ->
+              output "| %s%s ->" variant_name pattern_args;
+              with_indent (fun () -> execute_generators inner)))
+      in
+      let branches = List.mapi branch ctors in
+      let units = List.filter_map (function `Unit f -> Some f | `Gen _ -> None) branches in
+      let gens = List.filter_map (function `Gen f -> Some f | `Unit _ -> None) branches in
+      unless_empty gens (fun gens ->
+        output "begin match %s with" (make_param_name index name);
+        execute_generators (units @ gens);
+        output "end;")
   in
   Option.may (fun g -> g ()) (aux index var)
 
@@ -597,60 +553,41 @@ let rec eval_count_params vars =
     in
     group_vars ([], [], [], []) vars
   in
-  let static = string_of_int (List.length @@ List.filter (fun x -> x) static) in
-  let choices_in =
-    match choices_in with
-    | [] -> ""
-    | choices_in ->
-      choices_in |>
-      List.mapi
-        (fun i (param, vars) ->
-           sprintf
-             " + (match %s with [] -> 0 | _ :: _ -> %s)"
-             (make_param_name i param)
-             (eval_count_params vars)) |>
-      String.concat ""
+  (* one shape for every dynamic contribution: " + (match X with P -> n | ...)" *)
+  let count_match name arms =
+    sprintf " + (match %s with %s)" name
+      (arms |> List.map (fun (p, n) -> p ^ " -> " ^ n) |> String.concat " | ")
   in
-  let bool_choices = match bool_choices with
-  | [] -> ""
-  | _ -> bool_choices |> List.mapi begin fun i ((param_id, vars)) ->
-    sprintf " + (match %s with %s -> %s | %s -> 0)"
-      (make_param_name i param_id)
-      (match_variant_pattern i (Some "Some") (Some vars) ~is_poly:false)
-      (eval_count_params vars)
-      (match_variant_pattern i (Some "None") None ~is_poly:false)
-  end |> String.concat "" in
-  let choices =
-    match choices with
-    | [] -> ""
-    | _ ->
-    choices |> List.mapi begin fun i (name,ctors) ->
-      sprintf " + (match %s with " (make_param_name i name) ^
-      (ctors |> List.mapi (fun i ctor ->
-        match ctor with
-        | Verbatim (n,_) -> 
-          sprintf "%s -> 0" (vname n ~is_poly:true)
-        | Simple (param,args) -> 
-          sprintf "%s -> %s" (match_variant_pattern i param.value args ~is_poly:true)
-            (eval_count_params @@ Option.default [] args)) |> String.concat " | ")
-      ^ ")"
-    end |> String.concat ""
+  let counts fmt groups = groups |> List.mapi fmt |> String.concat "" in
+  let static = string_of_int (List.length @@ List.filter (fun x -> x) static) in
+  let choices_in = choices_in |> counts (fun i (param, vars) ->
+    count_match (make_param_name i param)
+      ["[]", "0"; "_ :: _", eval_count_params vars])
+  in
+  let bool_choices = bool_choices |> counts (fun i (param_id, vars) ->
+    count_match (make_param_name i param_id)
+      [ match_variant_pattern i (Some "Some") (Some vars) ~is_poly:false, eval_count_params vars;
+        match_variant_pattern i (Some "None") None ~is_poly:false, "0" ])
+  in
+  let choices = choices |> counts (fun i (name, ctors) ->
+    count_match (make_param_name i name)
+      (ctors |> List.mapi (fun i -> function
+        | Verbatim (n, _) -> vname n ~is_poly:true, "0"
+        | Simple (param, args) ->
+          match_variant_pattern i param.value args ~is_poly:true,
+          eval_count_params (Option.default [] args))))
   in
   static ^ choices_in ^ choices ^ bool_choices
 
-let emit_set_params ?(emit_extra = ignore) ~count vars =
+let emit_set_params ~count emit_vars =
   output "let set_params stmt =";
   inc_indent ();
   output "let p = T.start_params stmt (%s) in" count;
-  emit_extra ();
-  List.iteri set_var vars;
+  emit_vars ();
   output "T.finish_params p";
   dec_indent ();
   output "in";
   "set_params"
-
-let output_params_binder _ vars =
-  emit_set_params ~count:(eval_count_params vars) vars
 
 let rec exclude_in_vars l =
   List.filter_map
@@ -661,21 +598,19 @@ let rec exclude_in_vars l =
       | v -> Some (Sql.map_sub_vars exclude_in_vars v))
     l
 
-let output_params_binder index vars =
+let output_params_binder _ vars =
   match exclude_in_vars vars with
   | [] -> "T.no_params"
-  | vars -> output_params_binder index vars
+  | vars -> emit_set_params ~count:(eval_count_params vars) (fun () -> List.iteri set_var vars)
 
 
 let make_to_literal meta typ =
-  match codec_set_param meta with
-  | Some setter ->
+  match resolve_codec codec_set_param typ meta with
+  | Custom_codec setter ->
     let trait_type_name = match typ.Type.t with | Union _ -> "Text" | StringLiteral _ -> "Text" | _ -> L.as_lang_type typ in
     sprintf "(fun v -> T.Types.%s.%s_to_literal (%s v))" trait_type_name (L.as_runtime_repr_name typ) setter
-  | None ->
-    match typ.Type.t with
-    | Union { ctors; _ } -> sprintf "%s.to_literal" (get_enum_name ctors)
-    | _ -> sprintf "T.Types.%s.to_literal" (L.as_lang_type typ)
+  | Enum_codec m -> sprintf "%s.to_literal" m
+  | Builtin_codec t -> sprintf "T.Types.%s.to_literal" (L.as_lang_type t)
 
 let gen_in_substitution meta var =
   if Option.is_none var.id.value then failwith "empty label in IN param";
@@ -745,76 +680,59 @@ let join_ctor join_ctors join_id =
 let cond_test ~ctor_of ~deps_of = function
   | Gen.Dep_selected (pid, dep_id) -> sprintf "List.mem %s %s" (ctor_of dep_id) (deps_of pid)
 
+let render_cond ~ctor_of ~deps_of cond body =
+  sprintf {|(if %s then %s else "")|} (cond_test cond ~ctor_of ~deps_of) body
+
 let make_sql ~join_ctors l =
-  let b = Buffer.create 100 in
-  let rec loop app = function
-    | [] -> ()
-    | Static "" :: tl when app -> loop app tl
-    | Static s :: tl ->
-      if app then bprintf b " ^ ";
-      Buffer.add_string b (quote s);
-      loop true tl
-    | SubstIn (param, m) :: tl ->
-      if app then bprintf b " ^ ";
-      Buffer.add_string b (gen_in_substitution m param);
-      loop true tl
-    | DynamicIn (name, in_or_not_in, sqls) :: tl ->
-      if app then bprintf b " ^ ";
-      bprintf b "(match %s with" (make_param_name 0 name);
-      bprintf b " [] -> \"%s\" | _ :: _ -> "
-        (String.uppercase_ascii @@ string_of_bool @@ match in_or_not_in with `In -> false | `NotIn -> true);
-      loop false sqls;
-      bprintf b ")";
-      loop true tl
-    | Dynamic (name, ctors) :: tl ->
-      if app then bprintf b " ^ ";
-      bprintf b "(match %s with" (make_param_name 0 name);
-      ctors |> List.iteri (fun i ({ ctor; args; sql; is_poly }) -> 
-        bprintf b " %s%s -> " (if i = 0 then "" else "| ") 
-          (match_variant_pattern i ctor.value args ~is_poly:is_poly); loop false sql);
-      bprintf b ")";
-      loop true tl
-    | Cond (cond, body) :: tl ->
-      if app then bprintf b " ^ ";
-      bprintf b "(if %s then "
-        (cond_test cond
-          ~ctor_of:(fun id -> join_ctor join_ctors id)
-          ~deps_of:(fun pid -> make_param_name 0 pid ^ ".deps"));
-      loop false body;
-      bprintf b {| else "")|};
-      loop true tl
-    | SubstTuple (id, Insertion schema) :: tl ->
-      if app then bprintf b " ^ ";
+  let rec render l =
+    let parts =
+      match l with
+      | Gen.Static "" :: tl -> quote "" :: List.filter_map piece tl
+      | l -> List.filter_map piece l
+    in
+    match parts with
+    | [] -> quote ""
+    | parts -> String.concat " ^ " parts
+  and piece = function
+    | Static "" -> None
+    | Static s -> Some (quote s)
+    | SubstIn (param, m) -> Some (gen_in_substitution m param)
+    | DynamicIn (name, in_or_not_in, sqls) ->
+      Some (sprintf "(match %s with [] -> \"%s\" | _ :: _ -> %s)"
+        (make_param_name 0 name)
+        (String.uppercase_ascii @@ string_of_bool @@ match in_or_not_in with `In -> false | `NotIn -> true)
+        (render sqls))
+    | Dynamic (name, ctors) ->
+      Some (sprintf "(match %s with %s)"
+        (make_param_name 0 name)
+        (ctors
+         |> List.mapi (fun i { ctor; args; sql; is_poly } ->
+             sprintf "%s -> %s" (match_variant_pattern i ctor.value args ~is_poly) (render sql))
+         |> String.concat " | "))
+    | Cond (cond, body) ->
+      Some (render_cond cond (render body)
+        ~ctor_of:(fun id -> join_ctor join_ctors id)
+        ~deps_of:(fun pid -> make_param_name 0 pid ^ ".deps"))
+    | SubstTuple (id, Insertion schema) ->
+      Some (gen_tuple_substitution ~is_row:false (resolve_tuple_label id) schema)
+    | SubstTuple (id, Where_in { value = (types, _); pos = _ }) ->
       let label = resolve_tuple_label id in
-      Buffer.add_string b (gen_tuple_substitution ~is_row:false label schema);
-      loop true tl
-    | SubstTuple (id, Where_in { value = (types, _); pos = _ }) :: tl ->
-      if app then bprintf b " ^ ";
-      let label = resolve_tuple_label id in
-      let types = List.map (fun (t, m) -> (t, m)) types in
       let schema = make_schema_of_tuple_types label types in
-      bprintf b "%s ^ " (quote "(");
-      Buffer.add_string b (gen_tuple_substitution ~is_row:false label schema);
-      bprintf b " ^ %s" (quote ")");
-      loop true tl
-    | SubstTuple (id, ValueRows { types; _ }) :: tl ->
-        if app then bprintf b " ^ ";
-        let label = resolve_tuple_label id in
-        (* TODO: Implement meta for ValueRows *)
-        let types = List.map (fun typ -> typ, Meta.empty()) types in
-        let schema = make_schema_of_tuple_types label types in
-        let empty = schema 
-          |> List.map (const "NULL") 
-          |> String.join ", " 
-          |> sprintf {|"SELECT %s WHERE FALSE"|} in
-        let not_empty = gen_tuple_substitution ~is_row:true label schema in
-        Buffer.add_string b @@ sprintf {|( if %s = [] then %s else ( "VALUES " ^ %s ) )|} label empty not_empty;
-        loop true tl  
+      Some (sprintf "%s ^ %s ^ %s"
+        (quote "(") (gen_tuple_substitution ~is_row:false label schema) (quote ")"))
+    | SubstTuple (id, ValueRows { types; _ }) ->
+      let label = resolve_tuple_label id in
+      (* TODO: Implement meta for ValueRows *)
+      let types = List.map (fun typ -> typ, Meta.empty()) types in
+      let schema = make_schema_of_tuple_types label types in
+      let empty = schema
+        |> List.map (const "NULL")
+        |> String.join ", "
+        |> sprintf {|"SELECT %s WHERE FALSE"|} in
+      let not_empty = gen_tuple_substitution ~is_row:true label schema in
+      Some (sprintf {|( if %s = [] then %s else ( "VALUES " ^ %s ) )|} label empty not_empty)
   in
-  Buffer.add_string b "(";
-  loop false l;
-  Buffer.add_string b ")";
-  Buffer.contents b
+  "(" ^ render l ^ ")"
 
 type callback_build_state = {
   bindings: string list;
@@ -838,26 +756,35 @@ let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module stmt =
     sprintf "%s.count" (col_ref di)
   ) |> String.concat " + " in
 
-  let (_ : string) =
-    emit_set_params other_vars
-      ~count:(sprintf "%s + %s" static_count dynamic_counts)
-      ~emit_extra:(fun () ->
-        List.iter (fun di -> output "%s.set p;" (col_ref di)) dynamic_infos)
-  in
-
   let find_di_by_pid pid = List.find (fun di -> di.param_id = pid) dynamic_infos in
+  let is_di pid = List.exists (fun di -> di.param_id = pid) dynamic_infos in
+
+  (* params are bound positionally, so col.set must run exactly where the
+     dynamic select occurs among the other vars, not before them;
+     indices skip dynamic selects to stay in sync with other_vars *)
+  let set_vars_in_order () =
+    let set index = function
+      | Sql.DynamicSelect (pid, _) -> output "%s.set p;" (col_ref (find_di_by_pid pid)); index
+      | var -> set_var index var; index + 1
+    in
+    let (_ : int) = List.fold_left set 0 stmt.vars in
+    ()
+  in
+  let (_ : string) =
+    emit_set_params ~count:(sprintf "%s + %s" static_count dynamic_counts) set_vars_in_order
+  in
 
   let rec build_parts acc pending_comma = function
     | [] -> List.rev acc
     | Gen.Static s :: rest ->
-      let s_trimmed = String.trim s in
-      let ends_with_comma = String.length s_trimmed > 0 && s_trimmed.[String.length s_trimmed - 1] = ',' in
-      if ends_with_comma then
-        let s_no_comma = String.sub s_trimmed 0 (String.length s_trimmed - 1) in
-        build_parts (if s_no_comma = "" then acc else quote s_no_comma :: acc) true rest
-      else
-        build_parts (quote s :: acc) false rest
-    | Gen.Dynamic (pid, _) :: rest ->
+      let piece, pending =
+        match String.rindex_opt s ',' with
+        | Some i when String.(trim (slice ~first:(i + 1) s)) = "" -> String.slice ~last:i s, true
+        | _ -> s, false
+      in
+      let acc = if pending && String.trim piece = "" then acc else quote piece :: acc in
+      build_parts acc pending rest
+    | Gen.Dynamic (pid, _) :: rest when is_di pid ->
       let di = find_di_by_pid pid in
       let dyn_expr =
         if pending_comma then
@@ -875,19 +802,20 @@ let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module stmt =
         | parts -> String.concat " ^ " parts
       in
       let expr =
-        sprintf {|(if %s then %s else "")|}
-          (cond_test cond
-            ~ctor_of:(fun dep_id -> ctor_prefix di ^ join_ctor join_ctors dep_id)
-            ~deps_of:(fun _ -> deps_ref di))
-          body_expr
+        render_cond cond body_expr
+          ~ctor_of:(fun dep_id -> ctor_prefix di ^ join_ctor join_ctors dep_id)
+          ~deps_of:(fun _ -> deps_ref di)
       in
       build_parts (expr :: acc) pending_comma rest
-    | _ :: rest -> build_parts acc pending_comma rest
+    | (Gen.Dynamic _ | Gen.SubstIn _ | Gen.DynamicIn _ | Gen.SubstTuple _) as piece :: rest ->
+      let expr = make_sql ~join_ctors [piece] in
+      let acc = if pending_comma then expr :: quote "," :: acc else expr :: acc in
+      build_parts acc false rest
   in
-  let sql_parts = build_parts [] false sql_pieces in
-  let sql_expr = String.concat " ^ " sql_parts in
+  let sql_expr = String.concat " ^ " (build_parts [] false sql_pieces) in
 
-  output_r_acc_init module_kind;
+  let c = consumer module_kind in
+  c.c_init ();
 
   let rec split_schema_multi acc current = function
     | [] -> List.rev ((List.rev current, None) :: acc)
@@ -940,25 +868,23 @@ let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module stmt =
 
   let callback_body = build_callback_body () in
 
-  let (bind_start, bind_end, full_callback) =
-    module_kind_consumer module_kind
+  let full_callback =
+    c.c_callback
       ~direct:(sprintf "(fun row -> %s)" callback_body)
       ~fold:(sprintf "(fun row -> r_acc := (%s !r_acc))" callback_body)
       ~list:(sprintf "(fun row -> r_acc := (%s) :: !r_acc)" callback_body)
   in
+  let (bind_start, bind_end) = c.c_bind in
 
   output "%sT.%s db" bind_start (select_func_of_kind stmt.kind);
   output "  (%s)" sql_expr;
   output "  set_params %s%s" full_callback bind_end;
-  complete_func module_kind
+  complete_func c
 
 let emit_dynamic_module_select ~module_kind ~dynamic_infos stmt =
   if not (supports_module_kind module_kind stmt) then () else
   let dynamic_names = List.map (fun di -> di.param_name) dynamic_infos in
-  let format_input v =
-    if List.mem v dynamic_names then sprintf "(%s : _ t)" v
-    else sprintf "~%s" v
-  in
+  let format_input = format_func_input dynamic_names ~dyn_annot:(fun _ -> "_ t") in
   let (_ : string list) =
     emit_func_header ~name:"select" ~extra_params:""
       ~has_callback:(has_row_callback stmt) ~format_input ~module_kind stmt
@@ -983,13 +909,16 @@ let emit_sql_with_subst subst stmt =
     output "in";
     "__sqlgg_sql"
 
+let empty_exec_result = {|IO.return { T.affected_rows = 0L; insert_id = None }|}
+
 let generate_stmt ~module_kind index stmt =
   if not (supports_module_kind module_kind stmt) then () else
+  let c = consumer module_kind in
   if Props.get stmt.props "noop" <> None then begin
     let _ = gen_func_signature ~dynamic_infos:[] ~module_kind ~index stmt in
     output "ignore db;";
-    output "IO.return { T.affected_rows = 0L; insert_id = None }";
-    complete_func module_kind
+    output "%s" empty_exec_result;
+    complete_func c
   end else
   let subst = gen_func_signature ~dynamic_infos:[] ~module_kind ~index stmt in
   let sql = emit_sql_with_subst subst stmt in
@@ -997,20 +926,20 @@ let generate_stmt ~module_kind index stmt =
     match stmt.schema with
     | [] -> "execute", ""
     | _ ->
-      let func = select_func_of_kind stmt.kind in
+      select_func_of_kind stmt.kind,
       match module_kind, stmt.kind with
-      | `Single, _ -> func, output_schema_binder_labeled index stmt.schema
-      | _, Stmt.Select (`Zero_one | `One) -> func, output_select1_cb index stmt.schema
-      | _ -> func, output_schema_binder_labeled index stmt.schema
+      | (`Direct | `Fold | `List), Stmt.Select (`Zero_one | `One) -> output_select1_cb index stmt.schema
+      | _ -> output_schema_binder_labeled index stmt.schema
   in
   let params_binder_name = output_params_binder index stmt.vars in
-  output_r_acc_init module_kind;
-  let (bind, bind_end, callback) =
-    module_kind_consumer module_kind
+  c.c_init ();
+  let callback =
+    c.c_callback
       ~direct:callback
       ~fold:(sprintf "(fun x -> r_acc := %s x !r_acc)" callback)
       ~list:(sprintf "(fun x -> r_acc := %s x :: !r_acc)" callback)
   in
+  let (bind, bind_end) = c.c_bind in
   let exec = sprintf "T.%s db %s %s %s%s" func sql params_binder_name callback bind_end in
   let exec =
     match
@@ -1022,13 +951,12 @@ let generate_stmt ~module_kind index stmt =
         (get_sql stmt)
     with
     | None -> exec
-    | Some id ->
-    match id.value with
-    | None -> failwith "empty label in tuple substitution"
-    | Some value -> sprintf {|( match %s with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> %s)|} value exec
+    | Some { value = None; _ } -> failwith "empty label in tuple substitution"
+    | Some { value = Some value; _ } ->
+      sprintf {|( match %s with [] -> %s | _ :: _ -> %s)|} value empty_exec_result exec
   in
   output "%s%s" bind exec;
-  complete_func module_kind
+  complete_func c
 
 let sanitize_to_variant_name s =
   let normalized =
@@ -1062,7 +990,6 @@ let generate_enum_modules stmts =
       enum_unless_codec codec_set_param domain meta
     ) schemas
   in
-  
 
   let schema_columns_to_enums schema_cols =
     let attr_enum attr = option_list (enum_unless_codec codec_get_column attr.domain attr.meta) in
@@ -1106,18 +1033,19 @@ let generate_enum_modules stmts =
     (List.map (fun ctor -> Printf.sprintf "| %s -> \"%s\"" (get_ctor_name ctor) (String.escaped ctor)) ctor_list))
   in
 
-  indented (fun () -> 
+  indented (fun () ->
     let result = schema_columns_to_enums schemas @ vars_to_enums vars in
-    let (_: int * unit list) = List.fold_left_map begin fun acc enum -> 
+    let (_ : int) = List.fold_left (fun acc enum ->
       let hash = enum_get_hash enum in
-      if Hashtbl.mem enums_hash_tbl hash then acc, ()
+      if Hashtbl.mem enums_hash_tbl hash then acc
       else begin
         Hashtbl.add enums_hash_tbl hash (acc, enum);
-        acc + 1, begin empty_line (); generate_enum_module acc enum end
-      end
-    end 0 result in 
-    ()
-  )
+        empty_line ();
+        generate_enum_module acc enum;
+        acc + 1
+      end) 0 result
+    in ())
+
   
 let get_all_dynamic_select_infos index stmt =
   let query_name = Gen.choose_name stmt.Gen.props stmt.Gen.kind index in
@@ -1158,13 +1086,9 @@ let generate_dynamic_select_modules stmts =
       ) sql_pieces |> Option.default [] in
       
       let fields = List.map2 (fun ctor field ->
-        let name = match ctor with
-          | Sql.Simple (ctor_param_id, _) -> field_name_of_param_id ctor_param_id
-          | Sql.Verbatim (name, _) -> name
-        in
-        let args = match ctor with
-          | Sql.Simple (_, args) -> Option.default [] args
-          | Sql.Verbatim _ -> []
+        let name, args = match ctor with
+          | Sql.Simple (ctor_param_id, args) -> field_name_of_param_id ctor_param_id, Option.default [] args
+          | Sql.Verbatim (name, _) -> name, []
         in
         { field_name = scoped_field_name name; field_args = args; field_schema = field; field_ctor = ctor }
       ) di.ctors di.schema_fields in
@@ -1247,10 +1171,8 @@ let generate ~gen_io ~migration_names name stmts =
   generate_dynamic_select_modules stmts;
   empty_line ();
   List.iteri (generate_stmt_wrapper ~module_kind:`Direct) stmts;
-  let has_row_cb = List.exists has_row_callback stmts in
-  let has_single = List.exists is_single_row_select stmts in
-  [`Single, has_single; `Fold, has_row_cb; `List, has_row_cb]
-  |> List.filter_map (fun (module_kind, cond) -> if cond then Some module_kind else None)
+  [`Single; `Fold; `List]
+  |> List.filter (fun module_kind -> List.exists (supports_module_kind module_kind) stmts)
   |> List.iteri (fun i module_kind ->
     if i > 0 then output "";
     emit_module_annotated (module_kind_name module_kind) (fun () ->

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -3625,3 +3625,4 @@ harmless pair:
   > SELECT 1 WHERE FALSE AND @b { None { TRUE } | Some { (FALSE OR TRUE) } };
   > EOF
       T.select_one_maybe db ("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( (FALSE OR TRUE) ) ")) set_params get_row
+

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -2901,7 +2901,7 @@ Virtual select: explicit choices with alias alongside plain columns:
   > EOF
   Failed mixed_explicit: SELECT id, @col { Name { name } | Cat { category } } AS detail FROM t WHERE id = @id
   At : @col { Name { name } | Cat { category } }
-  Fatal error: exception Failure("sharing choices not implemented")
+  Fatal error: exception Failure("dynamic_select reserves the name col for the column picker, rename choice col")
   [2]
 
 Virtual select: tab-separated columns (non-space whitespace):

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -1,0 +1,724 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+  module In_list = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~ids ~nm callback =
+      let set_params stmt =
+        let p = T.start_params stmt (1 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+        col.set p;
+        T.set_param_Text p nm;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~ids ~nm callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.set_param_Text p nm;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~ids ~nm callback =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.set_param_Text p nm;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Tuple_list = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~pairs callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~pairs callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~pairs callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Opt_filter = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~v callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match v with Some _ -> 1 | None -> 0) + col.count) in
+        col.set p;
+        begin match v with
+        | None -> ()
+        | Some v ->
+          T.set_param_Int p v;
+        end;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~v callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match v with Some _ -> 1 | None -> 0) + col.count) in
+          col.set p;
+          begin match v with
+          | None -> ()
+          | Some v ->
+            T.set_param_Int p v;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~v callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match v with Some _ -> 1 | None -> 0) + col.count) in
+          col.set p;
+          begin match v with
+          | None -> ()
+          | Some v ->
+            T.set_param_Int p v;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Order_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~sort callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~sort callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~sort callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Order_comma_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~sort callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~sort callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~sort callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Where_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~f callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+        col.set p;
+        begin match f with
+        | `All -> ()
+        | `ById (id) ->
+          T.set_param_Int p id;
+        end;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~f callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (id) ->
+            T.set_param_Int p id;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~f callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (id) ->
+            T.set_param_Int p id;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Shared_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~f callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+        col.set p;
+        begin match f with
+        | `All -> ()
+        | `ById (a) ->
+          T.set_param_Int p a;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ById (b) ->
+          T.set_param_Int p b;
+        end;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~f callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~f callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Kitchen_sink = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~ids ~pairs ~nm ~f ~sort callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match pairs with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0) + col.count) in
+        col.set p;
+        begin match nm with
+        | None -> ()
+        | Some nm ->
+          T.set_param_Text p nm;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ById (a) ->
+          T.set_param_Int p a;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ById (b) ->
+          T.set_param_Int p b;
+        end;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
+  AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~ids ~pairs ~nm ~f ~sort callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match pairs with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0) + col.count) in
+          col.set p;
+          begin match nm with
+          | None -> ()
+          | Some nm ->
+            T.set_param_Text p nm;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
+  AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~ids ~pairs ~nm ~f ~sort callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match pairs with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0) + col.count) in
+          col.set p;
+          begin match nm with
+          | None -> ()
+          | Some nm ->
+            T.set_param_Text p nm;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
+  AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+
+  let create_t db  =
+    T.execute db ("CREATE TABLE t (\n\
+    id INT,\n\
+    name TEXT\n\
+)") T.no_params
+
+  module Fold = struct
+  end (* module Fold *)
+  
+  module List = struct
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/test_dynamic_select_compose/compose.sql
+++ b/test/cram/test_dynamic_select_compose/compose.sql
@@ -1,0 +1,44 @@
+CREATE TABLE t (
+    id INT,
+    name TEXT
+);
+
+-- [sqlgg] dynamic_select=true
+-- @in_list
+SELECT id, name FROM t WHERE id IN @ids AND name = @nm;
+
+-- [sqlgg] dynamic_select=true
+-- @tuple_list
+SELECT id, name FROM t WHERE (id, name) IN @pairs;
+
+-- [sqlgg] dynamic_select=true
+-- @opt_filter
+SELECT id, name FROM t WHERE { id = @v }?;
+
+-- [sqlgg] dynamic_select=true
+-- @order_choice
+SELECT id, name FROM t ORDER BY @sort { I { id } | N { name } };
+
+-- [sqlgg] dynamic_select=true
+-- @order_comma_choice
+SELECT id, name FROM t ORDER BY id, @sort { I { id } | N { name } };
+
+-- [sqlgg] dynamic_select=true
+-- @where_choice
+SELECT id, name FROM t WHERE @f { All { TRUE } | ById { id = @id } };
+
+-- [sqlgg] dynamic_select=true
+-- @shared_choice
+SELECT id, name FROM t
+WHERE @f { All { TRUE } | ById { id = @a } }
+  AND (@f { All { TRUE } | ById { id = @b } } OR id = 0);
+
+-- [sqlgg] dynamic_select=true
+-- @kitchen_sink
+SELECT id, name FROM t
+WHERE id IN @ids
+  AND (id, name) IN @pairs
+  AND { name = @nm }?
+  AND @f { All { TRUE } | ById { id = @a } }
+  AND (@f { All { TRUE } | ById { id = @b } } OR id = 0)
+ORDER BY @sort { I { id } | N { name } };

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -1,0 +1,633 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+  module Cte_plain = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db ~st (col : _ t) ~lo callback =
+      let set_params stmt =
+        let p = T.start_params stmt (2 + col.count) in
+        T.set_param_Int p st;
+        col.set p;
+        T.set_param_Int p lo;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db ~st (col : _ t) ~lo callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (2 + col.count) in
+          T.set_param_Int p st;
+          col.set p;
+          T.set_param_Int p lo;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db ~st (col : _ t) ~lo callback =
+        let set_params stmt =
+          let p = T.start_params stmt (2 + col.count) in
+          T.set_param_Int p st;
+          col.set p;
+          T.set_param_Int p lo;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Cte_in_list = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db ~ids ~nm (col : _ t) ~lo callback =
+      let set_params stmt =
+        let p = T.start_params stmt (2 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+        T.set_param_Text p nm;
+        col.set p;
+        T.set_param_Int p lo;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db ~ids ~nm (col : _ t) ~lo callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (2 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+          T.set_param_Text p nm;
+          col.set p;
+          T.set_param_Int p lo;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db ~ids ~nm (col : _ t) ~lo callback =
+        let set_params stmt =
+          let p = T.start_params stmt (2 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
+          T.set_param_Text p nm;
+          col.set p;
+          T.set_param_Int p lo;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Cte_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db ~f (col : _ t) ~sort callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + col.count) in
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s) ->
+          T.set_param_Int p s;
+        end;
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db ~f (col : _ t) ~sort callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          begin match f with
+          | `All -> ()
+          | `ByStatus (s) ->
+            T.set_param_Int p s;
+          end;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db ~f (col : _ t) ~sort callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + col.count) in
+          begin match f with
+          | `All -> ()
+          | `ByStatus (s) ->
+            T.set_param_Int p s;
+          end;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Cte_opt_filter = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db ~st (col : _ t) ~pairs callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + (match st with Some _ -> 1 | None -> 0) + col.count) in
+        begin match st with
+        | None -> ()
+        | Some st ->
+          T.set_param_Int p st;
+        end;
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db ~st (col : _ t) ~pairs callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + (match st with Some _ -> 1 | None -> 0) + col.count) in
+          begin match st with
+          | None -> ()
+          | Some st ->
+            T.set_param_Int p st;
+          end;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db ~st (col : _ t) ~pairs callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + (match st with Some _ -> 1 | None -> 0) + col.count) in
+          begin match st with
+          | None -> ()
+          | Some st ->
+            T.set_param_Int p st;
+          end;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Cte_shared_choice = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~f callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+        begin match f with
+        | `All -> ()
+        | `ById (a) ->
+          T.set_param_Int p a;
+        end;
+        col.set p;
+        begin match f with
+        | `All -> ()
+        | `ById (b) ->
+          T.set_param_Int p b;
+        end;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~f callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~f callback =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
+          begin match f with
+          | `All -> ()
+          | `ById (a) ->
+            T.set_param_Int p a;
+          end;
+          col.set p;
+          begin match f with
+          | `All -> ()
+          | `ById (b) ->
+            T.set_param_Int p b;
+          end;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Cte_param_col = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+      let is_new cutoff : _ t =
+        let _set_is_new p =
+          begin match cutoff with None -> T.set_param_null p | Some v -> T.set_param_Int p v end;
+          ()
+        in
+        {
+          set = _set_is_new;
+          read = (fun row idx -> (T.get_column_Bool_nullable row idx, idx + 1));
+          column = ("(status >= " ^ "?" ^ ")");
+          count = 1;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+      method is_new = Cols.is_new
+    end
+
+    let select db ~st (col : _ t) callback =
+      let set_params stmt =
+        let p = T.start_params stmt (1 + col.count) in
+        T.set_param_Int p st;
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db ~st (col : _ t) callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + col.count) in
+          T.set_param_Int p st;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db ~st (col : _ t) callback =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + col.count) in
+          T.set_param_Int p st;
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Where_subquery = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~st ~names callback =
+      let set_params stmt =
+        let p = T.start_params stmt (1 + (match names with [] -> 0 | _ :: _ -> 0) + col.count) in
+        col.set p;
+        T.set_param_Int p st;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~st ~names callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + (match names with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.set_param_Int p st;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~st ~names callback =
+        let set_params stmt =
+          let p = T.start_params stmt (1 + (match names with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.set_param_Int p st;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+
+  let create_t db  =
+    T.execute db ("CREATE TABLE t (\n\
+    id INT,\n\
+    name TEXT,\n\
+    status INT\n\
+)") T.no_params
+
+  module Fold = struct
+  end (* module Fold *)
+  
+  module List = struct
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/test_dynamic_select_compose/cte.sql
+++ b/test/cram/test_dynamic_select_compose/cte.sql
@@ -1,0 +1,40 @@
+CREATE TABLE t (
+    id INT,
+    name TEXT,
+    status INT
+);
+
+-- [sqlgg] dynamic_select=true
+-- @cte_plain
+WITH filtered AS (SELECT id, name FROM t WHERE status = @st)
+SELECT id, name FROM filtered WHERE id > @lo;
+
+-- [sqlgg] dynamic_select=true
+-- @cte_in_list
+WITH filtered AS (SELECT id, name FROM t WHERE id IN @ids AND name = @nm)
+SELECT id, name FROM filtered WHERE id > @lo;
+
+-- [sqlgg] dynamic_select=true
+-- @cte_choice
+WITH filtered AS (SELECT id, name FROM t WHERE @f { All { TRUE } | ByStatus { status = @s } })
+SELECT id, name FROM filtered ORDER BY @sort { I { id } | N { name } };
+
+-- [sqlgg] dynamic_select=true
+-- @cte_opt_filter
+WITH filtered AS (SELECT id, name FROM t WHERE { status = @st }?)
+SELECT id, name FROM filtered WHERE (id, name) IN @pairs;
+
+-- [sqlgg] dynamic_select=true
+-- @cte_shared_choice
+WITH filtered AS (SELECT id, name FROM t WHERE @f { All { TRUE } | ById { id = @a } })
+SELECT id, name FROM filtered WHERE @f { All { TRUE } | ById { id = @b } };
+
+-- [sqlgg] dynamic_select=true
+-- @cte_param_col
+WITH recent AS (SELECT id, name, status FROM t WHERE status = @st)
+SELECT id, name, (status >= @cutoff) AS is_new FROM recent;
+
+-- [sqlgg] dynamic_select=true
+-- @where_subquery
+SELECT id, name FROM t
+WHERE id IN (SELECT id FROM t WHERE status = @st AND name IN @names);

--- a/test/cram/test_dynamic_select_compose/dune
+++ b/test/cram/test_dynamic_select_compose/dune
@@ -1,0 +1,7 @@
+(cram
+ (deps
+  %{bin:sqlgg}
+  (glob_files *.sql)
+  (glob_files *.compare.ml)
+  run.ml
+  ../print_ocaml_impl.ml))

--- a/test/cram/test_dynamic_select_compose/run.ml
+++ b/test/cram/test_dynamic_select_compose/run.ml
@@ -1,0 +1,89 @@
+open Printf
+
+module C = Compose.Sqlgg(Print_ocaml_impl)
+module W = Cte.Sqlgg(Print_ocaml_impl)
+
+let go name f =
+  printf "-- %s\n" name;
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_select_response [];
+  f ();
+  printf "\n"
+
+let () =
+  let db = () in
+
+  go "in_list: empty ids" (fun () ->
+    C.In_list.select db C.In_list.name ~ids:[] ~nm:"x" (fun _ -> ()));
+  go "in_list: two ids" (fun () ->
+    C.In_list.select db C.In_list.name ~ids:[1L; 2L] ~nm:"x" (fun _ -> ()));
+
+  go "tuple_list: empty pairs" (fun () ->
+    C.Tuple_list.select db C.Tuple_list.id ~pairs:[] (fun _ -> ()));
+  go "tuple_list: two pairs with null" (fun () ->
+    C.Tuple_list.select db C.Tuple_list.id ~pairs:[(Some 1L, Some "a"); (None, Some "b")] (fun _ -> ()));
+
+  go "opt_filter: none" (fun () ->
+    C.Opt_filter.select db C.Opt_filter.name ~v:None (fun _ -> ()));
+  go "opt_filter: some" (fun () ->
+    C.Opt_filter.select db C.Opt_filter.name ~v:(Some 5L) (fun _ -> ()));
+
+  go "order_choice: by id" (fun () ->
+    C.Order_choice.select db C.Order_choice.name ~sort:`I (fun _ -> ()));
+  go "order_choice: by name" (fun () ->
+    C.Order_choice.select db C.Order_choice.name ~sort:`N (fun _ -> ()));
+
+  go "order_comma_choice: comma before choice" (fun () ->
+    C.Order_comma_choice.select db C.Order_comma_choice.name ~sort:`N (fun _ -> ()));
+
+  go "where_choice: all" (fun () ->
+    C.Where_choice.select db C.Where_choice.name ~f:`All (fun _ -> ()));
+  go "where_choice: by id" (fun () ->
+    C.Where_choice.select db C.Where_choice.name ~f:(`ById 7L) (fun _ -> ()));
+
+  go "shared_choice: all" (fun () ->
+    C.Shared_choice.select db C.Shared_choice.name ~f:`All (fun _ -> ()));
+  go "shared_choice: by id (both occurrences)" (fun () ->
+    C.Shared_choice.select db C.Shared_choice.name ~f:(`ById 7L) (fun _ -> ()));
+
+  go "kitchen_sink: everything on" (fun () ->
+    C.Kitchen_sink.select db C.Kitchen_sink.name
+      ~ids:[1L; 2L] ~pairs:[(Some 1L, Some "a")] ~nm:(Some "x") ~f:(`ById 5L) ~sort:`N
+      (fun _ -> ()));
+  go "kitchen_sink: everything off" (fun () ->
+    C.Kitchen_sink.select db C.Kitchen_sink.name
+      ~ids:[] ~pairs:[] ~nm:None ~f:`All ~sort:`I
+      (fun _ -> ()));
+
+  go "cte_plain" (fun () ->
+    W.Cte_plain.select db ~st:1L W.Cte_plain.name ~lo:10L (fun _ -> ()));
+
+  go "cte_in_list: empty ids" (fun () ->
+    W.Cte_in_list.select db ~ids:[] ~nm:"x" W.Cte_in_list.name ~lo:0L (fun _ -> ()));
+  go "cte_in_list: two ids" (fun () ->
+    W.Cte_in_list.select db ~ids:[1L; 2L] ~nm:"x" W.Cte_in_list.name ~lo:0L (fun _ -> ()));
+
+  go "cte_choice: all, by id" (fun () ->
+    W.Cte_choice.select db ~f:`All W.Cte_choice.name ~sort:`I (fun _ -> ()));
+  go "cte_choice: by status, by name" (fun () ->
+    W.Cte_choice.select db ~f:(`ByStatus 2L) W.Cte_choice.name ~sort:`N (fun _ -> ()));
+
+  go "cte_opt_filter: none, empty pairs" (fun () ->
+    W.Cte_opt_filter.select db ~st:None W.Cte_opt_filter.name ~pairs:[] (fun _ -> ()));
+  go "cte_opt_filter: some, pairs" (fun () ->
+    W.Cte_opt_filter.select db ~st:(Some 1L) W.Cte_opt_filter.name ~pairs:[(Some 1L, Some "a")] (fun _ -> ()));
+
+  go "cte_shared_choice: all" (fun () ->
+    W.Cte_shared_choice.select db W.Cte_shared_choice.name ~f:`All (fun _ -> ()));
+  go "cte_shared_choice: by id (cte + main)" (fun () ->
+    W.Cte_shared_choice.select db W.Cte_shared_choice.name ~f:(`ById 9L) (fun _ -> ()));
+
+  go "cte_param_col: plain column" (fun () ->
+    W.Cte_param_col.select db ~st:1L W.Cte_param_col.id (fun _ -> ()));
+  go "cte_param_col: param inside picked column binds after cte param" (fun () ->
+    W.Cte_param_col.select db ~st:1L (W.Cte_param_col.is_new (Some 100L)) (fun _ -> ()));
+
+  go "where_subquery: empty names" (fun () ->
+    W.Where_subquery.select db W.Where_subquery.name ~st:1L ~names:[] (fun _ -> ()));
+  go "where_subquery: two names" (fun () ->
+    W.Where_subquery.select db W.Where_subquery.name ~st:1L ~names:["a"; "b"] (fun _ -> ()))

--- a/test/cram/test_dynamic_select_compose/run.t
+++ b/test/cram/test_dynamic_select_compose/run.t
@@ -1,0 +1,132 @@
+Dynamic select composed with other parameter constructs.
+
+  $ cat compose.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > compose.ml
+  $ diff compose.ml compose.compare.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c compose.ml
+
+Dynamic select on top of parameterized CTEs and subqueries.
+
+  $ cat cte.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > cte.ml
+  $ diff cte.ml cte.compare.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c cte.ml
+
+Run the generated code against the printing mock and check the final SQL strings.
+
+  $ cp ../print_ocaml_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_ocaml_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg,yojson -I . -c run.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg,yojson -I . -linkpkg -o run.exe print_ocaml_impl.cmo compose.cmo cte.cmo run.cmo
+  $ ./run.exe | grep -v '^\[MOCK'
+  -- in_list: empty ids
+  [SQL] SELECT name FROM t WHERE FALSE AND name = 'x'
+  
+  -- in_list: two ids
+  [SQL] SELECT name FROM t WHERE id IN (1, 2) AND name = 'x'
+  
+  -- tuple_list: empty pairs
+  [SQL] SELECT id FROM t WHERE FALSE
+  
+  -- tuple_list: two pairs with null
+  [SQL] SELECT id FROM t WHERE (id, name) IN ((1, 'a'), (NULL, 'b'))
+  
+  -- opt_filter: none
+  [SQL] SELECT name FROM t WHERE  TRUE 
+  
+  -- opt_filter: some
+  [SQL] SELECT name FROM t WHERE  (  id = 5  ) 
+  
+  -- order_choice: by id
+  [SQL] SELECT name FROM t ORDER BY  ( id ) 
+  
+  -- order_choice: by name
+  [SQL] SELECT name FROM t ORDER BY  ( name ) 
+  
+  -- order_comma_choice: comma before choice
+  [SQL] SELECT name FROM t ORDER BY id, ( name ) 
+  
+  -- where_choice: all
+  [SQL] SELECT name FROM t WHERE  ( TRUE ) 
+  
+  -- where_choice: by id
+  [SQL] SELECT name FROM t WHERE  ( id = 7 ) 
+  
+  -- shared_choice: all
+  [SQL] SELECT name FROM t
+  WHERE  ( TRUE ) 
+  AND ( ( TRUE )  OR id = 0)
+  
+  -- shared_choice: by id (both occurrences)
+  [SQL] SELECT name FROM t
+  WHERE  ( id = 7 ) 
+  AND ( ( id = 7 )  OR id = 0)
+  
+  -- kitchen_sink: everything on
+  [SQL] SELECT name FROM t
+  WHERE id IN (1, 2)
+  AND (id, name) IN ((1, 'a'))
+  AND  (  name = 'x'  ) 
+  AND  ( id = 5 ) 
+  AND ( ( id = 5 )  OR id = 0)
+  ORDER BY  ( name ) 
+  
+  -- kitchen_sink: everything off
+  [SQL] SELECT name FROM t
+  WHERE FALSE
+  AND FALSE
+  AND  TRUE 
+  AND  ( TRUE ) 
+  AND ( ( TRUE )  OR id = 0)
+  ORDER BY  ( id ) 
+  
+  -- cte_plain
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE status = 1)
+  SELECT name FROM filtered WHERE id > 10
+  
+  -- cte_in_list: empty ids
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE FALSE AND name = 'x')
+  SELECT name FROM filtered WHERE id > 0
+  
+  -- cte_in_list: two ids
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE id IN (1, 2) AND name = 'x')
+  SELECT name FROM filtered WHERE id > 0
+  
+  -- cte_choice: all, by id
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  ( TRUE ) )
+  SELECT name FROM filtered ORDER BY  ( id ) 
+  
+  -- cte_choice: by status, by name
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  ( status = 2 ) )
+  SELECT name FROM filtered ORDER BY  ( name ) 
+  
+  -- cte_opt_filter: none, empty pairs
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  TRUE )
+  SELECT name FROM filtered WHERE FALSE
+  
+  -- cte_opt_filter: some, pairs
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  (  status = 1  ) )
+  SELECT name FROM filtered WHERE (id, name) IN ((1, 'a'))
+  
+  -- cte_shared_choice: all
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  ( TRUE ) )
+  SELECT name FROM filtered WHERE  ( TRUE ) 
+  
+  -- cte_shared_choice: by id (cte + main)
+  [SQL] WITH filtered AS (SELECT id, name FROM t WHERE  ( id = 9 ) )
+  SELECT name FROM filtered WHERE  ( id = 9 ) 
+  
+  -- cte_param_col: plain column
+  [SQL] WITH recent AS (SELECT id, name, status FROM t WHERE status = 1)
+  SELECT id FROM recent
+  
+  -- cte_param_col: param inside picked column binds after cte param
+  [SQL] WITH recent AS (SELECT id, name, status FROM t WHERE status = 1)
+  SELECT (status >= 100) FROM recent
+  
+  -- where_subquery: empty names
+  [SQL] SELECT name FROM t
+  WHERE id IN (SELECT id FROM t WHERE status = 1 AND FALSE)
+  
+  -- where_subquery: two names
+  [SQL] SELECT name FROM t
+  WHERE id IN (SELECT id FROM t WHERE status = 1 AND name IN ('a', 'b'))
+  

--- a/test/cram/test_dynamic_select_matrix/dune
+++ b/test/cram/test_dynamic_select_matrix/dune
@@ -1,0 +1,6 @@
+(cram
+ (deps
+  %{bin:sqlgg}
+  (glob_files *.sql)
+  run.ml
+  ../print_ocaml_impl.ml))

--- a/test/cram/test_dynamic_select_matrix/matrix.sql
+++ b/test/cram/test_dynamic_select_matrix/matrix.sql
@@ -1,0 +1,109 @@
+CREATE TABLE t (
+    id INT NOT NULL,
+    name TEXT NOT NULL,
+    status INT NOT NULL
+);
+
+-- === position: before (construct in CTE body, dynamic column after it) ===
+
+-- [sqlgg] dynamic_select=true
+-- @before_param
+WITH f AS (SELECT id, name, status FROM t WHERE status = @st)
+SELECT id, name FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @before_in
+WITH f AS (SELECT id, name, status FROM t WHERE id IN @ids)
+SELECT id, name FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @before_not_in
+WITH f AS (SELECT id, name, status FROM t WHERE id NOT IN @ids)
+SELECT id, name FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @before_tuple
+WITH f AS (SELECT id, name, status FROM t WHERE (id, name) IN @pairs)
+SELECT id, name FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @before_opt
+WITH f AS (SELECT id, name, status FROM t WHERE { status = @st }?)
+SELECT id, name FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @before_choice
+WITH f AS (SELECT id, name, status FROM t WHERE @c { All { TRUE } | ByS { status = @s } })
+SELECT id, name FROM f;
+
+-- === position: inside (construct inside the picked dynamic column) ===
+
+-- [sqlgg] dynamic_select=true
+-- @inside_param
+SELECT id, (status >= @cutoff) AS is_new FROM t;
+
+-- [sqlgg] dynamic_select=true
+-- @inside_in
+SELECT id, (id IN @ids) AS hit FROM t;
+
+-- [sqlgg] dynamic_select=true
+-- @inside_not_in
+SELECT id, (id NOT IN @ids) AS miss FROM t;
+
+-- [sqlgg] dynamic_select=true
+-- @inside_tuple
+SELECT id, ((id, name) IN @pairs) AS matched FROM t;
+
+-- [sqlgg] dynamic_select=true
+-- @inside_choice
+SELECT id, @c { Zero { 0 } | Val { @v } } AS x FROM t;
+
+-- === position: after (construct in main WHERE / ORDER BY, dynamic column first) ===
+
+-- [sqlgg] dynamic_select=true
+-- @after_param
+SELECT id, name FROM t WHERE status = @st;
+
+-- [sqlgg] dynamic_select=true
+-- @after_in
+SELECT id, name FROM t WHERE id IN @ids;
+
+-- [sqlgg] dynamic_select=true
+-- @after_not_in
+SELECT id, name FROM t WHERE id NOT IN @ids;
+
+-- [sqlgg] dynamic_select=true
+-- @after_tuple
+SELECT id, name FROM t WHERE (id, name) IN @pairs;
+
+-- [sqlgg] dynamic_select=true
+-- @after_opt
+SELECT id, name FROM t WHERE { status = @st }?;
+
+-- [sqlgg] dynamic_select=true
+-- @after_choice
+SELECT id, name FROM t WHERE @c { All { TRUE } | ByS { status = @s } };
+
+-- === shared choice across positions ===
+
+-- [sqlgg] dynamic_select=true
+-- @shared_before_after
+WITH f AS (SELECT id, name, status FROM t WHERE @c { All { TRUE } | ByS { status = @a } })
+SELECT id, name FROM f WHERE @c { All { TRUE } | ByS { status = @b } };
+
+-- === binding order across all three positions ===
+
+-- [sqlgg] dynamic_select=true
+-- @order_before_inside_after
+WITH f AS (SELECT id, name, status FROM t WHERE status = @a)
+SELECT id, (status >= @b) AS flag FROM f WHERE id > @c;
+
+-- [sqlgg] dynamic_select=true
+-- @mega
+WITH f AS (SELECT id, name, status FROM t WHERE id IN @ids AND { status = @st }?)
+SELECT id, (status >= @cutoff) AS is_new
+FROM f
+WHERE @c { All { TRUE } | ByS { status = @a } }
+  AND (id, name) IN @pairs
+  AND @c { All { TRUE } | ByS { status = @b } }
+ORDER BY @sort { I { id } | N { name } };

--- a/test/cram/test_dynamic_select_matrix/reusable.sql
+++ b/test/cram/test_dynamic_select_matrix/reusable.sql
@@ -1,0 +1,35 @@
+CREATE TABLE t (
+    id INT NOT NULL,
+    name TEXT NOT NULL,
+    status INT NOT NULL
+);
+
+-- @frag_param | include: reuse
+SELECT id, name, status FROM t WHERE status = @st;
+
+-- @frag_mixed | include: reuse
+SELECT id, name, status FROM t
+WHERE id IN @ids AND { status = @st }? AND @c { All { TRUE } | ByS { status = @s } };
+
+-- [sqlgg] dynamic_select=true
+-- @reuse_param
+WITH f AS &frag_param
+SELECT id, name FROM f WHERE id > @lo;
+
+-- [sqlgg] dynamic_select=true
+-- @reuse_param_col
+WITH f AS &frag_param
+SELECT id, (status >= @cutoff) AS is_new FROM f;
+
+-- [sqlgg] dynamic_select=true
+-- @reuse_mixed
+WITH f AS &frag_mixed
+SELECT id, name
+FROM f
+WHERE (id, name) IN @pairs
+ORDER BY @sort { I { id } | N { name } };
+
+-- [sqlgg] dynamic_select=true
+-- @reuse_twice
+WITH a AS &frag_param, b AS &frag_param
+SELECT a.id, a.name FROM a JOIN b ON a.id = b.id WHERE a.id > @lo;

--- a/test/cram/test_dynamic_select_matrix/run.ml
+++ b/test/cram/test_dynamic_select_matrix/run.ml
@@ -1,0 +1,130 @@
+open Printf
+
+module M = Matrix.Sqlgg(Print_ocaml_impl)
+module R = Reusable.Sqlgg(Print_ocaml_impl)
+
+let go name f =
+  printf "-- %s\n" name;
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_select_response [];
+  f ();
+  printf "\n"
+
+let () =
+  let db = () in
+
+  go "before_param" (fun () ->
+    M.Before_param.select db ~st:111L M.Before_param.name (fun _ -> ()));
+
+  go "before_in: empty" (fun () ->
+    M.Before_in.select db ~ids:[] M.Before_in.name (fun _ -> ()));
+  go "before_in: two" (fun () ->
+    M.Before_in.select db ~ids:[111L; 112L] M.Before_in.name (fun _ -> ()));
+
+  go "before_not_in: empty" (fun () ->
+    M.Before_not_in.select db ~ids:[] M.Before_not_in.name (fun _ -> ()));
+  go "before_not_in: two" (fun () ->
+    M.Before_not_in.select db ~ids:[111L; 112L] M.Before_not_in.name (fun _ -> ()));
+
+  go "before_tuple: empty" (fun () ->
+    M.Before_tuple.select db ~pairs:[] M.Before_tuple.name (fun _ -> ()));
+  go "before_tuple: two" (fun () ->
+    M.Before_tuple.select db ~pairs:[(111L, "a"); (112L, "b")] M.Before_tuple.name (fun _ -> ()));
+
+  go "before_opt: none" (fun () ->
+    M.Before_opt.select db ~st:None M.Before_opt.name (fun _ -> ()));
+  go "before_opt: some" (fun () ->
+    M.Before_opt.select db ~st:(Some 111L) M.Before_opt.name (fun _ -> ()));
+
+  go "before_choice: all" (fun () ->
+    M.Before_choice.select db ~c:`All M.Before_choice.name (fun _ -> ()));
+  go "before_choice: by status" (fun () ->
+    M.Before_choice.select db ~c:(`ByS 111L) M.Before_choice.name (fun _ -> ()));
+
+  go "inside_param: plain col" (fun () ->
+    M.Inside_param.select db M.Inside_param.id (fun _ -> ()));
+  go "inside_param: param col" (fun () ->
+    M.Inside_param.select db (M.Inside_param.is_new 222L) (fun _ -> ()));
+
+  go "inside_in: empty" (fun () ->
+    M.Inside_in.select db (M.Inside_in.hit []) (fun _ -> ()));
+  go "inside_in: two" (fun () ->
+    M.Inside_in.select db (M.Inside_in.hit [221L; 222L]) (fun _ -> ()));
+
+  go "inside_not_in: empty" (fun () ->
+    M.Inside_not_in.select db (M.Inside_not_in.miss []) (fun _ -> ()));
+  go "inside_not_in: two" (fun () ->
+    M.Inside_not_in.select db (M.Inside_not_in.miss [221L; 222L]) (fun _ -> ()));
+
+  go "inside_tuple: empty" (fun () ->
+    M.Inside_tuple.select db (M.Inside_tuple.matched []) (fun _ -> ()));
+  go "inside_tuple: two" (fun () ->
+    M.Inside_tuple.select db (M.Inside_tuple.matched [(221L, "a"); (222L, "b")]) (fun _ -> ()));
+
+  go "inside_choice: zero" (fun () ->
+    M.Inside_choice.select db (M.Inside_choice.x `Zero) (fun _ -> ()));
+  go "inside_choice: val" (fun () ->
+    M.Inside_choice.select db (M.Inside_choice.x (`Val 222L)) (fun _ -> ()));
+
+  go "after_param" (fun () ->
+    M.After_param.select db M.After_param.name ~st:333L (fun _ -> ()));
+
+  go "after_in: empty" (fun () ->
+    M.After_in.select db M.After_in.name ~ids:[] (fun _ -> ()));
+  go "after_in: two" (fun () ->
+    M.After_in.select db M.After_in.name ~ids:[333L; 334L] (fun _ -> ()));
+
+  go "after_not_in: empty" (fun () ->
+    M.After_not_in.select db M.After_not_in.name ~ids:[] (fun _ -> ()));
+  go "after_not_in: two" (fun () ->
+    M.After_not_in.select db M.After_not_in.name ~ids:[333L; 334L] (fun _ -> ()));
+
+  go "after_tuple: empty" (fun () ->
+    M.After_tuple.select db M.After_tuple.name ~pairs:[] (fun _ -> ()));
+  go "after_tuple: two" (fun () ->
+    M.After_tuple.select db M.After_tuple.name ~pairs:[(333L, "a"); (334L, "b")] (fun _ -> ()));
+
+  go "after_opt: none" (fun () ->
+    M.After_opt.select db M.After_opt.name ~st:None (fun _ -> ()));
+  go "after_opt: some" (fun () ->
+    M.After_opt.select db M.After_opt.name ~st:(Some 333L) (fun _ -> ()));
+
+  go "after_choice: all" (fun () ->
+    M.After_choice.select db M.After_choice.name ~c:`All (fun _ -> ()));
+  go "after_choice: by status" (fun () ->
+    M.After_choice.select db M.After_choice.name ~c:(`ByS 333L) (fun _ -> ()));
+
+  go "shared_before_after: all" (fun () ->
+    M.Shared_before_after.select db M.Shared_before_after.name ~c:`All (fun _ -> ()));
+  go "shared_before_after: by status" (fun () ->
+    M.Shared_before_after.select db M.Shared_before_after.name ~c:(`ByS 123L) (fun _ -> ()));
+
+  go "order_before_inside_after: plain col" (fun () ->
+    M.Order_before_inside_after.select db ~a:111L M.Order_before_inside_after.id ~c:333L (fun _ -> ()));
+  go "order_before_inside_after: param col" (fun () ->
+    M.Order_before_inside_after.select db ~a:111L (M.Order_before_inside_after.flag 222L) ~c:333L (fun _ -> ()));
+
+  go "mega: everything on" (fun () ->
+    M.Mega.select db ~ids:[111L; 112L] ~st:(Some 113L) (M.Mega.is_new 222L)
+      ~pairs:[(333L, "a")] ~c:(`ByS 331L) ~sort:`N (fun _ -> ()));
+  go "mega: everything off" (fun () ->
+    M.Mega.select db ~ids:[] ~st:None M.Mega.id
+      ~pairs:[] ~c:`All ~sort:`I (fun _ -> ()));
+
+  go "reuse_param" (fun () ->
+    R.Reuse_param.select db ~st:111L R.Reuse_param.name ~lo:333L (fun _ -> ()));
+
+  go "reuse_param_col: plain col" (fun () ->
+    R.Reuse_param_col.select db ~st:111L R.Reuse_param_col.id (fun _ -> ()));
+  go "reuse_param_col: param col" (fun () ->
+    R.Reuse_param_col.select db ~st:111L (R.Reuse_param_col.is_new 222L) (fun _ -> ()));
+
+  go "reuse_mixed: everything on" (fun () ->
+    R.Reuse_mixed.select db ~ids:[111L; 112L] ~st:(Some 113L) ~c:(`ByS 114L)
+      (R.Reuse_mixed.name) ~pairs:[(333L, "a")] ~sort:`N (fun _ -> ()));
+  go "reuse_mixed: everything off" (fun () ->
+    R.Reuse_mixed.select db ~ids:[] ~st:None ~c:`All
+      (R.Reuse_mixed.id) ~pairs:[] ~sort:`I (fun _ -> ()));
+
+  go "reuse_twice: same fragment binds both ctes" (fun () ->
+    R.Reuse_twice.select db ~st:111L R.Reuse_twice.name ~lo:333L (fun _ -> ()))

--- a/test/cram/test_dynamic_select_matrix/run.t
+++ b/test/cram/test_dynamic_select_matrix/run.t
@@ -1,0 +1,190 @@
+Matrix: every parameter construct in every position relative to the dynamic
+column (before = in CTE body, inside = in the picked column, after = in main
+WHERE/ORDER BY), checked by running the generated code and comparing the final
+SQL strings. Distinct sentinel values (111x = before, 222x = inside,
+333x = after) make any misordered binding visible.
+
+Reusable queries included as CTEs (WITH x AS &frag) must compose the same way.
+
+  $ cat matrix.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > matrix.ml
+  $ cat reusable.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > reusable.ml
+  $ cp ../print_ocaml_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_ocaml_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c matrix.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c reusable.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg,yojson -I . -c run.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg,yojson -I . -linkpkg -o run.exe print_ocaml_impl.cmo matrix.cmo reusable.cmo run.cmo
+  $ ./run.exe | grep -v '^\[MOCK'
+  -- before_param
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT name FROM f
+  
+  -- before_in: empty
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE FALSE)
+  SELECT name FROM f
+  
+  -- before_in: two
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE id IN (111, 112))
+  SELECT name FROM f
+  
+  -- before_not_in: empty
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE TRUE)
+  SELECT name FROM f
+  
+  -- before_not_in: two
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE id NOT IN (111, 112))
+  SELECT name FROM f
+  
+  -- before_tuple: empty
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE FALSE)
+  SELECT name FROM f
+  
+  -- before_tuple: two
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE (id, name) IN ((111, 'a'), (112, 'b')))
+  SELECT name FROM f
+  
+  -- before_opt: none
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  TRUE )
+  SELECT name FROM f
+  
+  -- before_opt: some
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  (  status = 111  ) )
+  SELECT name FROM f
+  
+  -- before_choice: all
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  ( TRUE ) )
+  SELECT name FROM f
+  
+  -- before_choice: by status
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  ( status = 111 ) )
+  SELECT name FROM f
+  
+  -- inside_param: plain col
+  [SQL] SELECT id FROM t
+  
+  -- inside_param: param col
+  [SQL] SELECT (status >= 222) FROM t
+  
+  -- inside_in: empty
+  [SQL] SELECT (FALSE) FROM t
+  
+  -- inside_in: two
+  [SQL] SELECT (id IN (221, 222)) FROM t
+  
+  -- inside_not_in: empty
+  [SQL] SELECT (TRUE) FROM t
+  
+  -- inside_not_in: two
+  [SQL] SELECT (id NOT IN (221, 222)) FROM t
+  
+  -- inside_tuple: empty
+  [SQL] SELECT (FALSE) FROM t
+  
+  -- inside_tuple: two
+  [SQL] SELECT ((id, name) IN ((221, 'a'), (222, 'b'))) FROM t
+  
+  -- inside_choice: zero
+  [SQL] SELECT  ( 0 )  FROM t
+  
+  -- inside_choice: val
+  [SQL] SELECT  ( 222 )  FROM t
+  
+  -- after_param
+  [SQL] SELECT name FROM t WHERE status = 333
+  
+  -- after_in: empty
+  [SQL] SELECT name FROM t WHERE FALSE
+  
+  -- after_in: two
+  [SQL] SELECT name FROM t WHERE id IN (333, 334)
+  
+  -- after_not_in: empty
+  [SQL] SELECT name FROM t WHERE TRUE
+  
+  -- after_not_in: two
+  [SQL] SELECT name FROM t WHERE id NOT IN (333, 334)
+  
+  -- after_tuple: empty
+  [SQL] SELECT name FROM t WHERE FALSE
+  
+  -- after_tuple: two
+  [SQL] SELECT name FROM t WHERE (id, name) IN ((333, 'a'), (334, 'b'))
+  
+  -- after_opt: none
+  [SQL] SELECT name FROM t WHERE  TRUE 
+  
+  -- after_opt: some
+  [SQL] SELECT name FROM t WHERE  (  status = 333  ) 
+  
+  -- after_choice: all
+  [SQL] SELECT name FROM t WHERE  ( TRUE ) 
+  
+  -- after_choice: by status
+  [SQL] SELECT name FROM t WHERE  ( status = 333 ) 
+  
+  -- shared_before_after: all
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  ( TRUE ) )
+  SELECT name FROM f WHERE  ( TRUE ) 
+  
+  -- shared_before_after: by status
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE  ( status = 123 ) )
+  SELECT name FROM f WHERE  ( status = 123 ) 
+  
+  -- order_before_inside_after: plain col
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT id FROM f WHERE id > 333
+  
+  -- order_before_inside_after: param col
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT (status >= 222) FROM f WHERE id > 333
+  
+  -- mega: everything on
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE id IN (111, 112) AND  (  status = 113  ) )
+  SELECT (status >= 222)
+  FROM f
+  WHERE  ( status = 331 ) 
+  AND (id, name) IN ((333, 'a'))
+  AND  ( status = 331 ) 
+  ORDER BY  ( name ) 
+  
+  -- mega: everything off
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE FALSE AND  TRUE )
+  SELECT id
+  FROM f
+  WHERE  ( TRUE ) 
+  AND FALSE
+  AND  ( TRUE ) 
+  ORDER BY  ( id ) 
+  
+  -- reuse_param
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT name FROM f WHERE id > 333
+  
+  -- reuse_param_col: plain col
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT id FROM f
+  
+  -- reuse_param_col: param col
+  [SQL] WITH f AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT (status >= 222) FROM f
+  
+  -- reuse_mixed: everything on
+  [SQL] WITH f AS (SELECT id, name, status FROM t
+  WHERE id IN (111, 112) AND  (  status = 113  )  AND  ( status = 114 ) )
+  SELECT name
+  FROM f
+  WHERE (id, name) IN ((333, 'a'))
+  ORDER BY  ( name ) 
+  
+  -- reuse_mixed: everything off
+  [SQL] WITH f AS (SELECT id, name, status FROM t
+  WHERE FALSE AND  TRUE  AND  ( TRUE ) )
+  SELECT id
+  FROM f
+  WHERE FALSE
+  ORDER BY  ( id ) 
+  
+  -- reuse_twice: same fragment binds both ctes
+  [SQL] WITH a AS (SELECT id, name, status FROM t WHERE status = 111), b AS (SELECT id, name, status FROM t WHERE status = 111)
+  SELECT a.name FROM a JOIN b ON a.id = b.id WHERE a.id > 333
+  

--- a/test/cram/test_shared_choice/dune
+++ b/test/cram/test_shared_choice/dune
@@ -1,0 +1,5 @@
+(cram
+ (deps
+  %{bin:sqlgg}
+  (glob_files *.sql)
+  (glob_files *.compare.ml)))

--- a/test/cram/test_shared_choice/run.t
+++ b/test/cram/test_shared_choice/run.t
@@ -1,0 +1,59 @@
+Shared choices (same @name used several times in one statement).
+
+  $ cat shared.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > shared.ml
+  $ diff shared.ml shared.compare.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c shared.ml
+
+Different branches are rejected:
+
+  $ sqlgg -gen caml -no-header - <<'EOF'
+  > CREATE TABLE t (a INT, b INT);
+  > SELECT * FROM t WHERE a = @x { A { 1 } | B { 2 } } AND b = @x { C { 10 } | D { 20 } };
+  > EOF
+  Failed : SELECT * FROM t WHERE a = @x { A { 1 } | B { 2 } } AND b = @x { C { 10 } | D { 20 } }
+  At : @x { C { 10 } | D { 20 } }
+  Fatal error: exception Failure("choice x is used several times with different branches")
+  [2]
+
+Different number of branches is rejected:
+
+  $ sqlgg -gen caml -no-header - <<'EOF'
+  > CREATE TABLE t (a INT, b INT);
+  > SELECT * FROM t WHERE a = @x { A { 1 } | B { 2 } } AND b = @x { A { 1 } | B { 2 } | C { 3 } };
+  > EOF
+  Failed : SELECT * FROM t WHERE a = @x { A { 1 } | B { 2 } } AND b = @x { A { 1 } | B { 2 } | C { 3 } }
+  At : @x { A { 1 } | B { 2 } | C { 3 } }
+  Fatal error: exception Failure("choice x is used several times with different branches")
+  [2]
+
+Param in one occurrence, constant in the other is rejected:
+
+  $ sqlgg -gen caml -no-header - <<'EOF'
+  > CREATE TABLE t (a INT, b INT);
+  > SELECT * FROM t WHERE a = @x { A { @p } | B { 2 } } AND b = @x { A { 1 } | B { 2 } };
+  > EOF
+  Failed : SELECT * FROM t WHERE a = @x { A { @p } | B { 2 } } AND b = @x { A { 1 } | B { 2 } }
+  At : @x { A { 1 } | B { 2 } }
+  Fatal error: exception Failure("choice x is used several times with different branches")
+  [2]
+
+Scalar param in one occurrence, IN-list in the other is rejected:
+
+  $ sqlgg -gen caml -no-header - <<'EOF'
+  > CREATE TABLE t (a INT, b INT);
+  > SELECT * FROM t WHERE @x { P { a = @v } | N { TRUE } } AND @x { P { b IN @v } | N { TRUE } };
+  > EOF
+  Failed : SELECT * FROM t WHERE @x { P { a = @v } | N { TRUE } } AND @x { P { b IN @v } | N { TRUE } }
+  At : @x { P { b IN @v } | N { TRUE } }
+  Fatal error: exception Failure("choice x is used several times with different branches")
+  [2]
+
+Differently named params of incompatible types are rejected:
+
+  $ sqlgg -gen caml -no-header -dialect=mysql - <<'EOF'
+  > CREATE TABLE t (id INT, name TEXT);
+  > SELECT id FROM t WHERE @f { P { id = @a } | N { TRUE } } AND @f { P { name = @b } | N { TRUE } };
+  > EOF
+  Failed : SELECT id FROM t WHERE @f { P { id = @a } | N { TRUE } } AND @f { P { name = @b } | N { TRUE } }
+  Fatal error: exception Failure("incompatible types for parameter \"b\" : Text and Int")
+  [2]

--- a/test/cram/test_shared_choice/shared.compare.ml
+++ b/test/cram/test_shared_choice/shared.compare.ml
@@ -1,0 +1,379 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_t db  =
+    T.execute db ("CREATE TABLE t (\n\
+    id INT NOT NULL,\n\
+    name TEXT,\n\
+    status INT\n\
+)") T.no_params
+
+  let shared_const db ~x callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match x with `Small -> 0 | `Big -> 0) + (match x with `Small -> 0 | `Big -> 0)) in
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params invoke_callback
+
+  let shared_param_same_name db ~x callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match x with `Const -> 0 | `Param _ -> 1) + (match x with `Const -> 0 | `Param _ -> 1)) in
+      begin match x with
+      | `Const -> ()
+      | `Param (v) ->
+        T.set_param_Int p v;
+      end;
+      begin match x with
+      | `Const -> ()
+      | `Param (v) ->
+        T.set_param_Int p v;
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params invoke_callback
+
+  let shared_params_diff_names db ~f callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1)) in
+      begin match f with
+      | `All -> ()
+      | `ByStatus (s) ->
+        T.set_param_Int p s;
+      end;
+      begin match f with
+      | `All -> ()
+      | `ByStatus (other) ->
+        T.set_param_Int p other;
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params invoke_callback
+
+  let shared_cte db ~f callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1)) in
+      begin match f with
+      | `All -> ()
+      | `ById (a) ->
+        T.set_param_Int p a;
+      end;
+      begin match f with
+      | `All -> ()
+      | `ById (b) ->
+        T.set_param_Int p b;
+      end;
+      T.finish_params p
+    in
+    T.select db ("WITH recent AS (\n\
+  SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
+)\n\
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params invoke_callback
+
+  let shared_mixed db ~ids ~nm ~f ~sort callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0)) in
+      begin match nm with
+      | None -> ()
+      | Some nm ->
+        T.set_param_Text p nm;
+      end;
+      begin match f with
+      | `All -> ()
+      | `ByStatus (s) ->
+        T.set_param_Int p s;
+      end;
+      begin match f with
+      | `All -> ()
+      | `ByStatus (s2) ->
+        T.set_param_Int p s2;
+      end;
+      T.finish_params p
+    in
+    T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
+  AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params invoke_callback
+
+  module Fold = struct
+    let shared_const db ~x callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with `Small -> 0 | `Big -> 0) + (match x with `Small -> 0 | `Big -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let shared_param_same_name db ~x callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with `Const -> 0 | `Param _ -> 1) + (match x with `Const -> 0 | `Param _ -> 1)) in
+        begin match x with
+        | `Const -> ()
+        | `Param (v) ->
+          T.set_param_Int p v;
+        end;
+        begin match x with
+        | `Const -> ()
+        | `Param (v) ->
+          T.set_param_Int p v;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let shared_params_diff_names db ~f callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1)) in
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s) ->
+          T.set_param_Int p s;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (other) ->
+          T.set_param_Int p other;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let shared_cte db ~f callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1)) in
+        begin match f with
+        | `All -> ()
+        | `ById (a) ->
+          T.set_param_Int p a;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ById (b) ->
+          T.set_param_Int p b;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("WITH recent AS (\n\
+  SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
+)\n\
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let shared_mixed db ~ids ~nm ~f ~sort callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0)) in
+        begin match nm with
+        | None -> ()
+        | Some nm ->
+          T.set_param_Text p nm;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s) ->
+          T.set_param_Int p s;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s2) ->
+          T.set_param_Int p s2;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
+  AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let shared_const db ~x callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with `Small -> 0 | `Big -> 0) + (match x with `Small -> 0 | `Big -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let shared_param_same_name db ~x callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match x with `Const -> 0 | `Param _ -> 1) + (match x with `Const -> 0 | `Param _ -> 1)) in
+        begin match x with
+        | `Const -> ()
+        | `Param (v) ->
+          T.set_param_Int p v;
+        end;
+        begin match x with
+        | `Const -> ()
+        | `Param (v) ->
+          T.set_param_Int p v;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let shared_params_diff_names db ~f callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1)) in
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s) ->
+          T.set_param_Int p s;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (other) ->
+          T.set_param_Int p other;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let shared_cte db ~f callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1)) in
+        begin match f with
+        | `All -> ()
+        | `ById (a) ->
+          T.set_param_Int p a;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ById (b) ->
+          T.set_param_Int p b;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("WITH recent AS (\n\
+  SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
+)\n\
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let shared_mixed db ~ids ~nm ~f ~sort callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0)) in
+        begin match nm with
+        | None -> ()
+        | Some nm ->
+          T.set_param_Text p nm;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s) ->
+          T.set_param_Int p s;
+        end;
+        begin match f with
+        | `All -> ()
+        | `ByStatus (s2) ->
+          T.set_param_Int p s2;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
+  AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
+  AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/test_shared_choice/shared.sql
+++ b/test/cram/test_shared_choice/shared.sql
@@ -1,0 +1,34 @@
+CREATE TABLE t (
+    id INT NOT NULL,
+    name TEXT,
+    status INT
+);
+
+-- @shared_const
+SELECT id FROM t
+WHERE id = @x { Small { 1 } | Big { 100 } }
+   OR status = @x { Small { 1 } | Big { 100 } };
+
+-- @shared_param_same_name
+SELECT id FROM t
+WHERE id = @x { Const { 1 } | Param { @v } }
+   OR status = @x { Const { 1 } | Param { @v } };
+
+-- @shared_params_diff_names
+SELECT id FROM t
+WHERE @f { All { TRUE } | ByStatus { status = @s } }
+  AND @f { All { TRUE } | ByStatus { id <> @other } };
+
+-- @shared_cte
+WITH recent AS (
+  SELECT id FROM t WHERE @f { All { TRUE } | ById { id = @a } }
+)
+SELECT id FROM recent WHERE @f { All { TRUE } | ById { id = @b } };
+
+-- @shared_mixed
+SELECT id FROM t
+WHERE id IN @ids
+  AND { name = @nm }?
+  AND @f { All { TRUE } | ByStatus { status = @s } }
+  AND (@f { All { TRUE } | ByStatus { status = @s2 } } OR id = 0)
+ORDER BY @sort { I { id } | N { name } };

--- a/test/out/shared_choice.xml
+++ b/test/out/shared_choice.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+
+<sqlgg>
+ <stmt name="create_test" sql="CREATE TABLE test(a INT, b INT)" category="DDL" kind="create" target="test" cardinality="0">
+  <in/>
+  <out/>
+ </stmt>
+ <stmt name="select_1" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
+  <in/>
+  <out>
+   <value name="a" type="Int" nullable="true"/>
+   <value name="b" type="Int" nullable="true"/>
+  </out>
+ </stmt>
+ <stmt name="select_2" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
+  <in>
+   <value name="v" type="Int"/>
+  </in>
+  <out>
+   <value name="a" type="Int" nullable="true"/>
+   <value name="b" type="Int" nullable="true"/>
+  </out>
+ </stmt>
+ <stmt name="select_3" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
+  <in>
+   <value name="p" type="Int"/>
+   <value name="q" type="Int"/>
+  </in>
+  <out>
+   <value name="a" type="Int" nullable="true"/>
+   <value name="b" type="Int" nullable="true"/>
+  </out>
+ </stmt>
+ <table name="test">
+  <schema>
+   <value name="a" type="Int" nullable="true"/>
+   <value name="b" type="Int" nullable="true"/>
+  </schema>
+ </table>
+</sqlgg>

--- a/test/shared_choice.sql
+++ b/test/shared_choice.sql
@@ -1,0 +1,13 @@
+CREATE TABLE test(a INT, b INT);
+
+SELECT * FROM test
+WHERE a = @x { A { 1 } | B { 2 } }
+  AND b = @x { A { 10 } | B { 20 } };
+
+SELECT * FROM test
+WHERE a = @y { Const { 1 } | Param { @v } }
+  AND b = @y { Const { 1 } | Param { @v } };
+
+SELECT * FROM test
+WHERE a = @z { Const { 1 } | Param { @p } }
+  AND b = @z { Const { 1 } | Param { @q } };


### PR DESCRIPTION
### Description

This PR adds the support of shared Choices and makes dynamic select abosuletly composable with the rest of the exprs

#### Same choice can now be used several times


```sql
SELECT * FROM t
WHERE a = @x { A { 1 } | B { 2 } }
  AND b = @x { A { 10 } | B { 20 } };
```

This query was failed before since `@x` Choices expr was presented several times. now it's fixed.


####  Param names inside `Choices` branches don't have to match now

```sql
WITH cte AS (
 SELECT id FROM t 
 WHERE @f { ByStatus { status = @s } | All { TRUE } }
)
SELECT id FROM cte WHERE @f { ByStatus { id > @min } | All { TRUE } };
```

`@s` and `@min` are the same parameter here 

####  Dynamic select now composes with everything rest

```sql
-- @fragment_mixed | include: reuse
SELECT id, name, status FROM t
WHERE id IN @ids AND { status = @st }? AND @c { All { TRUE } | ByS { status = @s } };

-- [sqlgg] dynamic_select=true
-- @reuse_mixed
WITH f AS &fragment_mixed
SELECT id, name
FROM f
WHERE (id, name) IN @pairs
ORDER BY @sort { I { id } | N { name } };
```

Now: IN `@ids`, CTEs and reusable CTEs all work

query produced at runtime (checked by a [print test](https://github.com/jongleb/sqlgg/blob/branches-composable/test/cram/test_dynamic_select_matrix/run.t#L171)):


```sql
WITH f AS (SELECT id, name, status FROM t
WHERE id IN (111, 112) AND  (  status = 113  )  AND  ( status = 114 ) )
SELECT name
FROM f
WHERE (id, name) IN ((333, 'a'))
ORDER BY  ( name )
```