### PR TITLE
Limit migration id length

### DIFF
--- a/doc/_cli-options.md
+++ b/doc/_cli-options.md
@@ -16,10 +16,11 @@
   -migrations-file <file>                          Generated migrations SQL for -migrate (read and appended in place; required only when there is a new delta to record)
   -extends <file>                                  Hand-written migrations SQL, merged with generated ones by `id` (read-only)
   -now <YYYYMMDDHHMMSS>                            Pin the migration id timestamp (default: current clock); ids are <timestamp>_<descriptive_name>
-  -ddl-as-migration                                Emit brand-new tables as CREATE TABLE migrations (default: off - new tables are schema DDL for a clean server, not migrations)
+  -max-migration-id-length <N>                     Limit generated migration ids to N characters (default: no limit)
+  -ddl-as-migration                                Write new tables as CREATE TABLE migrations instead of plain schema DDL
 
  Dialect and checks:
-  -dialect mysql|postgresql|sqlite|tidb            Set SQL dialect - will only allow this dialect's features in SQL queries
+  -dialect mysql|postgresql|sqlite|tidb            Set SQL dialect. Queries can only use its features
   -no-check {all|<feature>{,<feature>}+}           Disable dialect feature checks (possible features: collation|join_on_subquery|create_table_as_select|on_duplicate_key|on_conflict|straight_join|lock_in_share_mode|fulltext_index|unsigned_types|autoincrement|replace_into|row_locking|default_expr|ttl|alter_column|user_defined_type)
   -allow-write-notnull-null                        Accept writing a nullable value into a NOT NULL column, instead of failing (MySQL, TiDB and SQLite only)
 

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -4,6 +4,8 @@ open Printf
 open ExtLib
 open Sqlgg
 
+module Name = Migration_id.Name
+
 module Cxx = Gen.Make(Gen_cxx)
 module Caml = Gen.Make(Gen_caml.Generator)
 module Caml_io = Gen.Make(Gen_caml.Generator_io)
@@ -120,11 +122,8 @@ let migration_to_sql ~id ~name (m : Gen_migrations.migration) =
 let block_id ((_, props) : string * Props.t) =
   Props.get props "id" |> Option.map (fun s ->
     match Migration_id.parse s with
-    | Some id -> Migration_id.sort_key id
+    | Some id -> id
     | None -> fatal "bad migration block id %S (expected integer or <timestamp>_<name>)" s)
-
-let max_block_id blocks =
-  List.filter_map block_id blocks |> List.fold_left max (-1)
 
 let merge_blocks gen ext =
   let numbered, rest =
@@ -133,7 +132,7 @@ let merge_blocks gen ext =
         Option.map_default (fun id -> ((id, b) :: num, rest)) (num, b :: rest) (block_id b))
       (gen @ ext) ([], [])
   in
-  List.map snd (List.stable_sort (fun (a, _) (b, _) -> compare a b) numbered) @ rest
+  List.map snd (List.stable_sort (fun (a, _) (b, _) -> Migration_id.compare a b) numbered) @ rest
 
 let now_stamp () =
   let t = Unix.localtime (Unix.time ()) in
@@ -142,19 +141,27 @@ let now_stamp () =
     [t.Unix.tm_mon + 1; t.Unix.tm_mday; t.Unix.tm_hour; t.Unix.tm_min; t.Unix.tm_sec]
 
 let next_base now existing =
-  let bump = max_block_id existing + 1 in
   let ts = match now with Some n -> n | None -> now_stamp () in
-  max ts bump
+  List.filter_map block_id existing
+  |> List.map Migration_id.next_ord
+  |> List.fold_left Int.max 0
+  |> Int.max ts
 
 type entry = { id : string; code_name : string; mig : Gen_migrations.migration }
 
-let assign_ids now existing migs =
-  let base = next_base now existing in
-  List.mapi (fun i (mig : Gen_migrations.migration) ->
-    let descr = Gen.choose_name mig.props mig.kind i in
-    let id = Migration_id.make ~name:descr base in
-    let code_name = if id.Migration_id.name = None then descr else Migration_id.to_string id in
-    { id = Migration_id.to_string id; code_name; mig }) migs
+let assign_ids ~naming base migs =
+  let entries =
+    List.mapi (fun i (mig : Gen_migrations.migration) ->
+      let descr = Name.fit naming (Gen.choose_name mig.props mig.kind i) in
+      let id = Migration_id.to_string (Migration_id.make ~name:descr base) in
+      { id; code_name = id; mig }) migs
+  in
+  let seen = Hashtbl.create 16 in
+  entries |> List.iter (fun { id; _ } ->
+    if Hashtbl.mem seen id then
+      fatal "two migrations get the same id %S. increase -max-migration-id-length" id;
+    Hashtbl.add seen id ());
+  entries
 
 let entry_to_sql { id; code_name; mig } = migration_to_sql ~id ~name:code_name mig
 
@@ -162,9 +169,6 @@ let entry_to_codegen { code_name; mig; _ } =
   { mig with props = Props.set mig.props "name" code_name }
 
 let entries_to_sql entries = entries |> List.map entry_to_sql |> String.concat "\n\n"
-
-let migrations_to_sql now existing migs =
-  assign_ids now existing migs |> entries_to_sql
 
 let read_file_opt path =
   if Sys.file_exists path then
@@ -239,9 +243,9 @@ let schema_of_sources sources =
 
 let load_schema files = schema_of_sources (to_file_sources files)
 
-let diff_schema ~ddl_as_migration ~from_ ~to_ =
+let diff_schema ~naming ~ddl_as_migration ~from_ ~to_ =
   let migs =
-    try Schema_diff.generate ~ddl_as_migration ~from_ ~to_
+    try Schema_diff.generate ~naming ~ddl_as_migration ~from_ ~to_
     with Gen_migrations.Migration_error msg ->
       fatal "cannot generate migration (write this step manually):\n%s" msg
   in
@@ -259,24 +263,26 @@ type gen_args = {
   inputs : Gen.stmt list list;
 }
 
-type diff_args = {
-  base_files : string list;
-  target_files : string list;
-  output : output option;
+type delta_args = {
   name : string;
+  target_files : string list;
   now : int option;
+  max_id_length : int option;
   ddl_as_migration : bool;
 }
 
+type diff_args = {
+  delta : delta_args;
+  base_files : string list;
+  output : output option;
+}
+
 type migrate_args = {
+  delta : delta_args;
   gen_lang : lang;
-  name : string;
   initial_files : string list;
-  target_files : string list;
   migrations_file : string option;
   extends_file : string option;
-  now : int option;
-  ddl_as_migration : bool;
 }
 
 type materialize_args = { base_files : string list }
@@ -299,6 +305,7 @@ let parse_args () =
   let migrations_file = ref None in
   let extends_file = ref None in
   let now = ref None in
+  let max_id_length = ref None in
   let ddl_as_migration = ref false in
   let work s = inputs := each_input ~output s :: !inputs in
   let groups =
@@ -324,12 +331,14 @@ let parse_args () =
       "-migrations-file", Arg.String (fun f -> migrations_file := Some f), "<file> Generated migrations SQL for -migrate (read and appended in place; required only when there is a new delta to record)";
       "-extends", Arg.String (fun f -> extends_file := Some f), "<file> Hand-written migrations SQL, merged with generated ones by `id` (read-only)";
       "-now", Arg.Int (fun n -> now := Some n), "<YYYYMMDDHHMMSS> Pin the migration id timestamp (default: current clock); ids are <timestamp>_<descriptive_name>";
-      "-ddl-as-migration", Arg.Set ddl_as_migration, " Emit brand-new tables as CREATE TABLE migrations (default: off - new tables are schema DDL for a clean server, not migrations)";
+      "-max-migration-id-length", Arg.Int (fun n -> max_id_length := Some n),
+        "<N> Limit generated migration ids to N characters (default: no limit)";
+      "-ddl-as-migration", Arg.Set ddl_as_migration, " Write new tables as CREATE TABLE migrations instead of plain schema DDL";
     ] };
 
     { title = "Dialect and checks"; opts =
     [
-      "-dialect", Arg.String set_dialect, sprintf "%s Set SQL dialect - will only allow this dialect's features in SQL queries" (Dialect.all |> List.map Dialect.to_string |> String.concat "|");
+      "-dialect", Arg.String set_dialect, sprintf "%s Set SQL dialect. Queries can only use its features" (Dialect.all |> List.map Dialect.to_string |> String.concat "|");
       "-no-check", Arg.String set_no_check,
         sprintf "{all|<feature>{,<feature>}+} Disable dialect feature checks (possible features: %s)"
           (Dialect.all_of_feature |> List.map Dialect.feature_to_string |> String.concat "|");
@@ -373,8 +382,13 @@ let parse_args () =
   in
   Arg.parse args work usage_msg;
   if Array.length Sys.argv = 1 then show_help ();
-  let now = !now in
-  let ddl_as_migration = !ddl_as_migration in
+  let delta =
+    { name = !name;
+      target_files = List.rev !target_files;
+      now = !now;
+      max_id_length = !max_id_length;
+      ddl_as_migration = !ddl_as_migration }
+  in
   match !migrate_mode, !diff_mode with
   | true, true -> fatal "-migrate and -diff are mutually exclusive"
   | true, false ->
@@ -385,24 +399,14 @@ let parse_args () =
       | None -> fatal "-migrate requires -gen <lang>"
     in
     Migrate {
+      delta;
       gen_lang;
-      name = !name;
       initial_files = List.rev !initial_files;
-      target_files = List.rev !target_files;
       migrations_file = !migrations_file;
       extends_file = !extends_file;
-      now;
-      ddl_as_migration;
     }
   | false, true ->
-    Diff {
-      base_files = List.rev !base_files;
-      target_files = List.rev !target_files;
-      output = !output;
-      name = !name;
-      now;
-      ddl_as_migration;
-    }
+    Diff { delta; base_files = List.rev !base_files; output = !output }
   | false, false ->
     if !output = Some Sql_ddl then
       Materialize_schema { base_files = List.rev !base_files }
@@ -420,7 +424,8 @@ let parse_migrations blocks =
   abort_on_errors ();
   migs
 
-let run_migrate ({ gen_lang; name; initial_files; target_files; migrations_file; extends_file; now; ddl_as_migration } : migrate_args) =
+let run_migrate ({ delta = { name; target_files; now; max_id_length; ddl_as_migration };
+                   gen_lang; initial_files; migrations_file; extends_file } : migrate_args) =
   let initial = to_file_sources initial_files in
   let ext = Option.map_default read_blocks [] extends_file in
   let recorded_blocks () = merge_blocks (Option.map_default read_blocks [] migrations_file) ext in
@@ -434,7 +439,9 @@ let run_migrate ({ gen_lang; name; initial_files; target_files; migrations_file;
     let full = parse_migrations (recorded_blocks ()) in
     process_migrations gen_lang name full
   in
-  match diff_schema ~ddl_as_migration ~from_:current ~to_:target with
+  let base = next_base now before in
+  let naming = Migration_id.naming ~max_length:max_id_length base in
+  match diff_schema ~naming ~ddl_as_migration ~from_:current ~to_:target with
   | [] ->
     regenerate ();
     (match before with
@@ -448,7 +455,7 @@ let run_migrate ({ gen_lang; name; initial_files; target_files; migrations_file;
       | Some f -> f
       | None -> fatal "%d new migration(s) to record: pass -migrations-file <file>" (List.length migs)
     in
-    let entries = assign_ids now before migs in
+    let entries = assign_ids ~naming base migs in
     let sql = entries_to_sql entries in
     let text =
       Option.map_default (fun existing -> existing ^ "\n\n" ^ sql) sql
@@ -474,15 +481,20 @@ let run_materialize_schema ({ base_files } : materialize_args) =
   end;
   print_endline ddl
 
-let run_diff ({ base_files; target_files; output; name; now; ddl_as_migration } : diff_args) =
+let run_diff ({ delta = { name; target_files; now; max_id_length; ddl_as_migration };
+                base_files; output } : diff_args) =
   let from_ = load_schema base_files in
   let to_   = load_schema target_files in
-  let migs = diff_schema ~ddl_as_migration ~from_ ~to_ in
+  let base = next_base now [] in
+  let naming = Migration_id.naming ~max_length:max_id_length base in
+  let migs = diff_schema ~naming ~ddl_as_migration ~from_ ~to_ in
   Tables.restore from_;
   match output with
   | None -> ()
-  | Some Sql_ddl -> if migs <> [] then print_endline (migrations_to_sql now [] migs)
-  | Some (Lang l) -> process_migrations l name (assign_ids now [] migs |> List.map entry_to_codegen)
+  | Some Sql_ddl ->
+    if migs <> [] then print_endline (entries_to_sql (assign_ids ~naming base migs))
+  | Some (Lang l) ->
+    process_migrations l name (assign_ids ~naming base migs |> List.map entry_to_codegen)
 
 let run_generate ({ output; name; inputs } : gen_args) =
   match inputs with

--- a/src/main.ml
+++ b/src/main.ml
@@ -308,7 +308,8 @@ let migration_of_block (sql, props) =
       match Props.get stmt.props "name", Props.get props "id" with
       | None, Some raw ->
         (match Migration_id.parse raw with
-         | Some ({ name = Some _; _ } as id) -> Props.set stmt.props "name" (Migration_id.to_string id)
+         | Some id when Option.is_some (Migration_id.name id) ->
+           Props.set stmt.props "name" (Migration_id.to_string id)
          | _ -> stmt.props)
       | _ -> stmt.props
     in

--- a/src/migration_id.ml
+++ b/src/migration_id.ml
@@ -1,23 +1,98 @@
+let sep = '_'
+let sep_str = String.make 1 sep
+
+module Name = struct
+
+  type word = string
+
+  let words s =
+    s
+    |> String.map (function ('a'..'z' | 'A'..'Z' | '0'..'9' | '_') as c -> c | _ -> sep)
+    |> String.split_on_char sep
+
+  type action = { verb : word list; subject : word list }
+
+  let action verb subject = { verb; subject }
+
+  type phrase = { primary : string; fallbacks : string list }
+
+  let word w = { primary = w; fallbacks = [] }
+
+  let of_action { verb; subject } =
+    let bare = String.concat sep_str verb in
+    match subject with
+    | [] -> word bare
+    | _ -> { primary = bare ^ sep_str ^ String.concat sep_str subject; fallbacks = [ bare ] }
+
+  type t = { head : word list; actions : action list }
+
+  let make head actions = { head; actions }
+
+  let phrases { head; actions } =
+    List.map word head @ List.map of_action actions
+
+  let join parts =
+    String.concat sep_str (List.map (fun a -> a.primary) (phrases parts))
+
+  let build ~limit parts =
+    match phrases parts with
+    | { primary = first; _ } :: rest when String.length first <= limit ->
+      let buf = Buffer.create limit in
+      Buffer.add_string buf first;
+      let fits s = Buffer.length buf + 1 + String.length s <= limit in
+      let add s = Buffer.add_char buf sep; Buffer.add_string buf s in
+      let rec aux = function
+        | [] -> ()
+        | { primary; fallbacks } :: rest ->
+          if fits primary then (add primary; aux rest)
+          else Option.may add (List.find_opt fits fallbacks)
+      in
+      aux rest;
+      Some (Buffer.contents buf)
+    | _ -> None
+
+  let render limit parts =
+    match limit with
+    | None -> join parts
+    | Some n -> Option.default "" (build ~limit:n parts)
+
+  let fit limit name = render limit { head = words name; actions = [] }
+
+end
+
 type t = { ord : int; name : string option }
 
-let make ?name ord =
-  { ord; name = (match name with Some "" | None -> None | n -> n) }
+let make ?name ord = { ord; name = (match name with Some "" -> None | n -> n) }
+
+let name { name; _ } = name
+
+let naming ~max_length ord =
+  let spent = String.length (string_of_int ord) + String.length sep_str in
+  Option.map (fun max -> max - spent) max_length
+
+let is_digits s =
+  s <> "" && String.for_all (function '0'..'9' -> true | _ -> false) s
 
 let parse raw =
-  let s = String.trim raw in
-  let prefix, name =
-    String.index_opt s '_'
-    |> Option.map_default
-         (fun i -> String.sub s 0 i, Some (String.sub s (i + 1) (String.length s - i - 1)))
-         (s, None)
-  in
-  int_of_string_opt prefix |> Option.map (make ?name)
+  match String.split_on_char sep (String.trim raw) with
+  | prefix :: rest when is_digits prefix ->
+    Option.map (make ~name:(String.concat sep_str rest)) (int_of_string_opt prefix)
+  | _ -> None
 
 let to_string { ord; name } =
-  name |> Option.map_default (Printf.sprintf "%d_%s" ord) (string_of_int ord)
+  let prefix = string_of_int ord in
+  Option.map_default (fun n -> prefix ^ sep_str ^ n) prefix name
 
 let sort_key { ord; _ } =
-  let canonical_stamp = "YYYYMMDDHHMMSS" in
-  let s = string_of_int ord in
-  let pad = String.length canonical_stamp - String.length s in
-  int_of_string (if pad <= 0 then s else s ^ String.make pad '0')
+  let date = String.length "YYYYMMDD" in
+  let stamp = String.length "YYYYMMDDHHMMSS" in
+  let digits = String.length (string_of_int ord) in
+  let rec pad_zeros x n = if n <= 0 then x else pad_zeros (x * 10) (n - 1) in
+  if digits < date then 0, ord else 1, pad_zeros ord (stamp - digits)
+
+let compare_key (a1, b1) (a2, b2) =
+  match Int.compare a1 a2 with 0 -> Int.compare b1 b2 | n -> n
+
+let compare a b = compare_key (sort_key a) (sort_key b)
+
+let next_ord id = snd (sort_key id) + 1

--- a/src/migration_id.mli
+++ b/src/migration_id.mli
@@ -1,0 +1,21 @@
+module Name : sig
+  type t
+  type word
+  type action
+
+  val words : string -> word list
+  val action : word list -> word list -> action
+  val make : word list -> action list -> t
+  val render : int option -> t -> string
+  val fit : int option -> string -> string
+end
+
+type t
+
+val make : ?name:string -> int -> t
+val name : t -> string option
+val parse : string -> t option
+val to_string : t -> string
+val compare : t -> t -> int
+val next_ord : t -> int
+val naming : max_length:int option -> int -> int option

--- a/src/schema_diff.ml
+++ b/src/schema_diff.ml
@@ -2,6 +2,9 @@ open Printf
 open Sqlgg
 
 module SMap = Tables.SMap
+module Name = Migration_id.Name
+
+let mig_name naming head actions = Name.render naming (Name.make head actions)
 
 let index_by key xs =
   List.fold_left (fun m x -> SMap.add (key x) x m) SMap.empty xs
@@ -94,10 +97,7 @@ let materialize_inline_unique (t : Tables.stored_table) =
 type change =
   | Create_table of Tables.stored_table
   | Drop_table of Tables.stored_table
-  | Alter_table of { table : Sql.table_name; sql : string; mig_name : string }
-
-let safe_ident =
-  String.map (function ('a'..'z' | 'A'..'Z' | '0'..'9' | '_') as c -> c | _ -> '_')
+  | Alter_table of { table : Sql.table_name; sql : string; actions : Sql.alter_action list }
 
 let index_kind_slug = function
   | Sql.Plain_idx -> "index"
@@ -105,29 +105,33 @@ let index_kind_slug = function
   | Sql.Fulltext_idx -> "fulltext"
   | Sql.Spatial_idx -> "spatial"
 
-let rename_slug what o n = sprintf "rename_%s_%s_%s" what (safe_ident o) (safe_ident n)
+let verb spelling = Name.words spelling
+let action v = Name.action (verb v) []
+let action_on v target = Name.action (verb v) (Name.words target)
+let rename kind old_ new_ =
+  Name.action (verb "rename" @ verb kind) (Name.words old_ @ Name.words new_)
 
-let action_slug : Sql.alter_action -> string = function
-  | `Add (col, _) -> "add_col_" ^ safe_ident col.name
-  | `Drop name -> "drop_col_" ^ safe_ident name
+let action_of : Sql.alter_action -> Name.action = function
+  | `Add (col, _) -> action_on "add_col" col.name
+  | `Drop name -> action_on "drop_col" name
   | `Change (old_name, new_col, _) ->
-    if old_name = new_col.name then "change_col_" ^ safe_ident new_col.name
-    else rename_slug "col" old_name new_col.name
-  | `RenameTable t -> "rename_to_" ^ safe_ident t.tn
-  | `RenameColumn (o, n) -> rename_slug "col" o n
-  | `RenameIndex (o, n) -> rename_slug "index" o n
+    if old_name = new_col.name then action_on "change_col" new_col.name
+    else rename "col" old_name new_col.name
+  | `RenameTable t -> action_on "rename_to" t.tn
+  | `RenameColumn (o, n) -> rename "col" o n
+  | `RenameIndex (o, n) -> rename "index" o n
   | `AddIndex { add_idx_name; add_idx_kind; _ } ->
-    let base = "add_" ^ index_kind_slug add_idx_kind in
-    Option.map_default (fun n -> base ^ "_" ^ safe_ident n) base add_idx_name
-  | `DropIndex name -> "drop_index_" ^ safe_ident name
-  | `AddPrimaryKey _ -> "add_pk"
-  | `DropPrimaryKey -> "drop_pk"
-  | `AddConstraint _ -> "add_constraint"
-  | `DropConstraint name -> "drop_constraint_" ^ safe_ident name
-  | `Default_or_convert_to _ -> "set_charset"
-  | `TtlOptions _ -> "set_ttl"
-  | `RemoveTtl _ -> "remove_ttl"
-  | `AlterColumnPG (col, _) -> "alter_col_" ^ safe_ident col
+    let v = verb "add" @ verb (index_kind_slug add_idx_kind) in
+    Option.map_default (fun n -> Name.action v (Name.words n)) (Name.action v []) add_idx_name
+  | `DropIndex name -> action_on "drop_index" name
+  | `AddPrimaryKey _ -> action "add_pk"
+  | `DropPrimaryKey -> action "drop_pk"
+  | `AddConstraint _ -> action "add_constraint"
+  | `DropConstraint name -> action_on "drop_constraint" name
+  | `Default_or_convert_to _ -> action "set_charset"
+  | `TtlOptions _ -> action "set_ttl"
+  | `RemoveTtl _ -> action "remove_ttl"
+  | `AlterColumnPG (col, _) -> action_on "alter_col" col
 
 let diff_columns ~from_ ~to_ =
   let from_cols = columns_without_index_unique from_ in
@@ -203,10 +207,7 @@ let alter_change name target actions =
       (fun (c : Tables.column) -> c.default_sql)
   in
   Option.map
-    (fun sql ->
-      let slugs = List.map action_slug actions in
-      let mig_name = String.concat "_" ("alter" :: safe_ident name.Sql.tn :: slugs) in
-      Alter_table { table = name; sql; mig_name })
+    (fun sql -> Alter_table { table = name; sql; actions })
     (Gen_migrations.alter_table_sql ~default_sql_lookup name (Gen_migrations.Columns actions))
 
 let diff ~ddl_as_migration ~from_ ~to_ ~by_from ~by_to =
@@ -250,10 +251,11 @@ let change_table = function
   | Drop_table t -> t.Tables.name
   | Alter_table { table; _ } -> table
 
-let change_name = function
-  | Create_table t -> "create_" ^ safe_ident t.Tables.name.tn
-  | Drop_table t -> "drop_" ^ safe_ident t.Tables.name.tn
-  | Alter_table { mig_name; _ } -> mig_name
+let change_name ~naming = function
+  | Create_table t -> mig_name naming (Name.words "create" @ Name.words t.Tables.name.tn) []
+  | Drop_table t -> mig_name naming (Name.words "drop" @ Name.words t.Tables.name.tn) []
+  | Alter_table { table; actions; _ } ->
+    mig_name naming (Name.words "alter" @ Name.words table.tn) (List.map action_of actions)
 
 let kind_of_change = function
   | Create_table t -> Stmt.Create t.Tables.name
@@ -283,13 +285,13 @@ let invert ~by_from ~by_to up =
         | Some down -> down
         | None -> irreversible "reverse diff renders to nothing"
 
-let generate ~ddl_as_migration ~from_ ~to_ =
+let generate ~naming ~ddl_as_migration ~from_ ~to_ =
   let from_ = List.map materialize_inline_unique from_ in
   let to_ = List.map materialize_inline_unique to_ in
   let by_from = table_by_name from_ in
   let by_to = table_by_name to_ in
   diff ~ddl_as_migration ~from_ ~to_ ~by_from ~by_to |> List.map (fun up ->
-    { Gen_migrations.props = Props.set Props.empty "name" (change_name up);
+    { Gen_migrations.props = Props.set Props.empty "name" (change_name ~naming up);
       kind = kind_of_change up;
       apply = render_apply up;
       revert = render_apply (invert ~by_from ~by_to up) })

--- a/src/test.ml
+++ b/src/test.ml
@@ -2327,6 +2327,40 @@ let test_join_hole_whitespace =
       [Gen.Static "FROM a"; join " LEFT JOIN b ON b.a = a.id"; Gen.Static "\nWHERE note = '  two  spaces  '"];
   ]
 
+let test_migration_name =
+  let module Name = Migration_id.Name in
+  let head = Name.words "alter_blog_sync_jobs" in
+  let actions =
+    [ Name.action (Name.words "add_col") (Name.words "redirects_synced");
+      Name.action (Name.words "add_col") (Name.words "redirects_skipped");
+      Name.action (Name.words "add_pk") [] ]
+  in
+  let render limit expected =
+    assert_equal ~printer:(fun s -> s) expected (Name.render limit (Name.make head actions))
+  in
+  let uncapped expected = "uncapped" >:: (fun () -> render None expected) in
+  let cut n expected = sprintf "cap %d" n >:: (fun () -> render (Some n) expected) in
+  let flat limit before after =
+    sprintf "fit %S" before >:: (fun () ->
+      assert_equal ~printer:(fun s -> s) after (Name.fit limit before))
+  in
+  let whole = "alter_blog_sync_jobs_add_col_redirects_synced_add_col_redirects_skipped_add_pk" in
+  [
+    uncapped whole;
+    cut 78 whole;
+    cut 77 "alter_blog_sync_jobs_add_col_redirects_synced_add_col_redirects_skipped";
+    cut 60 "alter_blog_sync_jobs_add_col_redirects_synced_add_col";
+    cut 53 "alter_blog_sync_jobs_add_col_redirects_synced_add_col";
+    cut 52 "alter_blog_sync_jobs_add_col_redirects_synced";
+    cut 27 "alter_blog_sync_jobs";
+    cut 19 "alter_blog_sync";
+    cut 6 "alter";
+
+    flat None "whatever_it_is"            "whatever_it_is";
+    flat (Some 15)  "alter_users_add_col_email" "alter_users_add";
+    flat (Some 11)  "alter_users_add_col_email" "alter_users";
+  ]
+
 let run () =
   Gen.params_mode := Some Named;
   let tests =
@@ -2371,6 +2405,7 @@ let run () =
     "test_nullability_rules" >::: test_nullability_rules;
     "test_fn_group_by_arg" >::: test_fn_group_by_arg;
     "test_join_hole_whitespace" >::: test_join_hole_whitespace;
+    "migration name" >::: test_migration_name;
   ]
   in
   let test_suite = "main" >::: tests in

--- a/test/cram/test_migrations/migrate-max-id-length.t/initial.sql
+++ b/test/cram/test_migrations/migrate-max-id-length.t/initial.sql
@@ -1,0 +1,2 @@
+CREATE TABLE some_extremely_long_table_specification (id INT NOT NULL PRIMARY KEY);
+CREATE TABLE some_extremely_long_table_identifier (id INT NOT NULL PRIMARY KEY);

--- a/test/cram/test_migrations/migrate-max-id-length.t/run.t
+++ b/test/cram/test_migrations/migrate-max-id-length.t/run.t
@@ -1,0 +1,61 @@
+Migration ids are <timestamp>_<name>. Siblings of one run share the timestamp, so
+the name is all that tells them apart, and it is stored in a finite name column.
+`-max-migration-id-length` caps the id by building the name up to the cap instead
+of letting the database chop it.
+
+Two tables with a shared prefix, four columns added to each. Uncapped:
+
+  $ sqlgg -no-header -dialect mysql -diff -gen sql -now 20260101120000 -base initial.sql -target target.sql | grep -o 'id=.*'
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column_add_col_second_additional_column_add_col_third_additional_column_add_col_fourth_additional_column
+  id=20260101120000_alter_some_extremely_long_table_specification_add_col_first_additional_column_add_col_second_additional_column_add_col_third_additional_column_add_col_fourth_additional_column
+
+Tightening the cap, one of them shrinks step by step. Actions drop off the tail
+whole; the one that no longer fits goes in as its bare verb `add_col`; then the
+table name gives up whole words. Nothing is ever cut mid-word:
+
+  $ for n in 160 150 125 90 80 58; do sqlgg -no-header -dialect mysql -diff -gen sql -now 20260101120000 -max-migration-id-length $n -base initial.sql -target target.sql | grep -o 'id=.*' | head -1; done
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column_add_col_second_additional_column_add_col_third_additional_column
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column_add_col_second_additional_column_add_col
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column_add_col_second_additional_column
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col
+  id=20260101120000_alter_some_extremely_long_table_identifier
+
+Cut past the word that differs and the two names collide. Nothing is appended to
+force them apart, so the batch is refused rather than recorded:
+
+  $ sqlgg -no-header -dialect mysql -diff -gen sql -now 20260101120000 -max-migration-id-length 50 -base initial.sql -target target.sql
+  two migrations get the same id "20260101120000_alter_some_extremely_long_table". increase -max-migration-id-length
+  [1]
+
+Below the timestamp width no name is left at all, caught by the same check:
+
+  $ sqlgg -no-header -dialect mysql -diff -gen sql -now 20260101120000 -max-migration-id-length 15 -base initial.sql -target target.sql
+  two migrations get the same id "20260101120000". increase -max-migration-id-length
+  [1]
+
+Shortening is deterministic, so -migrate stays idempotent:
+
+  $ : > migrations.sql
+
+  $ sqlgg -no-header -dialect mysql -migrate -gen caml -name migrations -now 20260101120000 -max-migration-id-length 80 -initial initial.sql -migrations-file migrations.sql -target target.sql > migrations.ml
+  appended 2 migration(s) to migrations.sql (id 20260101120000_alter_some_extremely_long_table_identifier_add_col, 20260101120000_alter_some_extremely_long_table_specification_add_col)
+
+  $ grep -o 'id=.*' migrations.sql
+  id=20260101120000_alter_some_extremely_long_table_identifier_add_col
+  id=20260101120000_alter_some_extremely_long_table_specification_add_col
+
+Generated code names follow the id:
+
+  $ grep -o 'let apply_[a-z0-9_]*' migrations.ml
+  let apply_20260101120000_alter_some_extremely_long_table_identifier_add_col
+  let apply_20260101120000_alter_some_extremely_long_table_specification_add_col
+
+  $ sqlgg -no-header -dialect mysql -migrate -gen caml -name migrations -now 20260102120000 -max-migration-id-length 80 -initial initial.sql -migrations-file migrations.sql -target target.sql > /dev/null
+  nothing new to migrate; regenerated code from 2 recorded migration(s)
+
+Recorded ids are never rewritten, so changing the cap later leaves applied
+migrations untouched:
+
+  $ sqlgg -no-header -dialect mysql -migrate -gen caml -name migrations -now 20260102120000 -initial initial.sql -migrations-file migrations.sql -target target.sql > /dev/null
+  nothing new to migrate; regenerated code from 2 recorded migration(s)

--- a/test/cram/test_migrations/migrate-max-id-length.t/target.sql
+++ b/test/cram/test_migrations/migrate-max-id-length.t/target.sql
@@ -1,0 +1,15 @@
+CREATE TABLE some_extremely_long_table_specification (
+  id INT NOT NULL PRIMARY KEY,
+  first_additional_column INT NOT NULL,
+  second_additional_column INT NOT NULL,
+  third_additional_column INT NOT NULL,
+  fourth_additional_column INT NOT NULL
+);
+
+CREATE TABLE some_extremely_long_table_identifier (
+  id INT NOT NULL PRIMARY KEY,
+  first_additional_column INT NOT NULL,
+  second_additional_column INT NOT NULL,
+  third_additional_column INT NOT NULL,
+  fourth_additional_column INT NOT NULL
+);


### PR DESCRIPTION
### Description

Generated migration ids grow with every action in the change, and the database silently cuts whatever does not fit the `name` column:

```
20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column_add_col_second_additional_column_add_col_third_additional_column_add_col_fourth_additional_column
```

`-max-migration-id-length N` builds the name up to N instead, dropping whole actions off the tail:

```
$ sqlgg -migrate -max-migration-id-length 90 ...
20260101120000_alter_some_extremely_long_table_identifier_add_col_first_additional_column
```
