### PR TITLE
 Drop redundant dynamic select row mapper and add ppx `[@sqlgg.col]`

### DIFF
--- a/impl/ocaml/ppx/ppx_sqlgg.ml
+++ b/impl/ocaml/ppx/ppx_sqlgg.ml
@@ -2,51 +2,78 @@ open Ppxlib
 
 let fun_name = function "t" -> "of_cols" | t -> t ^ "_of_cols"
 
-let build ~loc tname (fields : label_declaration list) =
+let col_attr =
+  Attribute.declare "sqlgg.col" Attribute.Context.label_declaration
+    Ast_pattern.(single_expr_payload (estring __))
+    Fun.id
+
+let col_name ld =
+  Option.value (Attribute.get col_attr ld) ~default:ld.pld_name.txt
+
+let build ~loc tname first rest =
+  let fields = first :: rest in
   let (module B) = Ast_builder.make loc in
   let open B in
   let lid = Located.lident in
   let record_ty = ptyp_constr (lid tname) [] in
-  let names = List.map (fun ld -> ld.pld_name.txt) fields in
-  let ctor =
-    eabstract (List.map pvar names)
-      [%expr
-        ([%e pexp_record (List.map (fun n -> (lid n, evar n)) names) None]
-          : [%t record_ty])]
-  in
-  let col_ty field_ty =
-    [%type:
-      ([%t field_ty], 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col]
+  let col_ty t =
+    [%type: ([%t t], 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col]
   in
   let cols_ty =
     ptyp_object
-      (List.map (fun ld -> otag ld.pld_name (col_ty ld.pld_type)) fields)
+      (List.map (fun ld -> otag (Located.mk (col_name ld)) (col_ty ld.pld_type)) fields)
       Open
   in
-  let body =
-    List.fold_left
-      (fun acc n ->
-        [%expr Sqlgg_scope.apply [%e acc] [%e pexp_send [%expr sqlgg__cols] (Located.mk n)]])
-      [%expr Sqlgg_scope.pure [%e ctor]]
-      names
+  let record =
+    pexp_record (List.map (fun ld -> lid ld.pld_name.txt, evar ld.pld_name.txt) fields) None
   in
-  [ [%stri
-      let [%p pvar (fun_name tname)] =
-       fun (sqlgg__cols : [%t cols_ty]) : [%t col_ty record_ty] -> [%e body]]
-  ]
+  let bind op ld =
+    { pbop_op = Located.mk op
+    ; pbop_pat = pvar ld.pld_name.txt
+    ; pbop_exp = pexp_send [%expr sqlgg__cols] (Located.mk (col_name ld))
+    ; pbop_loc = loc
+    }
+  in
+  let letop =
+    pexp_letop
+      { let_ = bind "let+" first
+      ; ands = List.map (bind "and+") rest
+      ; body = [%expr ([%e record] : [%t record_ty])]
+      }
+  in
+  [%str
+    let [%p pvar (fun_name tname)] =
+     fun (sqlgg__cols : [%t cols_ty]) : [%t col_ty record_ty] ->
+      let open Sqlgg_scope in
+      [%e letop]]
+
+let expand ~ctxt (_rec_flag, tds) =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  let error msg _name =
+    [ Ast_builder.Default.pstr_extension ~loc
+        (Location.error_extensionf ~loc "deriving sqlgg: %s" msg)
+        [] ]
+  in
+  let build = build ~loc in
+  let td_pat =
+    Ast_pattern.(
+      let record = map2 (ptype_record (__ ^:: __)) ~f:(fun x xs name -> build name x xs) in
+      let fail msg = map1 __ ~f:(fun _ -> error msg) in
+      map_value ~f:(fun td -> (td.ptype_params, td.ptype_kind), td.ptype_name.txt)
+        (map1 ~f:(fun (f, name) -> f name)
+          (pack2
+            (pair
+              (alt
+                (pair nil (alt record (fail "only record types are supported")))
+                (fail "type parameters are not supported"))
+              __))))
+  in
+  List.concat_map (fun td -> Ast_pattern.parse td_pat loc td Fun.id) tds
 
 let () =
   Deriving.add "sqlgg"
     ~str_type_decl:
-      (Deriving.Generator.V2.make Deriving.Args.empty (fun ~ctxt (_, tds) ->
-           let loc = Expansion_context.Deriver.derived_item_loc ctxt in
-           List.concat_map
-             (fun td ->
-               Ast_pattern.(parse (ptype_record __)) loc td.ptype_kind
-                 ~on_error:(fun () ->
-                   [ [%stri
-                       [%%ocaml.error
-                       "deriving sqlgg: only record types are supported"]] ])
-                 (build ~loc td.ptype_name.txt))
-             tds))
+      (Deriving.Generator.V2.make_noarg
+         ~attributes:[ Attribute.T col_attr ]
+         expand)
   |> Deriving.ignore

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -1005,13 +1005,9 @@ and infer_schema ~not_null_keys env columns =
     | OptionActions _ -> Meta.empty ()
   in
   let refine_column (col : table_name Schema.Source.Attr.t) =
-    let key = (col.sources, col.attr.name) in
-    if List.mem key not_null_keys && Type.is_nullable col.attr.domain then
-      { col with
-        attr = { col.attr with
-                 domain = Type.make_strict col.attr.domain } }
-    else
-      col
+    if List.mem (col.sources, col.attr.name) not_null_keys
+    then Schema.Source.Attr.map_attr (fun attr -> { attr with domain = Type.make_strict attr.domain }) col
+    else col
   in
   let resolve1 = function
     | { value = All; _ } -> List.map (fun x -> AttrWithSources (refine_column x)) env.schema
@@ -1022,32 +1018,28 @@ and infer_schema ~not_null_keys env columns =
           (fun n -> Schema.Source.Attr.map_attr (fun attr -> { attr with name = n }) col)
           col alias
       in
-      let make_col e =
-        let _, t = resolve_types env e in
-        let sources = match e with
-          | Column c -> (resolve_column ~env c.collated).sources
-          | _ -> []
-        in
-        let col = {
-          Schema.Source.Attr.attr = unnamed_attribute ~meta:(propagate_meta ~env e) (get_or_failwith t);
-          sources
-        } in 
-        let col = refine_column col in
-        apply_alias col
+      let resolve_expr = function
+        | Column c -> resolve_column ~env c.collated
+        | e ->
+          let _, t = resolve_types env e in
+          { Schema.Source.Attr.attr = unnamed_attribute ~meta:(propagate_meta ~env e) (get_or_failwith t);
+            sources = [] }
       in
       let col =
         match expr with
-        | Column col -> 
-          let col = resolve_column ~env col.collated in
-          let col = refine_column col in
-          AttrWithSources (apply_alias col)
         | Choices (p, choices) when dynamic_allowed env ->
           let dynamic = choices |> List.filter_map (fun (choice_p, e_opt) -> 
             Option.map (fun choice_e ->
-              { Sql.field_id = choice_p; field_attr = make_col choice_e; join_deps = [] }) e_opt
+              let field_attr =
+                choice_e
+                |> resolve_expr |> refine_column
+                |> Schema.Source.Attr.map_attr (fun attr -> unnamed_attribute ~meta:attr.meta attr.domain)
+                |> apply_alias
+              in
+              { Sql.field_id = choice_p; field_attr; join_deps = [] }) e_opt
           ) in 
           DynamicWithSources (p, dynamic)
-        | e -> AttrWithSources (make_col e)
+        | e -> AttrWithSources (e |> resolve_expr |> refine_column |> apply_alias)
       in
       [ col ]
   in
@@ -1896,10 +1888,11 @@ end = struct
     | Some n -> n
     | None -> let n = { name; state = Root None } in Hashtbl.add t name n; n
 
+  (* one node per variable, so nodes are compared physically *)
   let rec root n =
     match n.state with
     | Root typ -> n, typ
-    | Link p -> let (r, _) as res = root p in if r != p then n.state <- Link r; res
+    | Link p -> let (r, _) as res = root p in (* relink directly to root so next lookups are one step *) if r != p then n.state <- Link r; res
 
   let unify name t1 t2 =
     match Type.common_type t1 t2 with
@@ -1915,7 +1908,7 @@ end = struct
   let alias t n1 n2 =
     let (r1, _) = root (node t n1) in
     let (r2, t2) = root (node t n2) in
-    if r1 != r2 then begin
+    if r1 != r2 then begin (* physically same root = already aliased *)
       Option.may (note t r1.name) t2;
       r2.state <- Link r1
     end

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -150,13 +150,22 @@ type scoped_field = {
 module L = struct
   open Type
 
-  let as_lang_type t =
-    type_name @@
-    match t with
-    | { t = Blob; nullability } | { t = StringLiteral _; nullability } -> { t = Text; nullability }
-    | { t = FloatingLiteral _; nullability } -> { t = Float; nullability }
-    | { t = Decimal _; nullability } -> { t = Decimal { precision = None; scale = None }; nullability }
-    | t -> t
+  let as_lang_type = function
+  | { t = Blob; nullability } -> type_name { t = Text; nullability }
+  | { t = StringLiteral _; nullability } -> type_name { t = Text; nullability }
+  | { t = FloatingLiteral _; nullability } -> type_name { t = Float; nullability }
+  | { t = Decimal _; nullability; } -> type_name { t = Decimal { precision = None; scale = None }; nullability } 
+  | { t = Int; _ }
+  | { t = Text; _ }
+  | { t = Float; _ }
+  | { t = Bool; _ }
+  | { t = Datetime; _ }
+  | { t = Union _; _ }
+  | { t = Json; _ }
+  | { t = Json_path; _ }
+  | { t = One_or_all; _ }
+  | { t = UInt64; _ }
+  | { t = Any; _ } as t -> type_name t
 
   let as_runtime_repr_name = function
   | { t = Blob; _ }
@@ -275,12 +284,13 @@ let supports_module_kind module_kind stmt =
   | `Single -> is_single_row_select stmt
   | `Direct -> true
 
-let emit_module ?(annotate = false) name body =
+let emit_module_gen ~footer name body =
   output "module %s = struct" name;
   indented body;
-  if annotate then output "end (* module %s *)" name else output "end"
+  output "%s" (footer name)
 
-let emit_module_annotated = emit_module ~annotate:true
+let emit_module = emit_module_gen ~footer:(fun _ -> "end")
+let emit_module_annotated = emit_module_gen ~footer:(sprintf "end (* module %s *)")
 
 let emit_module_kind_variants stmt emit =
   [`Fold; `List] |> List.iter (fun module_kind ->
@@ -742,7 +752,7 @@ type callback_build_state = {
   idx_expr: string option;
 }
 
-let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module stmt =
+let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module ~with_callback stmt =
   let sql_pieces = get_sql stmt in
   let join_ctors = join_ctors_of_vars stmt.Gen.vars in
 
@@ -827,7 +837,7 @@ let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module stmt =
   in
   let schema_segments = split_schema_multi [] [] stmt.schema in
 
-  let labeled = has_row_callback stmt in
+  let labeled = with_callback && has_row_callback stmt in
   let build_callback_body () =
     let col_idx_at ~base ~offset = match base with
       | None -> string_of_int offset
@@ -885,11 +895,16 @@ let emit_dynamic_module_select ~module_kind ~dynamic_infos stmt =
   if not (supports_module_kind module_kind stmt) then () else
   let dynamic_names = List.map (fun di -> di.param_name) dynamic_infos in
   let format_input = format_func_input dynamic_names ~dyn_annot:(fun _ -> "_ t") in
+  let with_callback =
+    match module_kind, stmt.schema with
+    | `List, [Sql.Dynamic _] -> false
+    | (`Direct | `Single | `Fold | `List), _ -> has_row_callback stmt
+  in
   let (_ : string list) =
     emit_func_header ~name:"select" ~extra_params:""
-      ~has_callback:(has_row_callback stmt) ~format_input ~module_kind stmt
+      ~has_callback:with_callback ~format_input ~module_kind stmt
   in
-  emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:true stmt
+  emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:true ~with_callback stmt
 
 let emit_sql_with_subst subst stmt =
   let sql = make_sql ~join_ctors:(join_ctors_of_vars stmt.Gen.vars) @@ get_sql stmt in
@@ -1149,7 +1164,7 @@ let generate_stmt_wrapper ~module_kind index stmt =
   | _ :: _ :: _ ->
     if supports_module_kind module_kind stmt then begin
       let _subst = gen_func_signature ~dynamic_infos ~module_kind ~index stmt in
-      emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:false stmt
+      emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:false ~with_callback:true stmt
     end
 
 let generate ~gen_io ~migration_names name stmts =

--- a/test/cram/dynamic_subquery.t
+++ b/test/cram/dynamic_subquery.t
@@ -83,7 +83,7 @@ Full generated code:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~min callback =
+        let select db (col : _ t) ~min =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -93,8 +93,7 @@ Full generated code:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -158,7 +157,7 @@ Full generated code:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~id callback =
+        let select db (col : _ t) ~id =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -168,8 +167,7 @@ Full generated code:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -202,7 +200,7 @@ Driver picking different fields at runtime:
   >   Printf.printf "=== %s ===\n%!" label;
   >   Print_impl.clear_mock_responses ();
   >   Print_impl.setup_select_response [];
-  >   ignore (List.select () col ~min:10L (fun x -> x))
+  >   ignore (List.select () col ~min:10L)
   > 
   > let () =
   >   run "pick id" id;

--- a/test/cram/not_null_refine.compare.ml
+++ b/test/cram/not_null_refine.compare.ml
@@ -1,105 +1,31 @@
 module Sqlgg (T : Sqlgg_traits.M) = struct
 
   module IO = Sqlgg_io.Blocking
-  module Get_user = struct
+  module Dynamic_not_null = struct
     type brand
     include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
     module Cols = struct
-      let id : _ t =
-        {
-          set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
-          column = ("id");
-          count = 0;
-          deps = [];
-        }
       let name : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("name");
+          count = 0;
+          deps = [];
+        }
+      let descr : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
+          column = ("descr");
           count = 0;
           deps = [];
         }
     end
     include Cols
     let cols = object
-      method id = Cols.id
       method name = Cols.name
-    end
-
-    let select db (col : _ t) ~id callback =
-      let set_params stmt =
-        let p = T.start_params stmt (1 + col.count) in
-        col.set p;
-        T.set_param_Int p id;
-        T.finish_params p
-      in
-      T.select db
-      ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col)
-
-    module Fold = struct
-      let select db (col : _ t) ~id callback acc =
-        let set_params stmt =
-          let p = T.start_params stmt (1 + col.count) in
-          col.set p;
-          T.set_param_Int p id;
-          T.finish_params p
-        in
-        let r_acc = ref acc in
-        IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col !r_acc)))
-        (fun () -> IO.return !r_acc)
-
-    end (* module Fold *)
-
-    module List = struct
-      let select db (col : _ t) ~id =
-        let set_params stmt =
-          let p = T.start_params stmt (1 + col.count) in
-          col.set p;
-          T.set_param_Int p id;
-          T.finish_params p
-        in
-        let r_acc = ref [] in
-        IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
-        (fun () -> IO.return (List.rev !r_acc))
-
-    end (* module List *)
-
-  end
-
-  module List_users = struct
-    type brand
-    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
-    module Cols = struct
-      let id : _ t =
-        {
-          set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
-          column = ("id");
-          count = 0;
-          deps = [];
-        }
-      let name : _ t =
-        {
-          set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
-          column = ("name");
-          count = 0;
-          deps = [];
-        }
-    end
-    include Cols
-    let cols = object
-      method id = Cols.id
-      method name = Cols.name
+      method descr = Cols.descr
     end
 
     let select db (col : _ t) callback =
@@ -109,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users")
+      ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users")
+        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +64,78 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users")
+        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Dynamic_or_stays_nullable = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+      let descr : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          column = ("descr");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method name = Cols.name
+      method descr = Cols.descr
+    end
+
+    let select db (col : _ t) callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + col.count) in
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -147,82 +144,40 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   end
 
 
-  let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") T.no_params
+  let create_items db  =
+    T.execute db ("CREATE TABLE items (\n\
+  id INT NOT NULL,\n\
+  name TEXT NULL,\n\
+  descr TEXT NULL\n\
+)") T.no_params
 
-  let get_user_static db ~id callback =
+  let static_not_null db  callback =
     let invoke_callback stmt =
       callback
-        ~id:(T.get_column_Int stmt 0)
-        ~name:(T.get_column_Text_nullable stmt 1)
+        ~name:(T.get_column_Text stmt 0)
     in
-    let set_params stmt =
-      let p = T.start_params stmt (1) in
-      T.set_param_Int p id;
-      T.finish_params p
-    in
-    T.select db ("SELECT id, name FROM users WHERE id = ?") set_params invoke_callback
-
-  let list_users_static db  callback =
-    let invoke_callback stmt =
-      callback
-        ~id:(T.get_column_Int stmt 0)
-        ~name:(T.get_column_Text_nullable stmt 1)
-    in
-    T.select db ("SELECT id, name FROM users") T.no_params invoke_callback
+    T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params invoke_callback
 
   module Fold = struct
-    let get_user_static db ~id callback acc =
+    let static_not_null db  callback acc =
       let invoke_callback stmt =
         callback
-          ~id:(T.get_column_Int stmt 0)
-          ~name:(T.get_column_Text_nullable stmt 1)
-      in
-      let set_params stmt =
-        let p = T.start_params stmt (1) in
-        T.set_param_Int p id;
-        T.finish_params p
+          ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
-      (fun () -> IO.return !r_acc)
-
-    let list_users_static db  callback acc =
-      let invoke_callback stmt =
-        callback
-          ~id:(T.get_column_Int stmt 0)
-          ~name:(T.get_column_Text_nullable stmt 1)
-      in
-      let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
   
   module List = struct
-    let get_user_static db ~id callback =
+    let static_not_null db  callback =
       let invoke_callback stmt =
         callback
-          ~id:(T.get_column_Int stmt 0)
-          ~name:(T.get_column_Text_nullable stmt 1)
-      in
-      let set_params stmt =
-        let p = T.start_params stmt (1) in
-        T.set_param_Int p id;
-        T.finish_params p
+          ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
-      (fun () -> IO.return (List.rev !r_acc))
-
-    let list_users_static db  callback =
-      let invoke_callback stmt =
-        callback
-          ~id:(T.get_column_Int stmt 0)
-          ~name:(T.get_column_Text_nullable stmt 1)
-      in
-      let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/not_null_refine.sql
+++ b/test/cram/not_null_refine.sql
@@ -1,0 +1,16 @@
+CREATE TABLE items (
+  id INT NOT NULL,
+  name TEXT NULL,
+  descr TEXT NULL
+);
+
+-- @static_not_null
+SELECT name FROM items WHERE name IS NOT NULL;
+
+-- [sqlgg] dynamic_select=true
+-- @dynamic_not_null
+SELECT name, descr FROM items WHERE name IS NOT NULL AND descr IS NOT NULL;
+
+-- [sqlgg] dynamic_select=true
+-- @dynamic_or_stays_nullable
+SELECT name, descr FROM items WHERE name IS NOT NULL OR descr IS NOT NULL;

--- a/test/cram/not_null_refine.t
+++ b/test/cram/not_null_refine.t
@@ -1,0 +1,5 @@
+WHERE ... IS NOT NULL makes the column strict, in static and dynamic selects
+alike; OR between guards gives no guarantee and keeps columns nullable:
+  $ /bin/sh ./sqlgg_test.sh not_null_refine.sql not_null_refine.compare.ml
+  $ echo $?
+  0

--- a/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -77,8 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -142,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -152,8 +151,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -217,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~b callback =
+      let select db (col : _ t) ~b =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -227,8 +225,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/basic.t/run.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/run.ml
@@ -8,13 +8,13 @@ module Basic = Basic.Sqlgg(Print_impl)
 
 let () =
   let open Basic.Ok in
-  run "basic/ok: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "basic/ok: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "basic/ok: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L));
+  run "basic/ok: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))
 
 let () =
   let open Basic.Nonuniq in
-  run "basic/nonuniq: pick id -> join kept (non-unique key)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "basic/nonuniq: pick id -> join kept (non-unique key)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Basic.Ref_in_where in
-  run "basic/ref_in_where: pick id -> join kept (WHERE reference)" (fun () -> ignore (List.select () id ~b:"x" (fun x -> x)))
+  run "basic/ref_in_where: pick id -> join kept (WHERE reference)" (fun () -> ignore (List.select () id ~b:"x"))

--- a/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
+++ b/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -77,8 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/chain_bad.t/run.ml
+++ b/test/cram/test_build_dynamic_join/chain_bad.t/run.ml
@@ -8,4 +8,4 @@ module Chain_bad = Chain_bad.Sqlgg(Print_impl)
 
 let () =
   let open Chain_bad.Chain_bad in
-  run "chain_bad: pick id -> both joins kept (child pins parent)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "chain_bad: pick id -> both joins kept (child pins parent)" (fun () -> ignore (List.select () id ~uid:1L))

--- a/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -77,8 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -160,7 +159,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -170,8 +169,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -244,7 +242,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -254,8 +252,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -337,7 +334,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~label callback =
+      let select db (col : _ t) ~label =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -347,8 +344,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/chains.t/run.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/run.ml
@@ -8,29 +8,29 @@ let run label f =
 
 let () =
   let open S.Chain in
-  run "chain: pick id" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "chain: pick bio" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)));
-  run "chain: pick url (pulls profiles transitively)" (fun () -> ignore (List.select () url ~uid:1L (fun x -> x)));
+  run "chain: pick id" (fun () -> ignore (List.select () id ~uid:1L));
+  run "chain: pick bio" (fun () -> ignore (List.select () bio ~uid:1L));
+  run "chain: pick url (pulls profiles transitively)" (fun () -> ignore (List.select () url ~uid:1L));
   run "chain: pick all" (fun () ->
-    ignore (List.select () (let+ i = id and+ b = bio and+ u = url in (i, b, u)) ~uid:1L (fun x -> x)))
+    ignore (List.select () (let+ i = id and+ b = bio and+ u = url in (i, b, u)) ~uid:1L))
 
 let () =
   let open S.Chain3 in
   run "chain3: pick label (pulls the whole ancestor chain)" (fun () ->
-    ignore (List.select () label ~uid:1L (fun x -> x)));
+    ignore (List.select () label ~uid:1L));
   run "chain3: pick url (badges not pulled)" (fun () ->
-    ignore (List.select () url ~uid:1L (fun x -> x)))
+    ignore (List.select () url ~uid:1L))
 
 let () =
   let open S.Diamond in
   run "diamond: pick url (one branch)" (fun () ->
-    ignore (List.select () url ~uid:1L (fun x -> x)));
+    ignore (List.select () url ~uid:1L));
   run "diamond: pick label (other branch)" (fun () ->
-    ignore (List.select () label ~uid:1L (fun x -> x)));
+    ignore (List.select () label ~uid:1L));
   run "diamond: pick both (parent emitted once)" (fun () ->
-    ignore (List.select () (let+ u = url and+ l = label in (u, l)) ~uid:1L (fun x -> x)))
+    ignore (List.select () (let+ u = url and+ l = label in (u, l)) ~uid:1L))
 
 let () =
   let open S.Chain_pinned in
   run "chain_pinned: pick id (WHERE pins the whole chain, no joins dropped)" (fun () ->
-    ignore (List.select () id ~label:"x" (fun x -> x)))
+    ignore (List.select () id ~label:"x"))

--- a/test/cram/test_build_dynamic_join/example.t/example.compare.ml
+++ b/test/cram/test_build_dynamic_join/example.t/example.compare.ml
@@ -143,7 +143,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE")
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~org callback =
+      let select db (col : _ t) ~org =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -155,8 +155,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE")
         ("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
 WHERE u.org_id = ? AND u.deleted = FALSE")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/example.t/run.ml
+++ b/test/cram/test_build_dynamic_join/example.t/run.ml
@@ -9,12 +9,12 @@ module Example = Example.Sqlgg(Print_impl)
 let () =
   let open Example.User_info in
   run "brief: name + email -> no joins" (fun () ->
-    ignore (List.select () (let+ n = name and+ e = email in (n, e)) ~org:1L (fun x -> x)));
+    ignore (List.select () (let+ n = name and+ e = email in (n, e)) ~org:1L));
   run "card: name + bio + avatar_url -> profiles only" (fun () ->
-    ignore (List.select () (let+ n = name and+ b = bio and+ a = avatar_url in (n, b, a)) ~org:1L (fun x -> x)));
+    ignore (List.select () (let+ n = name and+ b = bio and+ a = avatar_url in (n, b, a)) ~org:1L));
   run "brief + billing, no profile: name + plan -> billing only" (fun () ->
-    ignore (List.select () (let+ n = name and+ pl = plan in (n, pl)) ~org:1L (fun x -> x)));
+    ignore (List.select () (let+ n = name and+ pl = plan in (n, pl)) ~org:1L));
   run "admin: everything -> both joins" (fun () ->
     ignore (List.select ()
       (let+ n = name and+ b = bio and+ pl = plan and+ bal = balance in (n, b, pl, bal))
-      ~org:1L (fun x -> x)))
+      ~org:1L))

--- a/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -133,7 +132,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -143,8 +142,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -208,7 +206,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -218,8 +216,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -292,7 +289,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -302,8 +299,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -376,7 +372,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -386,8 +382,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -451,7 +446,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -461,8 +456,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -526,7 +520,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -536,8 +530,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -610,7 +603,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -620,8 +613,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/join_kinds.t/run.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/run.ml
@@ -8,33 +8,33 @@ module Join_kinds = Join_kinds.Sqlgg(Print_impl)
 
 let () =
   let open Join_kinds.Inner_join in
-  run "join_kinds/inner: pick id -> join kept (INNER)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/inner: pick id -> join kept (INNER)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Join_using in
-  run "join_kinds/using: pick id -> join kept (USING)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/using: pick id -> join kept (USING)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Join_natural in
-  run "join_kinds/natural: pick id -> join kept (NATURAL)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/natural: pick id -> join kept (NATURAL)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Using_after_candidate in
-  run "join_kinds/using_after: pick id -> candidate kept (later USING)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/using_after: pick id -> candidate kept (later USING)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Natural_after_candidate in
-  run "join_kinds/natural_after: pick id -> candidate kept (later NATURAL)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/natural_after: pick id -> candidate kept (later NATURAL)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Right_join in
-  run "join_kinds/right_join: pick id -> join kept (RIGHT)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/right_join: pick id -> join kept (RIGHT)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Comma_join in
-  run "join_kinds/comma_join: pick id -> join kept (comma join)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "join_kinds/comma_join: pick id -> join kept (comma join)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Join_kinds.Implicit_before_candidate in
-  run "join_kinds/implicit_before: pick id -> join dropped (USING before candidate)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "join_kinds/implicit_before: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "join_kinds/implicit_before: pick id -> join dropped (USING before candidate)" (fun () -> ignore (List.select () id ~uid:1L));
+  run "join_kinds/implicit_before: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))

--- a/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -133,7 +132,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -143,8 +142,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -208,7 +206,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -218,8 +216,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/key_shapes.t/run.ml
+++ b/test/cram/test_build_dynamic_join/key_shapes.t/run.ml
@@ -8,14 +8,14 @@ module Key_shapes = Key_shapes.Sqlgg(Print_impl)
 
 let () =
   let open Key_shapes.Unique_key in
-  run "key_shapes/unique: pick id -> join dropped (UNIQUE key)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "key_shapes/unique: pick label -> join present" (fun () -> ignore (List.select () label ~uid:1L (fun x -> x)))
+  run "key_shapes/unique: pick id -> join dropped (UNIQUE key)" (fun () -> ignore (List.select () id ~uid:1L));
+  run "key_shapes/unique: pick label -> join present" (fun () -> ignore (List.select () label ~uid:1L))
 
 let () =
   let open Key_shapes.Composite_partial in
-  run "key_shapes/composite_partial: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "key_shapes/composite_partial: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Key_shapes.Composite_full in
-  run "key_shapes/composite_full: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "key_shapes/composite_full: pick title -> join present" (fun () -> ignore (List.select () title ~uid:1L (fun x -> x)))
+  run "key_shapes/composite_full: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L));
+  run "key_shapes/composite_full: pick title -> join present" (fun () -> ignore (List.select () title ~uid:1L))

--- a/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
+++ b/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -77,8 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -151,7 +150,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -161,8 +160,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -235,7 +233,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -245,8 +243,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/multi.t/run.ml
+++ b/test/cram/test_build_dynamic_join/multi.t/run.ml
@@ -8,19 +8,19 @@ let run label f =
 
 let () =
   let open S.Two_indep in
-  run "two_indep: pick id (no joins)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "two_indep: pick bio (profiles only)" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)));
-  run "two_indep: pick url (avatars only)" (fun () -> ignore (List.select () url ~uid:1L (fun x -> x)));
+  run "two_indep: pick id (no joins)" (fun () -> ignore (List.select () id ~uid:1L));
+  run "two_indep: pick bio (profiles only)" (fun () -> ignore (List.select () bio ~uid:1L));
+  run "two_indep: pick url (avatars only)" (fun () -> ignore (List.select () url ~uid:1L));
   run "two_indep: pick bio+url (both)" (fun () ->
-    ignore (List.select () (let+ b = bio and+ u = url in (b, u)) ~uid:1L (fun x -> x)))
+    ignore (List.select () (let+ b = bio and+ u = url in (b, u)) ~uid:1L))
 
 let () =
   let open S.Subq_in_on in
-  run "subq_in_on: pick id -> everything kept (subquery in another join's ON)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "subq_in_on: pick id -> everything kept (subquery in another join's ON)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open S.Same_twice in
-  run "same_twice: pick bio1 (p1 only)" (fun () -> ignore (List.select () bio1 ~uid:1L (fun x -> x)));
-  run "same_twice: pick bio2 (p2 only)" (fun () -> ignore (List.select () bio2 ~uid:1L (fun x -> x)));
+  run "same_twice: pick bio1 (p1 only)" (fun () -> ignore (List.select () bio1 ~uid:1L));
+  run "same_twice: pick bio2 (p2 only)" (fun () -> ignore (List.select () bio2 ~uid:1L));
   run "same_twice: pick both" (fun () ->
-    ignore (List.select () (let+ a = bio1 and+ b = bio2 in (a, b)) ~uid:1L (fun x -> x)))
+    ignore (List.select () (let+ a = bio1 and+ b = bio2 in (a, b)) ~uid:1L))

--- a/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
@@ -60,7 +60,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~b ~uid callback =
+      let select db (col : _ t) ~b ~uid =
         let set_params stmt =
           let p = T.start_params stmt (2 + col.count) in
           col.set p;
@@ -71,8 +71,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -136,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -146,8 +145,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -211,7 +209,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -221,8 +219,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -286,7 +283,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -296,8 +293,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -361,7 +357,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -371,8 +367,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -436,7 +431,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -446,8 +441,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -511,7 +505,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -521,8 +515,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -586,7 +579,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -596,8 +589,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/on_shapes.t/run.ml
+++ b/test/cram/test_build_dynamic_join/on_shapes.t/run.ml
@@ -8,36 +8,36 @@ module On_shapes = On_shapes.Sqlgg(Print_impl)
 
 let () =
   let open On_shapes.Param_in_on in
-  run "on_shapes/param_in_on: pick id -> join kept (param in ON)" (fun () -> ignore (List.select () id ~b:"x" ~uid:1L (fun x -> x)))
+  run "on_shapes/param_in_on: pick id -> join kept (param in ON)" (fun () -> ignore (List.select () id ~b:"x" ~uid:1L))
 
 let () =
   let open On_shapes.Extra_const_on in
-  run "on_shapes/extra_const_on: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "on_shapes/extra_const_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "on_shapes/extra_const_on: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L));
+  run "on_shapes/extra_const_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))
 
 let () =
   let open On_shapes.On_inequality in
-  run "on_shapes/inequality: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "on_shapes/inequality: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open On_shapes.No_alias in
-  run "on_shapes/no_alias: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "on_shapes/no_alias: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "on_shapes/no_alias: pick id -> join dropped" (fun () -> ignore (List.select () id ~uid:1L));
+  run "on_shapes/no_alias: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))
 
 let () =
   let open On_shapes.Flipped_on in
-  run "on_shapes/flipped_on: pick id -> join dropped (operand order does not matter)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "on_shapes/flipped_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "on_shapes/flipped_on: pick id -> join dropped (operand order does not matter)" (fun () -> ignore (List.select () id ~uid:1L));
+  run "on_shapes/flipped_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))
 
 let () =
   let open On_shapes.Const_key_on in
-  run "on_shapes/const_key_on: pick id -> join dropped (key equated to a constant)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)));
-  run "on_shapes/const_key_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L (fun x -> x)))
+  run "on_shapes/const_key_on: pick id -> join dropped (key equated to a constant)" (fun () -> ignore (List.select () id ~uid:1L));
+  run "on_shapes/const_key_on: pick bio -> join present" (fun () -> ignore (List.select () bio ~uid:1L))
 
 let () =
   let open On_shapes.Or_in_on in
-  run "on_shapes/or_in_on: pick id -> join kept (OR can match many rows)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "on_shapes/or_in_on: pick id -> join kept (OR can match many rows)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open On_shapes.Subq_own_on in
-  run "on_shapes/subq_own_on: pick id -> join kept (subquery in own ON)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "on_shapes/subq_own_on: pick id -> join kept (subquery in own ON)" (fun () -> ignore (List.select () id ~uid:1L))

--- a/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
@@ -56,7 +56,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -65,8 +65,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -128,7 +127,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -137,8 +136,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -200,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -209,8 +207,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -274,7 +271,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -284,8 +281,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -347,7 +343,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -356,8 +352,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -419,7 +414,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -428,8 +423,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -493,7 +487,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -503,8 +497,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/outside_refs.t/run.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/run.ml
@@ -8,28 +8,28 @@ module Outside_refs = Outside_refs.Sqlgg(Print_impl)
 
 let () =
   let open Outside_refs.Ref_in_group in
-  run "outside_refs/group: pick id -> join kept (GROUP BY)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "outside_refs/group: pick id -> join kept (GROUP BY)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Outside_refs.Ref_in_order in
-  run "outside_refs/order: pick id -> join kept (ORDER BY)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "outside_refs/order: pick id -> join kept (ORDER BY)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Outside_refs.Ref_in_having in
-  run "outside_refs/having: pick id -> join kept (HAVING)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "outside_refs/having: pick id -> join kept (HAVING)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Outside_refs.Complex_proj in
-  run "outside_refs/complex_proj: pick id -> join kept (complex expr)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "outside_refs/complex_proj: pick id -> join kept (complex expr)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Outside_refs.Subq_in_where in
-  run "outside_refs/subq_in_where: pick id -> join kept (subquery in WHERE)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "outside_refs/subq_in_where: pick id -> join kept (subquery in WHERE)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Outside_refs.Unqualified_where in
-  run "outside_refs/unqualified: pick id -> join kept (unqualified ref)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "outside_refs/unqualified: pick id -> join kept (unqualified ref)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Outside_refs.Join_unreferenced in
-  run "outside_refs/unreferenced: pick id -> join rendered statically" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "outside_refs/unreferenced: pick id -> join rendered statically" (fun () -> ignore (List.select () id ~uid:1L))

--- a/test/cram/test_build_dynamic_join/ppx.t/run.ml
+++ b/test/cram/test_build_dynamic_join/ppx.t/run.ml
@@ -13,24 +13,24 @@ let run label f =
 let () =
   let open Db.Wide in
   run "wide: item record -> both joins dropped" (fun () ->
-    ignore (List.select () (item_of_cols cols) ~min_id:0L (fun x -> x)));
+    ignore (List.select () (item_of_cols cols) ~min_id:0L));
   run "wide: item + stat -> only stats join" (fun () ->
     ignore (List.select ()
       (let+ i = item_of_cols cols
        and+ s = stat_of_cols cols in
        (i, s))
-      ~min_id:0L (fun x -> x)));
+      ~min_id:0L));
   run "wide: described -> only details join" (fun () ->
-    ignore (List.select () (described_of_cols cols) ~min_id:0L (fun x -> x)));
+    ignore (List.select () (described_of_cols cols) ~min_id:0L));
   run "wide: item + described + stat -> both joins" (fun () ->
     ignore (List.select ()
       (let+ i = item_of_cols cols
        and+ d = described_of_cols cols
        and+ s = stat_of_cols cols in
        (i, d, s))
-      ~min_id:0L (fun x -> x)))
+      ~min_id:0L))
 
 let () =
   let open Db.Narrow in
   run "narrow: same item record, different query" (fun () ->
-    ignore (List.select () (item_of_cols cols) ~min_id:0L (fun x -> x)))
+    ignore (List.select () (item_of_cols cols) ~min_id:0L))

--- a/test/cram/test_build_dynamic_join/self_join.t/run.ml
+++ b/test/cram/test_build_dynamic_join/self_join.t/run.ml
@@ -8,9 +8,9 @@ module Self_join = Self_join.Sqlgg(Print_impl)
 
 let () =
   let open Self_join.Bad in
-  run "self_join/bad: pick id -> join kept (non-unique self key)" (fun () -> ignore (List.select () id (fun x -> x)))
+  run "self_join/bad: pick id -> join kept (non-unique self key)" (fun () -> ignore (List.select () id))
 
 let () =
   let open Self_join.Good in
-  run "self_join/good: pick id -> join dropped (PK self key)" (fun () -> ignore (List.select () id (fun x -> x)));
-  run "self_join/good: pick name -> join present" (fun () -> ignore (List.select () name (fun x -> x)))
+  run "self_join/good: pick id -> join dropped (PK self key)" (fun () -> ignore (List.select () id));
+  run "self_join/good: pick name -> join present" (fun () -> ignore (List.select () name))

--- a/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
+++ b/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
@@ -56,7 +56,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -65,8 +65,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -128,7 +127,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -137,8 +136,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else ""))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/subquery_sources.t/run.ml
+++ b/test/cram/test_build_dynamic_join/subquery_sources.t/run.ml
@@ -8,17 +8,17 @@ module Subquery_sources = Subquery_sources.Sqlgg(Print_impl)
 
 let () =
   let open Subquery_sources.Join_subq_source in
-  run "subquery_sources/plain: pick id -> join kept (subquery source)" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "subquery_sources/plain: pick id -> join kept (subquery source)" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Subquery_sources.Subq_join_dup in
-  run "subquery_sources/cross_dup: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "subquery_sources/cross_dup: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Subquery_sources.Subq_union_dup in
-  run "subquery_sources/union_dup: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L (fun x -> x)))
+  run "subquery_sources/union_dup: pick id -> join kept" (fun () -> ignore (List.select () id ~uid:1L))
 
 let () =
   let open Subquery_sources.Subq_base_join in
-  run "subquery_sources/subq_base: pick id -> table join dropped" (fun () -> ignore (List.select () id (fun x -> x)));
-  run "subquery_sources/subq_base: pick bio -> table join present" (fun () -> ignore (List.select () bio (fun x -> x)))
+  run "subquery_sources/subq_base: pick id -> table join dropped" (fun () -> ignore (List.select () id));
+  run "subquery_sources/subq_base: pick bio -> table join present" (fun () -> ignore (List.select () bio))

--- a/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
+++ b/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -133,7 +132,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -143,8 +142,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -208,7 +206,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -218,8 +216,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -281,7 +278,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) callback =
+      let select db (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (0 + col.count) in
           col.set p;
@@ -290,8 +287,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else ""))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_join/whitespace.t/run.ml
+++ b/test/cram/test_build_dynamic_join/whitespace.t/run.ml
@@ -9,12 +9,12 @@ module Whitespace = Whitespace.Sqlgg(Print_impl)
 let () =
   let open Whitespace.Ws in
   run "ws: pick id -> both joins dropped, no gaps" (fun () ->
-    ignore (List.select () id ~uid:1L (fun x -> x)));
+    ignore (List.select () id ~uid:1L));
   run "ws: pick id + bio -> profiles kept, billing gap collapsed" (fun () ->
-    ignore (List.select () (let+ i = id and+ b = bio in (i, b)) ~uid:1L (fun x -> x)));
+    ignore (List.select () (let+ i = id and+ b = bio in (i, b)) ~uid:1L));
   run "ws: pick id + plan -> profiles gap collapsed, billing kept" (fun () ->
-    ignore (List.select () (let+ i = id and+ p = plan in (i, p)) ~uid:1L (fun x -> x)));
+    ignore (List.select () (let+ i = id and+ p = plan in (i, p)) ~uid:1L));
   run "ws: pick all -> both joins, single spaces" (fun () ->
     ignore (List.select ()
       (let+ i = id and+ b = bio and+ p = plan in (i, b, p))
-      ~uid:1L (fun x -> x)))
+      ~uid:1L))

--- a/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
+++ b/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
@@ -80,7 +80,7 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~uid callback =
+      let select db (col : _ t) ~uid =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -92,8 +92,7 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
         ("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
 WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_build_dynamic_subquery/test_run.ml
+++ b/test/cram/test_build_dynamic_subquery/test_run.ml
@@ -24,11 +24,11 @@ module M (T: Sqlgg_traits.M with
     open Sql.Star_over_subq
 
     let run c =
-      printf "[1.1] pick id\n";    prep (); ignore (List.select c id ~min:10L (fun x -> x));
-      printf "[1.2] pick name\n";  prep (); ignore (List.select c name ~min:10L (fun x -> x));
-      printf "[1.3] pick price\n"; prep (); ignore (List.select c price ~min:10L (fun x -> x));
+      printf "[1.1] pick id\n";    prep (); ignore (List.select c id ~min:10L);
+      printf "[1.2] pick name\n";  prep (); ignore (List.select c name ~min:10L);
+      printf "[1.3] pick price\n"; prep (); ignore (List.select c price ~min:10L);
       printf "[1.4] pick id + name + price\n"; prep ();
-        ignore (List.select c (let+ i = id and+ n = name and+ p = price in (i, n, p)) ~min:10L (fun x -> x))
+        ignore (List.select c (let+ i = id and+ n = name and+ p = price in (i, n, p)) ~min:10L)
   end
 
   (* Group 2: pass-through via explicit sub.* *)
@@ -36,9 +36,9 @@ module M (T: Sqlgg_traits.M with
     open Sql.Star_alias_over_subq
 
     let run c =
-      printf "[2.1] pick name\n";        prep (); ignore (List.select c name (fun x -> x));
+      printf "[2.1] pick name\n";        prep (); ignore (List.select c name);
       printf "[2.2] pick id + price\n";  prep ();
-        ignore (List.select c (let+ i = id and+ p = price in (i, p)) (fun x -> x))
+        ignore (List.select c (let+ i = id and+ p = price in (i, p)))
   end
 
   (* Group 3: pass-through over a LEFT JOIN subquery (nullable joined columns) *)
@@ -46,10 +46,10 @@ module M (T: Sqlgg_traits.M with
     open Sql.Star_over_join_subq
 
     let run c =
-      printf "[3.1] pick uid\n";                 prep (); ignore (List.select c uid (fun x -> x));
-      printf "[3.2] pick ototal (nullable)\n";   prep (); ignore (List.select c ototal (fun x -> x));
+      printf "[3.1] pick uid\n";                 prep (); ignore (List.select c uid);
+      printf "[3.2] pick ototal (nullable)\n";   prep (); ignore (List.select c ototal);
       printf "[3.3] pick uid + uname + ototal\n"; prep ();
-        ignore (List.select c (let+ a = uid and+ b = uname and+ d = ototal in (a, b, d)) (fun x -> x))
+        ignore (List.select c (let+ a = uid and+ b = uname and+ d = ototal in (a, b, d)))
   end
 
   (* Group 4: non-pass-through outer -> dynamic stays outside, subquery fixed *)
@@ -57,9 +57,9 @@ module M (T: Sqlgg_traits.M with
     open Sql.Cols_over_subq
 
     let run c =
-      printf "[4.1] pick id\n";          prep (); ignore (List.select c id ~id:1L (fun x -> x));
+      printf "[4.1] pick id\n";          prep (); ignore (List.select c id ~id:1L);
       printf "[4.2] pick id + name\n";   prep ();
-        ignore (List.select c (let+ i = id and+ n = name in (i, n)) ~id:1L (fun x -> x))
+        ignore (List.select c (let+ i = id and+ n = name in (i, n)) ~id:1L)
   end
 
   let run_all c =

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -485,7 +485,7 @@ Test DynamicSelect edge: single column:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -494,8 +494,7 @@ Test DynamicSelect edge: single column:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -578,7 +577,7 @@ DynamicSelect: SELECT * remains static select:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -587,8 +586,7 @@ DynamicSelect: SELECT * remains static select:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -680,7 +678,7 @@ DynamicSelect: SELECT * with expression in same list:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -689,8 +687,7 @@ DynamicSelect: SELECT * with expression in same list:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -782,7 +779,7 @@ DynamicSelect: auto names for expressions without alias:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -791,8 +788,7 @@ DynamicSelect: auto names for expressions without alias:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -866,7 +862,7 @@ Test DynamicSelect edge: expression at first position:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -875,8 +871,7 @@ Test DynamicSelect edge: expression at first position:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -959,7 +954,7 @@ Test DynamicSelect edge: literal only:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -968,8 +963,7 @@ Test DynamicSelect edge: literal only:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1079,7 +1073,7 @@ Test DynamicSelect edge: many columns:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1088,8 +1082,7 @@ Test DynamicSelect edge: many columns:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1181,7 +1174,7 @@ Test DynamicSelect edge: no space after commas:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1190,8 +1183,7 @@ Test DynamicSelect edge: no space after commas:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1274,7 +1266,7 @@ Test DynamicSelect edge: minimal spacing:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1283,8 +1275,7 @@ Test DynamicSelect edge: minimal spacing:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1358,7 +1349,7 @@ Test DynamicSelect edge: column without alias gets auto name:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1367,8 +1358,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1479,7 +1469,7 @@ Test DynamicSelect with dynamic_select flag:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~t callback =
+        let select db (col : _ t) ~t =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -1489,8 +1479,7 @@ Test DynamicSelect with dynamic_select flag:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1591,7 +1580,7 @@ Test DynamicSelect with two dynamic columns:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1600,8 +1589,7 @@ Test DynamicSelect with two dynamic columns:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM items")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1693,7 +1681,7 @@ Test DynamicSelect with Verbatim branches:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1702,8 +1690,7 @@ Test DynamicSelect with Verbatim branches:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM users")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1786,7 +1773,7 @@ Test DynamicSelect at beginning of SELECT:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1795,8 +1782,7 @@ Test DynamicSelect at beginning of SELECT:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM data")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -1879,7 +1865,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -1888,8 +1874,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t1")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2152,7 +2137,7 @@ Test DynamicSelect comprehensive list:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2163,8 +2148,7 @@ Test DynamicSelect comprehensive list:
           ("SELECT\n\
      " ^ col.column ^ "\n\
   FROM products")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2259,7 +2243,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~id callback =
+        let select db (col : _ t) ~id =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -2269,8 +2253,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2361,7 +2344,7 @@ Virtual select: consecutive params as columns:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2370,8 +2353,7 @@ Virtual select: consecutive params as columns:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2478,7 +2460,7 @@ Virtual select: mixed columns and params without spaces after commas:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~id callback =
+        let select db (col : _ t) ~id =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -2488,8 +2470,7 @@ Virtual select: mixed columns and params without spaces after commas:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2572,7 +2553,7 @@ Virtual select: subquery expression as dynamic column:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2581,8 +2562,7 @@ Virtual select: subquery expression as dynamic column:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2671,7 +2651,7 @@ Virtual select: CASE WHEN as dynamic column:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2680,8 +2660,7 @@ Virtual select: CASE WHEN as dynamic column:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2764,7 +2743,7 @@ Virtual select: function call with multiple args as column:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2773,8 +2752,7 @@ Virtual select: function call with multiple args as column:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2863,7 +2841,7 @@ Virtual select: arithmetic with param at expression start:
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) ~id callback =
+        let select db (col : _ t) ~id =
           let set_params stmt =
             let p = T.start_params stmt (1 + col.count) in
             col.set p;
@@ -2873,8 +2851,7 @@ Virtual select: arithmetic with param at expression start:
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)
@@ -2964,7 +2941,7 @@ Virtual select: tab-separated columns (non-space whitespace):
       end (* module Fold *)
   
       module List = struct
-        let select db (col : _ t) callback =
+        let select db (col : _ t) =
           let set_params stmt =
             let p = T.start_params stmt (0 + col.count) in
             col.set p;
@@ -2973,8 +2950,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           let r_acc = ref [] in
           IO.(>>=) (T.select db
           ("SELECT " ^ col.column ^ " FROM t")
-          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-            __sqlgg_r_col) :: !r_acc))
+          set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
       end (* module List *)

--- a/test/cram/test_dynamic_select/test_run.ml
+++ b/test/cram/test_dynamic_select/test_run.ml
@@ -732,8 +732,7 @@ module M (T: Sqlgg_traits.M with
         and+ p = price_with_tax 10L in
         (i, n, c, s, p)
       in
-      let _ = List.select connection combined
-        (fun col -> ignore col) in
+      let _ = List.select connection combined in
       printf "[TEST 19] Completed\n\n"
 
     let run connection = test_all_fields connection

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~ids ~nm callback =
+      let select db (col : _ t) ~ids ~nm =
         let set_params stmt =
           let p = T.start_params stmt (1 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -131,7 +130,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~pairs callback =
+      let select db (col : _ t) ~pairs =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
           col.set p;
@@ -140,8 +139,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -213,7 +211,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~v callback =
+      let select db (col : _ t) ~v =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match v with Some _ -> 1 | None -> 0) + col.count) in
           col.set p;
@@ -227,8 +225,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -290,7 +287,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~sort callback =
+      let select db (col : _ t) ~sort =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
           col.set p;
@@ -299,8 +296,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -362,7 +358,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~sort callback =
+      let select db (col : _ t) ~sort =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match sort with `I -> 0 | `N -> 0) + col.count) in
           col.set p;
@@ -371,8 +367,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -444,7 +439,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~f callback =
+      let select db (col : _ t) ~f =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
           col.set p;
@@ -458,8 +453,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -545,7 +539,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~f callback =
+      let select db (col : _ t) ~f =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
           col.set p;
@@ -566,8 +560,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         ("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -671,7 +664,7 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~ids ~pairs ~nm ~f ~sort callback =
+      let select db (col : _ t) ~ids ~pairs ~nm ~f ~sort =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0) + (match pairs with [] -> 0 | _ :: _ -> 0) + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + (match sort with `I -> 0 | `N -> 0) + (match nm with Some _ -> 1 | None -> 0) + col.count) in
           col.set p;
@@ -701,8 +694,7 @@ WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.co
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
 ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -62,7 +62,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
     end (* module Fold *)
 
     module List = struct
-      let select db ~st (col : _ t) ~lo callback =
+      let select db ~st (col : _ t) ~lo =
         let set_params stmt =
           let p = T.start_params stmt (2 + col.count) in
           T.set_param_Int p st;
@@ -74,8 +74,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         IO.(>>=) (T.select db
         ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
 SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -143,7 +142,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
     end (* module Fold *)
 
     module List = struct
-      let select db ~ids ~nm (col : _ t) ~lo callback =
+      let select db ~ids ~nm (col : _ t) ~lo =
         let set_params stmt =
           let p = T.start_params stmt (2 + (match ids with [] -> 0 | _ :: _ -> 0) + col.count) in
           T.set_param_Text p nm;
@@ -155,8 +154,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         IO.(>>=) (T.select db
         ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
 SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -230,7 +228,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
     end (* module Fold *)
 
     module List = struct
-      let select db ~f (col : _ t) ~sort callback =
+      let select db ~f (col : _ t) ~sort =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match f with `All -> 0 | `ByStatus _ -> 1) + (match sort with `I -> 0 | `N -> 0) + col.count) in
           begin match f with
@@ -245,8 +243,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         IO.(>>=) (T.select db
         ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
 SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -320,7 +317,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
     end (* module Fold *)
 
     module List = struct
-      let select db ~st (col : _ t) ~pairs callback =
+      let select db ~st (col : _ t) ~pairs =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + (match st with Some _ -> 1 | None -> 0) + col.count) in
           begin match st with
@@ -335,8 +332,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         IO.(>>=) (T.select db
         ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
 SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -420,7 +416,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~f callback =
+      let select db (col : _ t) ~f =
         let set_params stmt =
           let p = T.start_params stmt (0 + (match f with `All -> 0 | `ById _ -> 1) + (match f with `All -> 0 | `ById _ -> 1) + col.count) in
           begin match f with
@@ -440,8 +436,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         IO.(>>=) (T.select db
         ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
 SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -520,7 +515,7 @@ SELECT " ^ col.column ^ " FROM recent")
     end (* module Fold *)
 
     module List = struct
-      let select db ~st (col : _ t) callback =
+      let select db ~st (col : _ t) =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           T.set_param_Int p st;
@@ -531,8 +526,7 @@ SELECT " ^ col.column ^ " FROM recent")
         IO.(>>=) (T.select db
         ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
 SELECT " ^ col.column ^ " FROM recent")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)
@@ -598,7 +592,7 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~st ~names callback =
+      let select db (col : _ t) ~st ~names =
         let set_params stmt =
           let p = T.start_params stmt (1 + (match names with [] -> 0 | _ :: _ -> 0) + col.count) in
           col.set p;
@@ -609,8 +603,7 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM t\n\
 WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_scoped_select/dune
+++ b/test/cram/test_scoped_select/dune
@@ -1,6 +1,7 @@
 (cram
  (deps
   %{bin:sqlgg}
+  (package sqlgg)
   (glob_files *.sql)
   (glob_files *.ml)
   (glob_files *.mli)

--- a/test/cram/test_scoped_select/ppx_expansion.t
+++ b/test/cram/test_scoped_select/ppx_expansion.t
@@ -19,12 +19,13 @@ What [@@deriving sqlgg] expands to:
                                             'sqlgg__row, 'sqlgg__params)
                                             Sqlgg_scope.col   ;.. > )
         =
-        (Sqlgg_scope.apply
-           (Sqlgg_scope.apply
-              (Sqlgg_scope.pure (fun id -> fun name -> ({ id; name } : who)))
-              sqlgg__cols#id) sqlgg__cols#name : (who, 'sqlgg__brand,
-                                                   'sqlgg__row, 'sqlgg__params)
-                                                   Sqlgg_scope.col)
+        (let open Sqlgg_scope in
+           let+ id = sqlgg__cols#id
+           and+ name = sqlgg__cols#name in ({ id; name } : who) : (who,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
       let _ = who_of_cols
     end[@@ocaml.doc "@inline"][@@merlin.hide ]
 
@@ -40,3 +41,48 @@ Non-record types are rejected:
   2 | [@@deriving sqlgg]
   Error: deriving sqlgg: only record types are supported
   [2]
+
+[@sqlgg.col] maps a record field to a differently named column:
+
+  $ cat > renamed.ml <<'XEOF'
+  > type renamed = { id : int64; productName : string option [@sqlgg.col "name"] }
+  > [@@deriving sqlgg]
+  > XEOF
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -dsource -c renamed.ml 2>&1
+  type renamed = {
+    id: int64 ;
+    productName: string option [@sqlgg.col "name"]}[@@deriving sqlgg]
+  include
+    struct
+      let _ = fun (_ : renamed) -> ()
+      let renamed_of_cols
+        (sqlgg__cols :
+          <
+            id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                  Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                            'sqlgg__row, 'sqlgg__params)
+                                            Sqlgg_scope.col   ;.. > )
+        =
+        (let open Sqlgg_scope in
+           let+ id = sqlgg__cols#id
+           and+ productName = sqlgg__cols#name in
+           ({ id; productName } : renamed) : (renamed, 'sqlgg__brand,
+                                               'sqlgg__row, 'sqlgg__params)
+                                               Sqlgg_scope.col)
+      let _ = renamed_of_cols
+    end[@@ocaml.doc "@inline"][@@merlin.hide ]
+
+Type parameters are rejected:
+
+  $ cat > poly.ml <<'XEOF'
+  > type 'a poly = { id : 'a }
+  > [@@deriving sqlgg]
+  > XEOF
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c poly.ml 2>&1
+  File "poly.ml", lines 1-2, characters 0-18:
+  1 | type 'a poly = { id : 'a }
+  2 | [@@deriving sqlgg]
+  Error: deriving sqlgg: type parameters are not supported
+  [2]
+  $ echo done
+  done

--- a/test/cram/test_scoped_select/scope.expected.ml
+++ b/test/cram/test_scoped_select/scope.expected.ml
@@ -125,7 +125,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~min_stock callback =
+      let select db (col : _ t) ~min_stock =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -135,8 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM products WHERE stock > ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_scoped_select/scope_frag_ppx.ml
+++ b/test/cram/test_scoped_select/scope_frag_ppx.ml
@@ -16,4 +16,12 @@ module Frag (T : Sqlgg_traits.M with
   type t = { id : int64; name : string option } [@@deriving sqlgg]
 
   let _q3 db = Scope_q1.(select db (of_cols cols) ~id:2L)
+
+  type renamed = {
+    id : int64;
+    productName : string option; [@sqlgg.col "name"]
+  }
+  [@@deriving sqlgg]
+
+  let _q4 db = Scope_q1.(select db (renamed_of_cols cols) ~id:3L)
 end

--- a/test/cram/test_static_flags/both.t/both.compare.ml
+++ b/test/cram/test_static_flags/both.t/both.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~id callback =
+      let select db (col : _ t) ~id =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
+++ b/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~id callback =
+      let select db (col : _ t) ~id =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_static_flags/je_static.t/je_static.compare.ml
+++ b/test/cram/test_static_flags/je_static.t/je_static.compare.ml
@@ -71,7 +71,7 @@ WHERE i.id > ?")
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~min_id callback =
+      let select db (col : _ t) ~min_id =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -83,8 +83,7 @@ WHERE i.id > ?")
         ("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
 WHERE i.id > ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)

--- a/test/cram/test_static_flags/override.t/override.compare.ml
+++ b/test/cram/test_static_flags/override.t/override.compare.ml
@@ -58,7 +58,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end (* module Fold *)
 
     module List = struct
-      let select db (col : _ t) ~id callback =
+      let select db (col : _ t) ~id =
         let set_params stmt =
           let p = T.start_params stmt (1 + col.count) in
           col.set p;
@@ -68,8 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
-        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
-          __sqlgg_r_col) :: !r_acc))
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
     end (* module List *)


### PR DESCRIPTION
### Description

This PR adds `[@sqlgg.col]` attribute to the ppx deriver and drops the redundant row mapper from dynamic select `List.select`.

#### `[@sqlgg.col]`

Record fields can now map to differently named sql columns:

```ocaml
type competitor = {
  name : string;
  isRelated : bool; [@sqlgg.col "is_related"]
} [@@deriving sqlgg]
```

#### `List.select` without row mapper

```ocaml
(* before: transform via callback *)
List.select db
  (let+ price and+ qty in (price, qty))
  ~company_id
  (fun (price, qty) -> Int64.mul price qty)

(* after: transform right where you pick the columns *)
List.select db
  (let+ price and+ qty in Int64.mul price qty)
  ~company_id
```

Because callback isn't really needed since all the transformations can be expressed inside `col` already

#### IS NOT NULL in dynamic selects

Dynamic select columns now go through the same WHERE col IS NOT NULL refinement as static ones (previously it just never reached them, so they stayed option):

```sql
-- [sqlgg] dynamic_select=true
-- @get_names
SELECT name, descr FROM items WHERE name IS NOT NULL;
```

```ocaml
(* before *) name : string option
(* after  *) name : string  (* descr stays option *)
```