### PR TITLE
Add more ppx field attributes for records

### DIFF
--- a/doc/ocaml/ppx.md
+++ b/doc/ocaml/ppx.md
@@ -50,27 +50,27 @@ end
 Building a record out of the columns is an applicative chain of `let+` and `and+`:
 
 ```ocaml
-type who = { id : int64; name : string option }
+type product = { id : int64; name : string option }
 
-let who_from_q1 = Q1.(let+ id = id and+ name = name in { id; name })
+let product_from_q1 = Q1.(let+ id = id and+ name = name in { id; name })
 ```
 
 Written this way the record is bound to `Q1`. `id` and `name` resolve in that module and nowhere else, so `Q2`, which selects both columns as well, gets its own copy of the chain:
 
 ```ocaml
-let who_from_q2 = Q2.(let+ id = id and+ name = name in { id; name })
+let product_from_q2 = Q2.(let+ id = id and+ name = name in { id; name })
 ```
 
 `[@@deriving sqlgg]` derives the chain from the record type instead, once for both queries:
 
 ```ocaml
-type who = { id : int64; name : string option } [@@deriving sqlgg]
+type product = { id : int64; name : string option } [@@deriving sqlgg]
 ```
 
 It writes out the same chain, except the columns are now read off a `cols` object instead of a module:
 
 ```ocaml
-let who_of_cols cols =
+let product_of_cols cols =
   let open Sqlgg_scope in
   let+ id = cols#id
   and+ name = cols#name in
@@ -80,11 +80,11 @@ let who_of_cols cols =
 which is what makes one function serve both queries:
 
 ```ocaml
-let who_from_q1 = Q1.(who_of_cols cols)
-let who_from_q2 = Q2.(who_of_cols cols)
+let product_from_q1 = Q1.(product_of_cols cols)
+let product_from_q2 = Q2.(product_of_cols cols)
 ```
 
-The derived function is named after the type, so `who` gives `who_of_cols` (and a type named `t` gives plain `of_cols`).
+The derived function is named after the type, so `product` gives `product_of_cols` (and a type named `t` gives plain `of_cols`).
 
 Only the record's fields reach the `SELECT` list, and [unused JOINs](../sql/dynamic-select.md#unused-join-elimination) go with them.
 
@@ -104,14 +104,14 @@ Add the preprocessor to your `dune` file:
 The derived function is an ordinary column value, so it goes straight into `select`:
 
 ```ocaml
-let q1 db = Q1.(select db (who_of_cols cols) ~id:1L)
+let q1 db = Q1.(select db (product_of_cols cols) ~id:1L)
 
 let q2 db =
-  Q2.(select db (who_of_cols cols) ~min_stock:10L
-    (fun (w : who) -> print_endline (Option.value w.name ~default:"?")))
+  Q2.(select db (product_of_cols cols) ~min_stock:10L
+    (fun (w : product) -> print_endline (Option.value w.name ~default:"?")))
 ```
 
-Both calls run `SELECT id, name` and return `who` records. `q2` never fetches `stock`, since the record does not ask for it.
+Both calls run `SELECT id, name` and return `product` records. `q2` never fetches `stock`, since the record does not ask for it.
 
 ## Query Isolation
 
@@ -169,7 +169,28 @@ let with_warehouse db =
 
 Drop `warehouse` from the chain and the join to `stock_info` is [eliminated](../sql/dynamic-select.md#unused-join-elimination), nothing reads from it anymore.
 
-## `[@sqlgg.col "column_name"]`
+## What Gets Derived
+
+One function per record:
+
+```ocaml
+type product = { id : int64; name : string option } [@@deriving sqlgg]
+```
+
+```ocaml
+val product_of_cols :
+  < id : int64 col; name : string option col; .. > -> product col
+```
+
+It reads the record off a query's `cols`. A type named `t` drops the prefix and
+gives plain `of_cols`.
+
+## Per-Field Attributes
+
+An attribute on a field changes where its value comes from, or what happens to
+it on the way in or out.
+
+### `[@sqlgg.col "column_name"]`
 
 When a record field name does not match the SQL column name, override it per field:
 
@@ -184,3 +205,95 @@ let q db = Q1.(select db (renamed_of_cols cols) ~id:3L)
 ```
 
 Here the `productName` field is read from the `name` column.
+
+### `[@sqlgg.map f]`
+
+`f` runs on the value read from the column. The column is whatever `f` takes,
+the field is whatever it gives back:
+
+```ocaml
+type counts = {
+  id : int64;
+  reply_count : int; [@sqlgg.map Int64.to_int]
+}
+[@@deriving sqlgg]
+```
+
+```ocaml
+val counts_of_cols : < id : int64 col; reply_count : int64 col; .. > -> counts col
+```
+
+Use it when the conversion belongs to *this* record rather than to the column,
+for instance when two queries want the same column read differently. A
+conversion that belongs to the *column* is better declared once in the schema
+with [`-- [sqlgg] module=`](../sql/metadata.md), which then applies to every
+query that touches it.
+
+### `[@sqlgg.by]`
+
+Leaves the conversion open and takes it as a labelled argument, so one record
+serves call sites whose raw column types differ:
+
+```ocaml
+type counts = { id : int64; n : int [@sqlgg.by] } [@@deriving sqlgg]
+```
+
+```ocaml
+val counts_of_cols : n:('raw -> int) -> < id : int64 col; n : 'raw col; .. > -> counts col
+```
+
+```ocaml
+let from_number = Q_num.(counts_of_cols ~n:Int64.to_int cols)
+let from_label  = Q_txt.(counts_of_cols ~n:String.length cols)
+```
+
+The argument is mandatory, and deliberately so. An optional argument needs a
+default, and any concrete default would fix `'raw` to whatever that one
+function takes, for every call site at once. That is exactly the freedom the
+attribute exists to give. **Invariant: `[@sqlgg.by]` is never optional.**
+
+### `[@sqlgg.default v]`
+
+Sugar for `[@sqlgg.map (fun x -> Option.value x ~default:v)]`: the column is
+nullable, the field is not.
+
+```ocaml
+type counts = { id : int64; hits : int64 [@sqlgg.default 0L] } [@@deriving sqlgg]
+```
+
+```ocaml
+val counts_of_cols : < id : int64 col; hits : int64 option col; .. > -> counts col
+```
+
+The default replaces `NULL`, so the field cannot be an option.
+
+### `[@sqlgg.nested]`
+
+A field whose type is another derived record is read from the same `cols`:
+
+```ocaml
+type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
+
+type post = {
+  id : int64;
+  content : content; [@sqlgg.nested]
+  reply_count : int; [@sqlgg.map Int64.to_int]
+}
+[@@deriving sqlgg]
+```
+
+The derived chain calls `content_of_cols cols`, so the two records compose the
+same way a hand-written [composition](#composition) would. The nested record's
+columns do not appear in the outer object type — the inner call adds them:
+
+```ocaml
+val post_of_cols :
+  < id : int64 col; body : string option col; reply_count : int64 col; .. > -> post col
+```
+
+Since only the fields a record mentions reach the `SELECT` list, dropping a
+nested field drops its columns and any [join](../sql/dynamic-select.md#unused-join-elimination)
+that existed only to serve them.
+
+A record from another module works too. `channel : Feed.channel [@sqlgg.nested]`
+calls `Feed.channel_of_cols`.

--- a/impl/ocaml/ppx/ppx_sqlgg.ml
+++ b/impl/ocaml/ppx/ppx_sqlgg.ml
@@ -1,73 +1,477 @@
 open Ppxlib
+module D = Ast_builder.Default
 
-let fun_name = function "t" -> "of_cols" | t -> t ^ "_of_cols"
+let derived_name ~suffix = Expansion_helpers.mangle (Suffix suffix)
 
-let col_attr =
-  Attribute.declare "sqlgg.col" Attribute.Context.label_declaration
-    Ast_pattern.(single_expr_payload (estring __))
-    Fun.id
+let derived_lid ~suffix lid =
+  Loc.map lid ~f:(Expansion_helpers.mangle_lid (Suffix suffix))
 
-let col_name ld =
-  Option.value (Attribute.get col_attr ld) ~default:ld.pld_name.txt
+let cols_arg = "sqlgg__cols"
+let fn_arg = "sqlgg__f"
+let rec_arg = "sqlgg__r"
+let col_arg = Printf.sprintf "sqlgg__c_%s"
+let val_arg = Printf.sprintf "sqlgg__v_%s"
+let conv_arg = Printf.sprintf "sqlgg__conv_%s"
+
+type spec =
+  | Fn of expression
+  | Raw of core_type
+
+let ctx = Attribute.Context.label_declaration
+
+let located name pat =
+  Attribute.declare_with_attr_loc name ctx pat (fun ~attr_loc x ->
+      Loc.make ~loc:attr_loc x)
+
+let spec_attr name =
+  located name
+    Ast_pattern.(
+      map1 (single_expr_payload __) ~f:(fun e -> Fn e)
+      ||| map1 (ptyp __) ~f:(fun t -> Raw t))
+
+let col_attr = located "sqlgg.col" Ast_pattern.(single_expr_payload (estring __))
+let map_attr = spec_attr "sqlgg.map"
+let set_attr = spec_attr "sqlgg.set"
+let default_attr = located "sqlgg.default" Ast_pattern.(single_expr_payload __)
+let by_attr = Attribute.declare_flag "sqlgg.by" ctx
+let nested_attr = Attribute.declare_flag "sqlgg.nested" ctx
+
+let attributes =
+  [ Attribute.T col_attr; Attribute.T map_attr; Attribute.T set_attr
+  ; Attribute.T default_attr; Attribute.T by_attr; Attribute.T nested_attr ]
+
+type 'a how =
+  | Plain
+  | Defaulted of expression
+  | Mapped of 'a
+
+type 'a conv = { by : bool; how : 'a how }
+
+type 'a source =
+  | Column of { col : string loc; conv : 'a conv; set : 'a option }
+  | Group of longident loc
+
+type 'a field =
+  { fname : string
+  ; floc : location
+  ; fty : core_type
+  ; src : 'a source
+  }
+
+type binder =
+  | Anon
+  | Named of string
+  | Named_opt of string * expression
+
+type param =
+  { pkind : binder
+  ; ppat : pattern
+  ; ploc : location
+  }
+
+let efun params body =
+  List.fold_right
+    (fun { pkind; ppat; ploc = loc } acc ->
+      let lbl, def =
+        match pkind with
+        | Anon -> Nolabel, None
+        | Named n -> Labelled n, None
+        | Named_opt (n, d) -> Optional n, Some d
+      in
+      D.pexp_fun ~loc lbl def ppat acc)
+    params body
+
+let col_ty ~loc t =
+  [%type: ([%t t], 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col]
+
+let scope_vars ~loc =
+  [ [%type: 'sqlgg__brand]; [%type: 'sqlgg__row]; [%type: 'sqlgg__params] ]
+
+let row_var ~loc = [%type: 'sqlgg__cols]
+
+let record_ty ~loc tname = D.ptyp_constr ~loc (Loc.make ~loc (Lident tname)) []
+let opaque f = D.ptyp_var ~loc:f.floc (Printf.sprintf "sqlgg__raw_%s" f.fname)
+
+let intrinsic ~loc f = function
+  | { by = false; how = Plain } -> Some f.fty
+  | { by = false; how = Defaulted _ } -> Some [%type: [%t f.fty] option]
+  | { by = true; _ } | { how = Mapped _; _ } -> None
+let fill_default ~loc e = [%expr Stdlib.Option.value ~default:[%e e]]
+
+let analyze_field ~err ~pick ld =
+  let loc = ld.pld_loc in
+  let is_option ty =
+    match ty.ptyp_desc with
+    | Ptyp_constr ({ txt = Lident "option" | Ldot (_, "option"); _ }, [ _ ]) -> true
+    | _ -> false
+  in
+  let nullary_constr ty =
+    match ty.ptyp_desc with Ptyp_constr (lid, []) -> Some lid | _ -> None
+  in
+  let errf ~loc fmt =
+    Printf.ksprintf
+      (fun msg -> err (loc, Printf.sprintf "field %s: %s" ld.pld_name.txt msg))
+      fmt
+  in
+  let picked name { txt; loc } =
+    match pick txt with
+    | Ok x -> Some x
+    | Error why ->
+      errf ~loc "%s: %s" name why;
+      None
+  in
+  let col = Attribute.get col_attr ld in
+  let map = Attribute.get map_attr ld in
+  let default = Attribute.get default_attr ld in
+  let set_attr_value = Attribute.get set_attr ld in
+  let by = Attribute.has_flag by_attr ld in
+  let how =
+    match map, default with
+    | Some _, Some { loc; _ } ->
+      errf ~loc "[@sqlgg.map] and [@sqlgg.default] cannot be combined";
+      Some Plain
+    | Some m, None -> Option.map (fun x -> Mapped x) (picked "[@sqlgg.map]" m)
+    | None, Some { txt; loc } ->
+      if is_option ld.pld_type then
+        errf ~loc "[@sqlgg.default] replaces NULL, so the field cannot be an option";
+      Some (Defaulted txt)
+    | None, None -> Some Plain
+  in
+  let set =
+    match set_attr_value with
+    | None -> Some None
+    | Some s -> Option.map Option.some (picked "[@sqlgg.set]" s)
+  in
+  let used =
+    List.filter_map
+      (fun (name, present) -> if present then Some name else None)
+      [ "[@sqlgg.col]", Option.is_some col
+      ; "[@sqlgg.map]", Option.is_some map
+      ; "[@sqlgg.default]", Option.is_some default
+      ; "[@sqlgg.set]", Option.is_some set_attr_value
+      ; "[@sqlgg.by]", by ]
+  in
+  match how, set with
+  | None, _ | _, None -> None
+  | Some how, Some set ->
+    let column () =
+      Column { col = Option.value col ~default:ld.pld_name; conv = { by; how }; set }
+    in
+    let src =
+      match Attribute.has_flag nested_attr ld, used, nullary_constr ld.pld_type with
+      | false, _, _ -> column ()
+      | true, (_ :: _ as names), _ ->
+        errf ~loc "[@sqlgg.nested] cannot be combined with %s"
+          (String.concat ", " names);
+        column ()
+      | true, [], Some lid -> Group lid
+      | true, [], None ->
+        errf ~loc "[@sqlgg.nested] needs a record type deriving sqlgg";
+        column ()
+    in
+    Some { fname = ld.pld_name.txt; floc = loc; fty = ld.pld_type; src }
+
+let cols_type ~loc tname fields =
+  let (module B) = Ast_builder.make loc in
+  let row = row_var ~loc in
+  let vars = scope_vars ~loc @ [ row ] in
+  let meth f conv = Option.map (col_ty ~loc) (intrinsic ~loc f conv) in
+  let step f acc =
+    Option.bind acc (fun (meths, cstrs) ->
+        match f.src with
+        | Group lid ->
+          Some
+            ( meths
+            , (row, B.ptyp_constr (derived_lid ~suffix:"cols" lid) vars, loc) :: cstrs )
+        | Column { col; conv; _ } ->
+          Option.map (fun t -> B.otag col t :: meths, cstrs) (meth f conv))
+  in
+  List.fold_right step fields (Some ([], []))
+  |> Option.map (fun (meths, cstrs) ->
+         B.type_declaration
+           ~name:(B.Located.mk (derived_name ~suffix:"cols" tname))
+           ~params:(List.map (fun v -> v, (NoVariance, NoInjectivity)) vars)
+           ~cstrs:((row, B.ptyp_object meths Open, loc) :: cstrs)
+           ~kind:Ptype_abstract ~private_:Public ~manifest:(Some row))
 
 let build ~loc tname first rest =
   let fields = first :: rest in
   let (module B) = Ast_builder.make loc in
-  let open B in
-  let lid = Located.lident in
-  let record_ty = ptyp_constr (lid tname) [] in
-  let col_ty t =
-    [%type: ([%t t], 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col]
+  let record_ty = record_ty ~loc tname in
+  let item ~suffix body =
+    [%stri let [%p B.pvar (derived_name ~suffix tname)] = [%e body]]
   in
-  let cols_ty =
-    ptyp_object
-      (List.map (fun ld -> otag (Located.mk (col_name ld)) (col_ty ld.pld_type)) fields)
-      Open
+
+  let gen_item =
+    let bind op f =
+      let loc = f.floc in
+      let (module B) = Ast_builder.make loc in
+      B.binding_op ~op:(B.Located.mk op)
+        ~pat:(B.pvar (val_arg f.fname))
+        ~exp:(B.evar (col_arg f.fname))
+    in
+    let record =
+      B.pexp_record
+        (List.map (fun f -> B.Located.lident f.fname, B.evar (val_arg f.fname)) fields)
+        None
+    in
+    let letop =
+      B.pexp_letop
+        (B.letop ~let_:(bind "let+" first) ~ands:(List.map (bind "and+") rest)
+           ~body:[%expr ([%e record] : [%t record_ty])])
+    in
+    let params =
+      List.map
+        (fun f ->
+          let loc = f.floc in
+          let (module B) = Ast_builder.make loc in
+          { pkind = Named f.fname
+          ; ppat = [%pat? ([%p B.pvar (col_arg f.fname)] : [%t col_ty ~loc f.fty])]
+          ; ploc = loc
+          })
+        fields
+    in
+    item ~suffix:"of_cols_gen"
+      (efun params
+         [%expr
+           ((let open Sqlgg_scope in
+             [%e letop])
+             : [%t col_ty ~loc record_ty])])
   in
-  let record =
-    pexp_record (List.map (fun ld -> lid ld.pld_name.txt, evar ld.pld_name.txt) fields) None
-  in
-  let bind op ld =
-    { pbop_op = Located.mk op
-    ; pbop_pat = pvar ld.pld_name.txt
-    ; pbop_exp = pexp_send [%expr sqlgg__cols] (Located.mk (col_name ld))
-    ; pbop_loc = loc
-    }
-  in
-  let letop =
-    pexp_letop
-      { let_ = bind "let+" first
-      ; ands = List.map (bind "and+") rest
-      ; body = [%expr ([%e record] : [%t record_ty])]
+
+  let of_cols_item =
+    let column f col ({ by; how } as conv) =
+      let loc = col.loc in
+      let (module B) = Ast_builder.make loc in
+      let get = B.pexp_send (B.evar cols_arg) col in
+      let via e = [%expr Sqlgg_scope.map [%e e] [%e get]] in
+      let read =
+        match by, how with
+        | false, Plain -> get
+        | false, Defaulted e -> via (fill_default ~loc e)
+        | false, Mapped g -> via g
+        | true, _ -> via (B.evar (conv_arg f.fname))
+      in
+      let ty = Option.value (intrinsic ~loc f conv) ~default:(opaque f) in
+      Some (B.otag col (col_ty ~loc ty)), read
+    in
+    let meths, args =
+      List.split
+        (List.map
+           (fun f ->
+             let loc = f.floc in
+             let (module B) = Ast_builder.make loc in
+             let meth, read =
+               match f.src with
+               | Group lid ->
+                 ( None
+                 , [%expr
+                     [%e B.pexp_ident (derived_lid ~suffix:"of_cols" lid)]
+                       [%e B.evar cols_arg]] )
+               | Column { col; conv; _ } -> column f col conv
+             in
+             meth, (Labelled f.fname, read))
+           fields)
+    in
+    let params =
+      List.filter_map
+        (fun f ->
+          let loc = f.floc in
+          match f.src with
+          | Group _ | Column { conv = { by = false; _ }; _ } -> None
+          | Column { conv = { by = true; how }; _ } ->
+            let pkind =
+              match how with
+              | Plain -> Named f.fname
+              | Mapped e -> Named_opt (f.fname, e)
+              | Defaulted e -> Named_opt (f.fname, fill_default ~loc e)
+            in
+            Some { pkind; ppat = D.pvar ~loc (conv_arg f.fname); ploc = loc })
+        fields
+    in
+    let row =
+      { pkind = Anon
+      ; ppat =
+          B.ppat_constraint (B.pvar cols_arg)
+            (B.ptyp_object (List.filter_map Fun.id meths) Open)
+      ; ploc = loc
       }
+    in
+    let call = B.pexp_apply (B.evar (derived_name ~suffix:"of_cols_gen" tname)) args in
+    item ~suffix:"of_cols"
+      (efun (params @ [ row ]) [%expr ([%e call] : [%t col_ty ~loc record_ty])])
   in
-  [%str
-    let [%p pvar (fun_name tname)] =
-     fun (sqlgg__cols : [%t cols_ty]) : [%t col_ty record_ty] ->
-      let open Sqlgg_scope in
-      [%e letop]]
+
+  let apply_item =
+    let field_of ?set f =
+      let loc = f.floc in
+      let (module B) = Ast_builder.make loc in
+      let v = B.pexp_field (B.evar rec_arg) (B.Located.lident f.fname) in
+      match set with None -> v | Some g -> [%expr [%e g] [%e v]]
+    in
+    let flush acc = function
+      | [] -> acc
+      | pending ->
+        B.pexp_apply acc
+          (List.rev_map (fun (f, col, set) -> Labelled col.txt, field_of ?set f) pending)
+    in
+    let rec chain acc pending = function
+      | [] -> flush acc pending
+      | ({ src = Group lid; _ } as f) :: tl ->
+        let loc = f.floc in
+        chain
+          [%expr
+            [%e D.pexp_ident ~loc (derived_lid ~suffix:"apply" lid)]
+              [%e flush acc pending] [%e field_of f]]
+          [] tl
+      | ({ src = Column { col; set; _ }; _ } as f) :: tl ->
+        chain acc ((f, col, set) :: pending) tl
+    in
+    item ~suffix:"apply"
+      [%expr
+        fun [%p B.pvar fn_arg] ([%p B.pvar rec_arg] : [%t record_ty]) ->
+          [%e chain (B.evar fn_arg) [] fields]]
+  in
+
+  let cols_item =
+    match cols_type ~loc tname fields with
+    | None -> []
+    | Some decl -> [ B.pstr_type Recursive [ decl ] ]
+  in
+  cols_item @ [ gen_item; of_cols_item; apply_item ]
+
+let sig_items ~loc tname first rest =
+  let fields = first :: rest in
+  let (module B) = Ast_builder.make loc in
+  let record_ty = record_ty ~loc tname in
+  let sraw f = function
+    | { how = Mapped t; _ } -> t
+    | { by = true; how = Plain } -> opaque f
+    | { how = Plain | Defaulted _; _ } as conv ->
+      Option.value (intrinsic ~loc f conv) ~default:[%type: [%t f.fty] option]
+  in
+  let cols_decl = cols_type ~loc tname fields in
+  let groups =
+    List.filter (fun f -> match f.src with Group _ -> true | Column _ -> false) fields
+  in
+  match cols_decl, groups with
+  | None, (_ :: _ as blocked) ->
+    List.map
+      (fun f ->
+        D.psig_extension ~loc:f.floc
+          (Location.error_extensionf ~loc:f.floc
+             "deriving sqlgg: [@sqlgg.nested] needs %s, which a converted column \
+              rules out"
+             (derived_name ~suffix:"cols" tname))
+          [])
+      blocked
+  | _ ->
+    let nests = groups <> [] in
+    let value name type_ =
+      B.psig_value (B.value_description ~name:(B.Located.mk name) ~type_ ~prim:[])
+    in
+    let gen =
+      List.fold_right
+        (fun f acc -> B.ptyp_arrow (Labelled f.fname) (col_ty ~loc f.fty) acc)
+        fields (col_ty ~loc record_ty)
+    in
+    let of_cols =
+      let row =
+        if nests then
+          B.ptyp_constr
+            (B.Located.lident (derived_name ~suffix:"cols" tname))
+            (scope_vars ~loc @ [ row_var ~loc ])
+        else
+          B.ptyp_object
+            (List.filter_map
+               (fun f ->
+                 match f.src with
+                 | Group _ -> None
+                 | Column { col; conv; _ } ->
+                   Some (B.otag col (col_ty ~loc (sraw f conv))))
+               fields)
+            Open
+      in
+      let arg f conv =
+        let lbl =
+          match conv with
+          | { by = false; _ } -> None
+          | { by = true; how = Plain } -> Some (Labelled f.fname)
+          | { by = true; how = Defaulted _ | Mapped _ } -> Some (Optional f.fname)
+        in
+        Option.map (fun l -> l, [%type: [%t sraw f conv] -> [%t f.fty]]) lbl
+      in
+      List.fold_right
+        (fun f acc ->
+          match f.src with
+          | Group _ -> acc
+          | Column { conv; _ } ->
+            Option.fold (arg f conv) ~none:acc ~some:(fun (l, ty) ->
+                B.ptyp_arrow l ty acc))
+        fields
+        [%type: [%t row] -> [%t col_ty ~loc record_ty]]
+    in
+    let apply =
+      let callback =
+        List.fold_right
+          (fun f acc ->
+            match f.src with
+            | Group _ -> acc
+            | Column { col; set; _ } ->
+              B.ptyp_arrow (Labelled col.txt) (Option.value set ~default:f.fty) acc)
+          fields [%type: 'sqlgg__res]
+      in
+      [%type: [%t callback] -> [%t record_ty] -> 'sqlgg__res]
+    in
+    let cols_item =
+      match cols_decl with None -> [] | Some d -> [ B.psig_type Recursive [ d ] ]
+    in
+    cols_item
+    @ value (derived_name ~suffix:"of_cols_gen" tname) gen
+      :: value (derived_name ~suffix:"of_cols" tname) of_cols
+      :: (if nests then [] else [ value (derived_name ~suffix:"apply" tname) apply ])
+
+let dispatch ~loc ~ext ~pick ~record tds =
+  let reject ~loc msg =
+    [ ext ~loc (Location.error_extensionf ~loc "deriving sqlgg: %s" msg) ]
+  in
+
+  let derive ~tname ld lds =
+    let errs = ref [] in
+    let err e = errs := e :: !errs in
+    let first = analyze_field ~err ~pick ld in
+    let rest = List.filter_map (analyze_field ~err ~pick) lds in
+    match List.rev !errs, first with
+    | [], Some first -> record ~loc tname first rest
+    | msgs, _ -> List.concat_map (fun (loc, msg) -> reject ~loc msg) msgs
+  in
+  List.concat_map
+    (fun td ->
+      match td.ptype_params, td.ptype_kind with
+      | _ :: _, _ -> reject ~loc:td.ptype_loc "type parameters are not supported"
+      | [], Ptype_record [] -> reject ~loc:td.ptype_loc "record has no fields"
+      | [], Ptype_record (ld :: lds) -> derive ~tname:td.ptype_name.txt ld lds
+      | [], (Ptype_abstract | Ptype_variant _ | Ptype_open) ->
+        reject ~loc:td.ptype_loc "only record types are supported")
+    tds
 
 let expand ~ctxt (_rec_flag, tds) =
-  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
-  let error msg =
-    [ Ast_builder.Default.pstr_extension ~loc
-        (Location.error_extensionf ~loc "deriving sqlgg: %s" msg)
-        [] ]
-  in
-  let expand_td td =
-    match td.ptype_params with
-    | _ :: _ -> error "type parameters are not supported"
-    | [] ->
-      match td.ptype_kind with
-      | Ptype_record (first :: rest) -> build ~loc td.ptype_name.txt first rest
-      | _ -> error "only record types are supported"
-  in
-  List.concat_map expand_td tds
+  dispatch
+    ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~ext:(fun ~loc e -> D.pstr_extension ~loc e [])
+    ~pick:(function Fn e -> Ok e | Raw _ -> Error "expected a conversion function")
+    ~record:build tds
+
+let expand_sig ~ctxt (_rec_flag, tds) =
+  dispatch
+    ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
+    ~ext:(fun ~loc e -> D.psig_extension ~loc e [])
+    ~pick:
+      (function Raw t -> Ok t | Fn _ -> Error "expected a column type after a colon")
+    ~record:sig_items tds
 
 let () =
   Deriving.add "sqlgg"
-    ~str_type_decl:
-      (Deriving.Generator.V2.make_noarg
-         ~attributes:[ Attribute.T col_attr ]
-         expand)
+    ~str_type_decl:(Deriving.Generator.V2.make_noarg ~attributes expand)
+    ~sig_type_decl:(Deriving.Generator.V2.make_noarg ~attributes expand_sig)
   |> Deriving.ignore

--- a/test/cram/test_build_ppx/dune
+++ b/test/cram/test_build_ppx/dune
@@ -1,0 +1,4 @@
+(cram
+ (deps
+  %{bin:sqlgg}
+  ../print_impl.ml))

--- a/test/cram/test_build_ppx/field_attributes.t/locate.ml
+++ b/test/cram/test_build_ppx/field_attributes.t/locate.ml
@@ -1,0 +1,7 @@
+type row = {
+  id : int64;
+  name : string;
+  count : string; [@sqlgg.map Int64.to_int]
+  tail : int64;
+}
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/field_attributes.t/posts.sql
+++ b/test/cram/test_build_ppx/field_attributes.t/posts.sql
@@ -1,0 +1,22 @@
+CREATE TABLE posts (
+  id INT NOT NULL PRIMARY KEY,
+  body TEXT NULL,
+  reply_count INT NOT NULL,
+  hits INT NULL
+);
+
+-- [sqlgg] dynamic_select=true
+-- @feed
+SELECT id, body, reply_count, hits FROM posts WHERE id > @min_id;
+
+-- [sqlgg] dynamic_select=true
+-- @counts
+SELECT id, reply_count AS n FROM posts WHERE id > @min_id;
+
+-- [sqlgg] dynamic_select=true
+-- @labels
+SELECT id, body AS n FROM posts WHERE id > @min_id;
+
+-- @add_post
+INSERT INTO posts (id, body, reply_count, hits)
+VALUES (@id, @body, @reply_count, @hits);

--- a/test/cram/test_build_ppx/field_attributes.t/reject_seam.ml
+++ b/test/cram/test_build_ppx/field_attributes.t/reject_seam.ml
@@ -1,0 +1,3 @@
+type counted = { id : int64; n : int [@sqlgg.by] } [@@deriving sqlgg]
+
+let no_conversion cols : (counted, _, _, _) Sqlgg_scope.col = counted_of_cols cols

--- a/test/cram/test_build_ppx/field_attributes.t/run.ml
+++ b/test/cram/test_build_ppx/field_attributes.t/run.ml
@@ -1,0 +1,79 @@
+type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
+
+type post = {
+  id : int64;
+  content : content; [@sqlgg.nested]
+  reply_count : int; [@sqlgg.map Int64.to_int] [@sqlgg.set Int64.of_int]
+  hits : int64; [@sqlgg.default 0L] [@sqlgg.set (fun h -> Some h)]
+}
+[@@deriving sqlgg]
+
+type counted = { id : int64; n : int [@sqlgg.by] } [@@deriving sqlgg]
+
+type scaled = { id : int64; n : int [@sqlgg.by] [@sqlgg.map Int64.to_int] }
+[@@deriving sqlgg]
+
+module Db = Posts.Sqlgg(Print_impl)
+
+let run label f =
+  Printf.printf "=== %s ===\n%!" label;
+  Print_impl.clear_mock_responses ();
+  f ();
+  print_newline ()
+
+let rows l =
+  Print_impl.setup_select_response (Stdlib.List.map Print_impl.make_mock_row l)
+
+let print_post (p : post) =
+  Printf.printf "id=%Ld text=%s reply_count=%d hits=%Ld\n" p.id
+    (Option.value p.content.text ~default:"NULL") p.reply_count p.hits
+
+let print_counted (c : counted) = Printf.printf "id=%Ld n=%d\n" c.id c.n
+let print_scaled (c : scaled) = Printf.printf "id=%Ld n=%d\n" c.id c.n
+
+let () =
+  let open Print_impl in
+  let open Db.Feed in
+  run "a post" (fun () ->
+    rows [ [ mock_int 1L; mock_text "hi"; mock_int 7L; mock_null ] ];
+    Stdlib.List.iter print_post (List.select () (post_of_cols cols) ~min_id:0L));
+  run "the same post, columns picked by hand" (fun () ->
+    rows [ [ mock_int 1L; mock_text "hi"; mock_int 7L; mock_null ] ];
+    let col =
+      post_of_cols_gen ~id:cols#id ~content:(content_of_cols cols)
+        ~reply_count:(Sqlgg_scope.map Int64.to_int cols#reply_count)
+        ~hits:(Sqlgg_scope.map (fun h -> Option.value h ~default:(-1L)) cols#hits)
+    in
+    Stdlib.List.iter print_post (List.select () col ~min_id:0L))
+
+let () =
+  let open Print_impl in
+  run "n read as an int64" (fun () ->
+    let open Db.Counts in
+    rows [ [ mock_int 1L; mock_int 9L ] ];
+    Stdlib.List.iter print_counted
+      (List.select () (counted_of_cols ~n:Int64.to_int cols) ~min_id:0L));
+  run "the same record, n read as text" (fun () ->
+    let open Db.Labels in
+    rows [ [ mock_int 1L; mock_text "abcd" ] ];
+    let n s = String.length (Option.value s ~default:"") in
+    Stdlib.List.iter print_counted
+      (List.select () (counted_of_cols ~n cols) ~min_id:0L));
+  run "conversion left to the default" (fun () ->
+    let open Db.Counts in
+    rows [ [ mock_int 1L; mock_int 9L ] ];
+    Stdlib.List.iter print_scaled (List.select () (scaled_of_cols cols) ~min_id:0L));
+  run "conversion passed at the call site" (fun () ->
+    let open Db.Counts in
+    rows [ [ mock_int 1L; mock_int 9L ] ];
+    let n x = Int64.to_int x * 10 in
+    Stdlib.List.iter print_scaled
+      (List.select () (scaled_of_cols ~n cols) ~min_id:0L))
+
+let () =
+  run "inserting a post" (fun () ->
+    Print_impl.setup_execute_response ~affected_rows:1L ();
+    let p : post =
+      { id = 5L; content = { text = Some "hello" }; reply_count = 2; hits = 11L }
+    in
+    ignore (post_apply (Db.add_post ()) p))

--- a/test/cram/test_build_ppx/field_attributes.t/run.t
+++ b/test/cram/test_build_ppx/field_attributes.t/run.t
@@ -1,0 +1,93 @@
+The field attributes against a real query. The one to watch is [@sqlgg.by].
+Its conversion comes from the call site, so one record reads columns of
+different types.
+
+  $ cat posts.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > posts.ml
+  $ cp ../../print_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c posts.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c run.ml
+  $ ocamlfind ocamlc -package unix,sqlgg.traits -I . -linkpkg -o run.exe posts.cmo print_impl.cmo run.cmo
+  $ ./run.exe
+  === a post ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[1]: SELECT id, body, reply_count, hits FROM posts WHERE id > ?
+  [SQL] SELECT id, body, reply_count, hits FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=hi col2=7 col3=NULL 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Text_nullable[1] = Some "hi"
+  [MOCK] get_column_Int[2] = 7
+  [MOCK] get_column_Int_nullable[3] = None
+  id=1 text=hi reply_count=7 hits=0
+  
+  === the same post, columns picked by hand ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[2]: SELECT id, body, reply_count, hits FROM posts WHERE id > ?
+  [SQL] SELECT id, body, reply_count, hits FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=hi col2=7 col3=NULL 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Text_nullable[1] = Some "hi"
+  [MOCK] get_column_Int[2] = 7
+  [MOCK] get_column_Int_nullable[3] = None
+  id=1 text=hi reply_count=7 hits=-1
+  
+  === n read as an int64 ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[3]: SELECT id, reply_count FROM posts WHERE id > ?
+  [SQL] SELECT id, reply_count FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=9 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Int[1] = 9
+  id=1 n=9
+  
+  === the same record, n read as text ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[4]: SELECT id, body FROM posts WHERE id > ?
+  [SQL] SELECT id, body FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=abcd 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Text_nullable[1] = Some "abcd"
+  id=1 n=4
+  
+  === conversion left to the default ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[5]: SELECT id, reply_count FROM posts WHERE id > ?
+  [SQL] SELECT id, reply_count FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=9 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Int[1] = 9
+  id=1 n=9
+  
+  === conversion passed at the call site ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[6]: SELECT id, reply_count FROM posts WHERE id > ?
+  [SQL] SELECT id, reply_count FROM posts WHERE id > 0
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=9 
+  [MOCK] get_column_Int[0] = 1
+  [MOCK] get_column_Int[1] = 9
+  id=1 n=90
+  
+  === inserting a post ===
+  [MOCK EXECUTE] Connection type: [> `WR ]
+  [MOCK] PREPARE[7]: INSERT INTO posts (id, body, reply_count, hits)
+  VALUES (?, ?, ?, ?)
+  [SQL] INSERT INTO posts (id, body, reply_count, hits)
+  VALUES (5, 'hello', 2, 11)
+  [MOCK] Execute result: affected_rows=1, insert_id=None
+  
+
+A bare [@sqlgg.by] cannot be omitted at the call site.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c reject_seam.ml 2> /dev/null || echo rejected
+  rejected
+
+A conversion that does not fit blames its own field, not the whole record.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c locate.ml 2>&1 | head -1
+  File "locate.ml", line 4, characters 2-7:

--- a/test/cram/test_build_ppx/signature.t/feed.ml
+++ b/test/cram/test_build_ppx/signature.t/feed.ml
@@ -1,0 +1,2 @@
+type channel = { channel_id : int64; channel_name : string option }
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/signature.t/feed.mli
+++ b/test/cram/test_build_ppx/signature.t/feed.mli
@@ -1,0 +1,2 @@
+type channel = { channel_id : int64; channel_name : string option }
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/signature.t/m.ml
+++ b/test/cram/test_build_ppx/signature.t/m.ml
@@ -1,0 +1,23 @@
+type product = {
+  id : int64;
+  name : string option; [@sqlgg.col "title"]
+  hits : int64; [@sqlgg.default 0L]
+  n : int; [@sqlgg.by]
+}
+[@@deriving sqlgg]
+
+type counted = {
+  cid : int64;
+  reply_count : int; [@sqlgg.map Int64.to_int]
+  label : string; [@sqlgg.set String.trim]
+}
+[@@deriving sqlgg]
+
+type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
+
+type post = {
+  post_id : int64;
+  content : content; [@sqlgg.nested]
+  channel : Feed.channel; [@sqlgg.nested]
+}
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/signature.t/m.mli
+++ b/test/cram/test_build_ppx/signature.t/m.mli
@@ -1,0 +1,23 @@
+type product = {
+  id : int64;
+  name : string option; [@sqlgg.col "title"]
+  hits : int64; [@sqlgg.default 0L]
+  n : int; [@sqlgg.by]
+}
+[@@deriving sqlgg]
+
+type counted = {
+  cid : int64;
+  reply_count : int; [@sqlgg.map: int64]
+  label : string; [@sqlgg.set: string]
+}
+[@@deriving sqlgg]
+
+type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
+
+type post = {
+  post_id : int64;
+  content : content; [@sqlgg.nested]
+  channel : Feed.channel; [@sqlgg.nested]
+}
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/signature.t/run.t
+++ b/test/cram/test_build_ppx/signature.t/run.t
@@ -1,0 +1,18 @@
+The interface and the implementation are derived separately, so they have to
+agree. The signature is compiled first, the implementation against it.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c feed.mli
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c feed.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c m.mli
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c m.ml
+
+A nested record's columns reach the parent through the derived <t>_cols type.
+The parent never names them, and the child can live in another module.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c use_post.ml
+
+A function says nothing about the column type, so an interface cannot be
+derived from it.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -c wrong.mli 2>&1 | grep -c "sqlgg.map"
+  2

--- a/test/cram/test_build_ppx/signature.t/use_post.ml
+++ b/test/cram/test_build_ppx/signature.t/use_post.ml
@@ -1,0 +1,7 @@
+let read
+    (cols :
+      < post_id : (int64, _, _, _) Sqlgg_scope.col
+      ; body : (string option, _, _, _) Sqlgg_scope.col
+      ; channel_id : (int64, _, _, _) Sqlgg_scope.col
+      ; channel_name : (string option, _, _, _) Sqlgg_scope.col >) =
+  M.post_of_cols cols

--- a/test/cram/test_build_ppx/signature.t/wrong.mli
+++ b/test/cram/test_build_ppx/signature.t/wrong.mli
@@ -1,0 +1,1 @@
+type t = { id : int64; n : int [@sqlgg.map Int64.to_int] } [@@deriving sqlgg]

--- a/test/ppx_expansion/cases.expected.ml
+++ b/test/ppx_expansion/cases.expected.ml
@@ -1,21 +1,51 @@
-type who = {
+type product = {
   id: int64 ;
   name: string option }[@@deriving sqlgg]
 include
   struct
-    let _ = fun (_ : who) -> ()
-    let who_of_cols
+    let _ = fun (_ : product) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) product_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    let product_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~name:(sqlgg__c_name :
+              (string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_name = sqlgg__c_name in
+         ({ id = sqlgg__v_id; name = sqlgg__v_name } : product) : (product,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
+    let _ = product_of_cols_gen
+    let product_of_cols
       (sqlgg__cols :
         <
           id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                 Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
                                           'sqlgg__row, 'sqlgg__params)
                                           Sqlgg_scope.col   ;.. > )
-      : (who, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col=
-      let open Sqlgg_scope in
-        let+ id = sqlgg__cols#id
-        and+ name = sqlgg__cols#name in ({ id; name } : who)
-    let _ = who_of_cols
+      =
+      (product_of_cols_gen ~id:(sqlgg__cols#id) ~name:(sqlgg__cols#name) : 
+      (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+    let _ = product_of_cols
+    let product_apply sqlgg__f (sqlgg__r : product) =
+      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.name)
+    let _ = product_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type renamed = {
   id: int64 ;
@@ -23,6 +53,32 @@ type renamed = {
 include
   struct
     let _ = fun (_ : renamed) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) renamed_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    let renamed_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~productName:(sqlgg__c_productName :
+                     (string option, 'sqlgg__brand, 'sqlgg__row,
+                       'sqlgg__params) Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_productName = sqlgg__c_productName in
+         ({ id = sqlgg__v_id; productName = sqlgg__v_productName } : 
+           renamed) : (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                        Sqlgg_scope.col)
+    let _ = renamed_of_cols_gen
     let renamed_of_cols
       (sqlgg__cols :
         <
@@ -30,26 +86,446 @@ include
                 Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
                                           'sqlgg__row, 'sqlgg__params)
                                           Sqlgg_scope.col   ;.. > )
-      :
-      (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col=
-      let open Sqlgg_scope in
-        let+ id = sqlgg__cols#id
-        and+ productName = sqlgg__cols#name in
-        ({ id; productName } : renamed)
+      =
+      (renamed_of_cols_gen ~id:(sqlgg__cols#id)
+         ~productName:(sqlgg__cols#name) : (renamed, 'sqlgg__brand,
+                                             'sqlgg__row, 'sqlgg__params)
+                                             Sqlgg_scope.col)
     let _ = renamed_of_cols
+    let renamed_apply sqlgg__f (sqlgg__r : renamed) =
+      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.productName)
+    let _ = renamed_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type bad =
+type same_column_twice = {
+  id: int64 ;
+  also_id: int64 [@sqlgg.col "id"]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : same_column_twice) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) same_column_twice_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;id: (int64, 'sqlgg__brand,
+                                                    'sqlgg__row,
+                                                    'sqlgg__params)
+                                                    Sqlgg_scope.col   ;.. > 
+    let same_column_twice_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~also_id:(sqlgg__c_also_id :
+                 (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                   Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_also_id = sqlgg__c_also_id in
+         ({ id = sqlgg__v_id; also_id = sqlgg__v_also_id } : same_column_twice) : 
+      (same_column_twice, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = same_column_twice_of_cols_gen
+    let same_column_twice_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;id: (int64, 'sqlgg__brand, 'sqlgg__row,
+                                        'sqlgg__params) Sqlgg_scope.col   ;..
+          > )
+      =
+      (same_column_twice_of_cols_gen ~id:(sqlgg__cols#id)
+         ~also_id:(sqlgg__cols#id) : (same_column_twice, 'sqlgg__brand,
+                                       'sqlgg__row, 'sqlgg__params)
+                                       Sqlgg_scope.col)
+    let _ = same_column_twice_of_cols
+    let same_column_twice_apply sqlgg__f (sqlgg__r : same_column_twice) =
+      sqlgg__f ~id:(sqlgg__r.id) ~id:(sqlgg__r.also_id)
+    let _ = same_column_twice_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type converted = {
+  id: int64 ;
+  reply_count: int [@sqlgg.map Int64.to_int]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : converted) -> ()
+    let converted_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~reply_count:(sqlgg__c_reply_count :
+                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                       Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
+         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
+           converted) : (converted, 'sqlgg__brand, 'sqlgg__row,
+                          'sqlgg__params) Sqlgg_scope.col)
+    let _ = converted_of_cols_gen
+    let converted_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                 'sqlgg__brand, 'sqlgg__row,
+                                                 'sqlgg__params)
+                                                 Sqlgg_scope.col   ;.. > )
+      =
+      (converted_of_cols_gen ~id:(sqlgg__cols#id)
+         ~reply_count:(Sqlgg_scope.map Int64.to_int sqlgg__cols#reply_count) : 
+      (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+    let _ = converted_of_cols
+    let converted_apply sqlgg__f (sqlgg__r : converted) =
+      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
+    let _ = converted_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type deferred = {
+  id: int64 ;
+  reply_count: int [@sqlgg.by ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : deferred) -> ()
+    let deferred_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~reply_count:(sqlgg__c_reply_count :
+                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                       Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
+         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
+           deferred) : (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                         Sqlgg_scope.col)
+    let _ = deferred_of_cols_gen
+    let deferred_of_cols ~reply_count:sqlgg__conv_reply_count
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                 'sqlgg__brand, 'sqlgg__row,
+                                                 'sqlgg__params)
+                                                 Sqlgg_scope.col   ;.. > )
+      =
+      (deferred_of_cols_gen ~id:(sqlgg__cols#id)
+         ~reply_count:(Sqlgg_scope.map sqlgg__conv_reply_count
+                         sqlgg__cols#reply_count) : (deferred, 'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col)
+    let _ = deferred_of_cols
+    let deferred_apply sqlgg__f (sqlgg__r : deferred) =
+      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
+    let _ = deferred_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type deferred_with_default =
+  {
+  id: int64 ;
+  reply_count: int [@sqlgg.by ][@sqlgg.map Int64.to_int]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : deferred_with_default) -> ()
+    let deferred_with_default_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~reply_count:(sqlgg__c_reply_count :
+                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                       Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
+         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
+           deferred_with_default) : (deferred_with_default, 'sqlgg__brand,
+                                      'sqlgg__row, 'sqlgg__params)
+                                      Sqlgg_scope.col)
+    let _ = deferred_with_default_of_cols_gen
+    let deferred_with_default_of_cols ?reply_count:(sqlgg__conv_reply_count=
+      Int64.to_int)
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                 'sqlgg__brand, 'sqlgg__row,
+                                                 'sqlgg__params)
+                                                 Sqlgg_scope.col   ;.. > )
+      =
+      (deferred_with_default_of_cols_gen ~id:(sqlgg__cols#id)
+         ~reply_count:(Sqlgg_scope.map sqlgg__conv_reply_count
+                         sqlgg__cols#reply_count) : (deferred_with_default,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col)
+    let _ = deferred_with_default_of_cols
+    let deferred_with_default_apply sqlgg__f
+      (sqlgg__r : deferred_with_default) =
+      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
+    let _ = deferred_with_default_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_default = {
+  id: int64 ;
+  hits: int [@sqlgg.default 0]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : with_default) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_default_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;hits: (int option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    let with_default_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~hits:(sqlgg__c_hits :
+              (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_hits = sqlgg__c_hits in
+         ({ id = sqlgg__v_id; hits = sqlgg__v_hits } : with_default) : 
+      (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = with_default_of_cols_gen
+    let with_default_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;hits: (int option, 'sqlgg__brand,
+                                          'sqlgg__row, 'sqlgg__params)
+                                          Sqlgg_scope.col   ;.. > )
+      =
+      (with_default_of_cols_gen ~id:(sqlgg__cols#id)
+         ~hits:(Sqlgg_scope.map (Stdlib.Option.value ~default:0)
+                  sqlgg__cols#hits) : (with_default, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col)
+    let _ = with_default_of_cols
+    let with_default_apply sqlgg__f (sqlgg__r : with_default) =
+      sqlgg__f ~id:(sqlgg__r.id) ~hits:(sqlgg__r.hits)
+    let _ = with_default_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type trimmed = {
+  id: int64 ;
+  name: string [@sqlgg.set String.trim]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : trimmed) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) trimmed_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string, 'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    let trimmed_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~name:(sqlgg__c_name :
+              (string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_name = sqlgg__c_name in
+         ({ id = sqlgg__v_id; name = sqlgg__v_name } : trimmed) : (trimmed,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
+    let _ = trimmed_of_cols_gen
+    let trimmed_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;name: (string, 'sqlgg__brand, 'sqlgg__row,
+                                          'sqlgg__params) Sqlgg_scope.col   ;..
+          > )
+      =
+      (trimmed_of_cols_gen ~id:(sqlgg__cols#id) ~name:(sqlgg__cols#name) : 
+      (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+    let _ = trimmed_of_cols
+    let trimmed_apply sqlgg__f (sqlgg__r : trimmed) =
+      sqlgg__f ~id:(sqlgg__r.id) ~name:(String.trim sqlgg__r.name)
+    let _ = trimmed_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested = {
+  id: int64 ;
+  product: product [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : nested) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) nested_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        product_cols
+    let nested_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~product:(sqlgg__c_product :
+                 (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                   Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_product = sqlgg__c_product in
+         ({ id = sqlgg__v_id; product = sqlgg__v_product } : nested) : 
+      (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+    let _ = nested_of_cols_gen
+    let nested_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (nested_of_cols_gen ~id:(sqlgg__cols#id)
+         ~product:(product_of_cols sqlgg__cols) : (nested, 'sqlgg__brand,
+                                                    'sqlgg__row,
+                                                    'sqlgg__params)
+                                                    Sqlgg_scope.col)
+    let _ = nested_of_cols
+    let nested_apply sqlgg__f (sqlgg__r : nested) =
+      product_apply (sqlgg__f ~id:(sqlgg__r.id)) sqlgg__r.product
+    let _ = nested_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_qualified = {
+  id: int64 ;
+  channel: Feed.channel [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_qualified) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) nested_qualified_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        Feed.channel_cols
+    let nested_qualified_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~channel:(sqlgg__c_channel :
+                 (Feed.channel, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                   Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_channel = sqlgg__c_channel in
+         ({ id = sqlgg__v_id; channel = sqlgg__v_channel } : nested_qualified) : 
+      (nested_qualified, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = nested_qualified_of_cols_gen
+    let nested_qualified_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (nested_qualified_of_cols_gen ~id:(sqlgg__cols#id)
+         ~channel:(Feed.channel_of_cols sqlgg__cols) : (nested_qualified,
+                                                         'sqlgg__brand,
+                                                         'sqlgg__row,
+                                                         'sqlgg__params)
+                                                         Sqlgg_scope.col)
+    let _ = nested_qualified_of_cols
+    let nested_qualified_apply sqlgg__f (sqlgg__r : nested_qualified) =
+      Feed.channel_apply (sqlgg__f ~id:(sqlgg__r.id)) sqlgg__r.channel
+    let _ = nested_qualified_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t = {
+  id: int64 ;
+  label: string [@sqlgg.col "name"]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : t) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols) cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string, 'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    let of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      ~label:(sqlgg__c_label :
+               (string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                 Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+         and+ sqlgg__v_label = sqlgg__c_label in
+         ({ id = sqlgg__v_id; label = sqlgg__v_label } : t) : (t,
+                                                                'sqlgg__brand,
+                                                                'sqlgg__row,
+                                                                'sqlgg__params)
+                                                                Sqlgg_scope.col)
+    let _ = of_cols_gen
+    let of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;name: (string, 'sqlgg__brand, 'sqlgg__row,
+                                          'sqlgg__params) Sqlgg_scope.col   ;..
+          > )
+      =
+      (of_cols_gen ~id:(sqlgg__cols#id) ~label:(sqlgg__cols#name) : (t,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
+    let _ = of_cols
+    let apply sqlgg__f (sqlgg__r : t) =
+      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.label)
+    let _ = apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type variant =
   | A 
   | B [@@deriving sqlgg]
 include
   struct
-    let _ = fun (_ : bad) -> ()
+    let _ = fun (_ : variant) -> ()
     [%%ocaml.error "deriving sqlgg: only record types are supported"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
-type 'a poly = {
+type 'a parameterised = {
   id: 'a }[@@deriving sqlgg]
 include
   struct
-    let _ = fun (_ : 'a poly) -> ()
+    let _ = fun (_ : 'a parameterised) -> ()
     [%%ocaml.error "deriving sqlgg: type parameters are not supported"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/cases.input.ml
+++ b/test/ppx_expansion/cases.input.ml
@@ -1,8 +1,35 @@
-type who = { id : int64; name : string option } [@@deriving sqlgg]
+type product = { id : int64; name : string option } [@@deriving sqlgg]
 
 type renamed = { id : int64; productName : string option [@sqlgg.col "name"] }
 [@@deriving sqlgg]
 
-type bad = A | B [@@deriving sqlgg]
+type same_column_twice = { id : int64; also_id : int64 [@sqlgg.col "id"] }
+[@@deriving sqlgg]
 
-type 'a poly = { id : 'a } [@@deriving sqlgg]
+type converted = { id : int64; reply_count : int [@sqlgg.map Int64.to_int] }
+[@@deriving sqlgg]
+
+type deferred = { id : int64; reply_count : int [@sqlgg.by] } [@@deriving sqlgg]
+
+type deferred_with_default = {
+  id : int64;
+  reply_count : int; [@sqlgg.by] [@sqlgg.map Int64.to_int]
+}
+[@@deriving sqlgg]
+
+type with_default = { id : int64; hits : int [@sqlgg.default 0] }
+[@@deriving sqlgg]
+
+type trimmed = { id : int64; name : string [@sqlgg.set String.trim] }
+[@@deriving sqlgg]
+
+type nested = { id : int64; product : product [@sqlgg.nested] } [@@deriving sqlgg]
+
+type nested_qualified = { id : int64; channel : Feed.channel [@sqlgg.nested] }
+[@@deriving sqlgg]
+
+type t = { id : int64; label : string [@sqlgg.col "name"] } [@@deriving sqlgg]
+
+type variant = A | B [@@deriving sqlgg]
+
+type 'a parameterised = { id : 'a } [@@deriving sqlgg]

--- a/test/ppx_expansion/dune
+++ b/test/ppx_expansion/dune
@@ -16,3 +16,33 @@
  (alias runtest)
  (action
   (diff cases.expected.ml cases.actual.ml)))
+
+(rule
+ (target errors.actual.ml)
+ (deps
+  (:pp pp.exe)
+  (:input errors.input.ml))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./%{pp} --impl %{input}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff errors.expected.ml errors.actual.ml)))
+
+(rule
+ (target sig.actual.mli)
+ (deps
+  (:pp pp.exe)
+  (:input sig.input.mli))
+ (action
+  (with-stdout-to
+   %{target}
+   (run ./%{pp} --intf %{input}))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff sig.expected.mli sig.actual.mli)))

--- a/test/ppx_expansion/errors.expected.ml
+++ b/test/ppx_expansion/errors.expected.ml
@@ -1,0 +1,73 @@
+type product = {
+  id: int64 }[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : product) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) product_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. > 
+    let product_of_cols_gen
+      ~id:(sqlgg__c_id :
+            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col)
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__c_id
+          in ({ id = sqlgg__v_id } : product) : (product, 'sqlgg__brand,
+                                                  'sqlgg__row,
+                                                  'sqlgg__params)
+                                                  Sqlgg_scope.col)
+    let _ = product_of_cols_gen
+    let product_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (product_of_cols_gen ~id:(sqlgg__cols#id) : (product, 'sqlgg__brand,
+                                                    'sqlgg__row,
+                                                    'sqlgg__params)
+                                                    Sqlgg_scope.col)
+    let _ = product_of_cols
+    let product_apply sqlgg__f (sqlgg__r : product) =
+      sqlgg__f ~id:(sqlgg__r.id)
+    let _ = product_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type map_and_default =
+  {
+  stock: int [@sqlgg.map Int64.to_int][@sqlgg.default 0]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : map_and_default) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field stock: [@sqlgg.map] and [@sqlgg.default] cannot be combined"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type default_on_option = {
+  name: string option [@sqlgg.default "unnamed"]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : default_on_option) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field name: [@sqlgg.default] replaces NULL, so the field cannot be an option"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_and_col =
+  {
+  product: product [@sqlgg.nested ][@sqlgg.col "product_id"]}[@@deriving
+                                                               sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_and_col) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field product: [@sqlgg.nested] cannot be combined with [@sqlgg.col]"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_not_a_record = {
+  dimensions: (int64 * int64) [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_not_a_record) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field dimensions: [@sqlgg.nested] needs a record type deriving sqlgg"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/errors.input.ml
+++ b/test/ppx_expansion/errors.input.ml
@@ -1,0 +1,17 @@
+type product = { id : int64 } [@@deriving sqlgg]
+
+type map_and_default = {
+  stock : int; [@sqlgg.map Int64.to_int] [@sqlgg.default 0]
+}
+[@@deriving sqlgg]
+
+type default_on_option = { name : string option [@sqlgg.default "unnamed"] }
+[@@deriving sqlgg]
+
+type nested_and_col = {
+  product : product; [@sqlgg.nested] [@sqlgg.col "product_id"]
+}
+[@@deriving sqlgg]
+
+type nested_not_a_record = { dimensions : int64 * int64 [@sqlgg.nested] }
+[@@deriving sqlgg]

--- a/test/ppx_expansion/sig.expected.mli
+++ b/test/ppx_expansion/sig.expected.mli
@@ -1,0 +1,253 @@
+type product = {
+  id: int64 ;
+  name: string option }[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) product_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    val product_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        name:(string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val product_of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col   ;.. > 
+        ->
+        (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+    val product_apply :
+      (id:int64 -> name:string option -> 'sqlgg__res) ->
+        product -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type renamed = {
+  id: int64 ;
+  productName: string option [@sqlgg.col "name"]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) renamed_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    val renamed_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        productName:(string option, 'sqlgg__brand, 'sqlgg__row,
+          'sqlgg__params) Sqlgg_scope.col ->
+          (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val renamed_of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col   ;.. > 
+        ->
+        (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+    val renamed_apply :
+      (id:int64 -> name:string option -> 'sqlgg__res) ->
+        renamed -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_default = {
+  id: int64 ;
+  hits: int [@sqlgg.default 0]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_default_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;hits: (int option,
+                                                      'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    val with_default_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        hits:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val with_default_of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;hits: (int option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col   ;.. > 
+        ->
+        (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+    val with_default_apply :
+      (id:int64 -> hits:int -> 'sqlgg__res) -> with_default -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type deferred = {
+  id: int64 ;
+  reply_count: int [@sqlgg.by ]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    val deferred_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        reply_count:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val deferred_of_cols :
+      reply_count:('sqlgg__raw_reply_count -> int) ->
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                 'sqlgg__brand, 'sqlgg__row,
+                                                 'sqlgg__params)
+                                                 Sqlgg_scope.col   ;.. > 
+          ->
+          (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val deferred_apply :
+      (id:int64 -> reply_count:int -> 'sqlgg__res) -> deferred -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type t = {
+  id: int64 }[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols) cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. > 
+    val of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        -> (t, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+    val of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col   ;.. > 
+        -> (t, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+    val apply : (id:int64 -> 'sqlgg__res) -> t -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type converted = {
+  id: int64 ;
+  reply_count: int [@sqlgg.map : int64]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    val converted_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        reply_count:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val converted_of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;reply_count: (int64, 'sqlgg__brand,
+                                               'sqlgg__row, 'sqlgg__params)
+                                               Sqlgg_scope.col   ;.. > 
+        ->
+        (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+    val converted_apply :
+      (id:int64 -> reply_count:int -> 'sqlgg__res) ->
+        converted -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type trimmed = {
+  id: int64 ;
+  name: string [@sqlgg.set : string]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) trimmed_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;name: (string, 'sqlgg__brand,
+                                                      'sqlgg__row,
+                                                      'sqlgg__params)
+                                                      Sqlgg_scope.col   ;..
+                      > 
+    val trimmed_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        name:(string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val trimmed_of_cols :
+      <
+        id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;name: (string, 'sqlgg__brand, 'sqlgg__row,
+                                        'sqlgg__params) Sqlgg_scope.col   ;..
+        >  ->
+        (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+    val trimmed_apply :
+      (id:int64 -> name:string -> 'sqlgg__res) -> trimmed -> 'sqlgg__res
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type map_without_a_type = {
+  id: int64 ;
+  n: int [@sqlgg.map Int64.to_int]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    [%%ocaml.error
+      "deriving sqlgg: field n: [@sqlgg.map]: expected a column type after a colon"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested = {
+  id: int64 ;
+  product: product [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) nested_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        product_cols
+    val nested_of_cols_gen :
+      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+        ->
+        product:(product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col ->
+          (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+            Sqlgg_scope.col
+    val nested_of_cols :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols) nested_cols
+        ->
+        (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/sig.input.mli
+++ b/test/ppx_expansion/sig.input.mli
@@ -1,0 +1,23 @@
+type product = { id : int64; name : string option } [@@deriving sqlgg]
+
+type renamed = { id : int64; productName : string option [@sqlgg.col "name"] }
+[@@deriving sqlgg]
+
+type with_default = { id : int64; hits : int [@sqlgg.default 0] }
+[@@deriving sqlgg]
+
+type deferred = { id : int64; reply_count : int [@sqlgg.by] } [@@deriving sqlgg]
+
+type t = { id : int64 } [@@deriving sqlgg]
+
+type converted = { id : int64; reply_count : int [@sqlgg.map: int64] }
+[@@deriving sqlgg]
+
+type trimmed = { id : int64; name : string [@sqlgg.set: string] }
+[@@deriving sqlgg]
+
+type map_without_a_type = { id : int64; n : int [@sqlgg.map Int64.to_int] }
+[@@deriving sqlgg]
+
+type nested = { id : int64; product : product [@sqlgg.nested] }
+[@@deriving sqlgg]


### PR DESCRIPTION
##### `[@sqlgg.col]` 

Read the field from a differently named column

```ocaml
type post = { id : int64; text : string option [@sqlgg.col "body"] }
[@@deriving sqlgg]

val post_of_cols : < id : int64 col; body : string option col; .. > -> post col
```

##### `[@sqlgg.map]`

Convert the column value. The record fixes the conversion

```ocaml
type post = { id : int64; reply_count : int [@sqlgg.map Int64.to_int] }
[@@deriving sqlgg]

val post_of_cols : < id : int64 col; reply_count : int64 col; .. > -> post col
```

##### `[@sqlgg.default]`

A default for NULLable column

```ocaml
type post = { id : int64; hits : int64 [@sqlgg.default 0L] } [@@deriving sqlgg]

val post_of_cols : < id : int64 col; hits : int64 option col; .. > -> post col
```

##### `[@sqlgg.by]`

The call site supplies the conversion, so one record fits columns of different types

```ocaml
type counted = { id : int64; n : int [@sqlgg.by] } [@@deriving sqlgg]

val counted_of_cols :
  n:('raw -> int) -> < id : int64 col; n : 'raw col; .. > -> counted col

let from_number = Q_num.(counted_of_cols ~n:Int64.to_int cols)
let from_text   = Q_txt.(counted_of_cols ~n:String.length cols)
```

##### `[@sqlgg.nested]`

A field that is itself a derived record, read from the same cols

```ocaml
type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
type post = { id : int64; content : content [@sqlgg.nested] } [@@deriving sqlgg]

val post_of_cols : < id : int64 col; body : string option col; .. > -> post col
```