### PR TITLE
Extend ppx `nested` to nullable joins

### DIFF
--- a/doc/ocaml/ppx.md
+++ b/doc/ocaml/ppx.md
@@ -169,22 +169,6 @@ let with_warehouse db =
 
 Drop `warehouse` from the chain and the join to `stock_info` is [eliminated](../sql/dynamic-select.md#unused-join-elimination), nothing reads from it anymore.
 
-## What Gets Derived
-
-One function per record:
-
-```ocaml
-type product = { id : int64; name : string option } [@@deriving sqlgg]
-```
-
-```ocaml
-val product_of_cols :
-  < id : int64 col; name : string option col; .. > -> product col
-```
-
-It reads the record off a query's `cols`. A type named `t` drops the prefix and
-gives plain `of_cols`.
-
 ## Per-Field Attributes
 
 An attribute on a field changes where its value comes from, or what happens to
@@ -282,18 +266,137 @@ type post = {
 [@@deriving sqlgg]
 ```
 
-The derived chain calls `content_of_cols cols`, so the two records compose the
-same way a hand-written [composition](#composition) would. The nested record's
-columns do not appear in the outer object type — the inner call adds them:
+The reader calls the inner one on the same object:
 
 ```ocaml
-val post_of_cols :
-  < id : int64 col; body : string option col; reply_count : int64 col; .. > -> post col
+let post_of_cols cols =
+  let+ id = cols#id
+  and+ content = content_of_cols cols
+  and+ reply_count = cols#reply_count in
+  { id; content; reply_count = Int64.to_int reply_count }
 ```
 
-Since only the fields a record mentions reach the `SELECT` list, dropping a
-nested field drops its columns and any [join](../sql/dynamic-select.md#unused-join-elimination)
-that existed only to serve them.
+So the query must supply `content`'s columns too. The row type says that with a
+second constraint. It does not name those columns.
 
-A record from another module works too. `channel : Feed.channel [@sqlgg.nested]`
-calls `Feed.channel_of_cols`.
+```ocaml
+type (..., 'cols) post_cols = 'cols
+  constraint 'cols = < id : int64 col; reply_count : int64 col; .. >
+  constraint 'cols = (..., 'cols) content_cols
+
+val post_of_cols : (..., 'cols) post_cols -> post col
+```
+
+Nest one more record and you get one more constraint. A record from another
+module works the same way: `channel : Feed.channel [@sqlgg.nested]` calls
+`Feed.channel_of_cols`.
+
+#### Over an outer join
+
+Columns from the right side of an outer join arrive as options, so a record read
+straight off one gets an option per column:
+
+```sql
+-- [sqlgg] dynamic_select=true
+-- @q4
+SELECT p.id, p.name, s.product_id, s.place, s.warehouse
+FROM products p
+LEFT JOIN stock_info s ON s.product_id = p.id
+WHERE p.id = @id;
+```
+
+Make the field an option and the attribute puts the option on the relation
+instead:
+
+```ocaml
+type stock = { product_id : int64; place : string; warehouse : string option }
+[@@deriving sqlgg ~nullable_cols]
+
+type product = {
+  id : int64;
+  name : string option;
+  stock : stock option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+let with_stock db = Q4.(select db (product_of_cols cols) ~id:1L)
+```
+
+The field's type picks the reading:
+
+```ocaml
+stock : stock          [@sqlgg.nested]   (* columns as declared *)
+stock : stock option   [@sqlgg.nested]   (* columns from an outer join *)
+```
+
+Pick the wrong one and it does not typecheck against that query.
+
+#### Present, absent, and neither
+
+A **strict** field is one that is not an option and has no
+[`[@sqlgg.default]`](#sqlggdefault-v). `[@sqlgg.nested]` reads the relation like
+this:
+
+```ocaml
+match product_id, place, warehouse with
+| Some product_id, Some place, _ -> Some { product_id; place; warehouse }
+| None, None, None -> None
+| None, _, _ -> failwith "sqlgg: stock.product_id is NULL"
+| _, None, _ -> failwith "sqlgg: stock.place is NULL"
+```
+
+A missing match nulls every column at once, so the failing arms are not a
+missing match. `default_none` gives `None` there instead:
+
+```ocaml
+Option.bind product_id (fun product_id ->
+  Option.bind place (fun place -> Some { product_id; place; warehouse }))
+```
+
+Optional and defaulted fields never raise. Conversions run only once the
+relation is there.
+
+#### `~nullable_cols`
+
+The two functions above are not derived by default. Ask for them:
+
+```ocaml
+type stock = { product_id : int64; place : string; warehouse : string option }
+[@@deriving sqlgg ~nullable_cols]
+```
+
+```ocaml
+type (..., 'cols) stock_nullable_cols
+
+val stock_of_nullable_cols     : (..., 'cols) stock_nullable_cols -> stock option col
+val stock_of_nullable_cols_exn : (..., 'cols) stock_nullable_cols -> stock option col
+```
+
+`[@sqlgg.nested]` calls the second, `default_none` the first. You can also call
+them yourself, which is the way to read a relation without inventing a record
+for it:
+
+```ocaml
+let product_and_stock cols =
+  let+ p = product_of_cols cols
+  and+ s = stock_of_nullable_cols_exn cols in
+  (p, s)
+```
+
+```ocaml
+val product_and_stock : < ... > -> (product * stock option) col
+```
+
+A tuple, and the folding still happens. Adding a `stock option` field to
+`product` would have changed every place that reads a product.
+
+Put the flag on the **inner** record. A record cannot see who will nest it. The
+deriver gets one type declaration at a time, so `stock` is expanded before the
+compiler reaches `product`. Forget the flag and the error points at the nesting:
+
+```
+Error: Unbound type constructor "stock_nullable_cols"
+```
+
+A record read as a relation reads its own nested fields the same way, so they
+need the flag too.

--- a/doc/sql/nullability.md
+++ b/doc/sql/nullability.md
@@ -61,6 +61,10 @@ LEFT JOIN profiles p ON u.id = p.user_id;
 -- p.bio: nullable (even if column is NOT NULL)
 ```
 
+The whole right side is nullable together: the row either matched or it did not.
+In OCaml, [`[@sqlgg.nested]`](../ocaml/ppx.md#sqlggjoined) folds that
+back into a single option on the joined record, instead of one per column.
+
 ### RIGHT JOIN
 
 Left side becomes nullable:

--- a/impl/ocaml/ppx/ppx_sqlgg.ml
+++ b/impl/ocaml/ppx/ppx_sqlgg.ml
@@ -1,21 +1,37 @@
 open Ppxlib
 module D = Ast_builder.Default
 
-let derived_name ~suffix = Expansion_helpers.mangle (Suffix suffix)
+let error ~loc fmt =
+  Printf.ksprintf (fun msg -> Location.Error.createf ~loc "deriving sqlgg: %s" msg) fmt
 
-let derived_lid ~suffix lid =
-  Loc.map lid ~f:(Expansion_helpers.mangle_lid (Suffix suffix))
+type reader =
+  | Read_direct
+  | Read_nullable
+  | Read_nullable_exn
+
+let nullable_row = function
+  | Read_direct -> false
+  | Read_nullable | Read_nullable_exn -> true
+
+type suffix =
+  | Cols of { is_nullable : bool }
+  | Read of reader
+
+let string_of_suffix = function
+  | Cols { is_nullable = false } -> "cols"
+  | Cols { is_nullable = true } -> "nullable_cols"
+  | Read Read_direct -> "of_cols"
+  | Read Read_nullable -> "of_nullable_cols"
+  | Read Read_nullable_exn -> "of_nullable_cols_exn"
+
+let derived_name suffix = Expansion_helpers.mangle (Suffix (string_of_suffix suffix))
+
+let derived_lid suffix lid =
+  Loc.map lid ~f:(Expansion_helpers.mangle_lid (Suffix (string_of_suffix suffix)))
 
 let cols_arg = "sqlgg__cols"
-let fn_arg = "sqlgg__f"
-let rec_arg = "sqlgg__r"
-let col_arg = Printf.sprintf "sqlgg__c_%s"
 let val_arg = Printf.sprintf "sqlgg__v_%s"
 let conv_arg = Printf.sprintf "sqlgg__conv_%s"
-
-type spec =
-  | Fn of expression
-  | Raw of core_type
 
 let ctx = Attribute.Context.label_declaration
 
@@ -23,455 +39,572 @@ let located name pat =
   Attribute.declare_with_attr_loc name ctx pat (fun ~attr_loc x ->
       Loc.make ~loc:attr_loc x)
 
-let spec_attr name =
-  located name
-    Ast_pattern.(
-      map1 (single_expr_payload __) ~f:(fun e -> Fn e)
-      ||| map1 (ptyp __) ~f:(fun t -> Raw t))
-
 let col_attr = located "sqlgg.col" Ast_pattern.(single_expr_payload (estring __))
-let map_attr = spec_attr "sqlgg.map"
-let set_attr = spec_attr "sqlgg.set"
+
+let map_attr =
+  located "sqlgg.map"
+    Ast_pattern.(
+      map1 (single_expr_payload __) ~f:(fun e -> Either.Left e)
+      ||| map1 (ptyp __) ~f:(fun t -> Either.Right t))
 let default_attr = located "sqlgg.default" Ast_pattern.(single_expr_payload __)
 let by_attr = Attribute.declare_flag "sqlgg.by" ctx
-let nested_attr = Attribute.declare_flag "sqlgg.nested" ctx
+
+let nested_attr =
+  Attribute.declare "sqlgg.nested" ctx
+    Ast_pattern.(
+      map0 (pstr nil) ~f:false
+      ||| map0
+            (single_expr_payload (pexp_ident (lident (string "default_none"))))
+            ~f:true)
+    (fun x -> x)
 
 let attributes =
-  [ Attribute.T col_attr; Attribute.T map_attr; Attribute.T set_attr
-  ; Attribute.T default_attr; Attribute.T by_attr; Attribute.T nested_attr ]
+  [ Attribute.T col_attr
+  ; Attribute.T map_attr
+  ; Attribute.T default_attr
+  ; Attribute.T by_attr
+  ; Attribute.T nested_attr
+  ]
 
 type 'a how =
   | Plain
   | Defaulted of expression
   | Mapped of 'a
 
-type 'a conv = { by : bool; how : 'a how }
+type 'a conv =
+  { by : bool
+  ; is_nullable : bool
+  ; how : 'a how
+  }
+
+type nesting =
+  | Nested
+  | Joined_opt
+  | Joined_default_none
+
+type 'a column =
+  { col : string loc
+  ; conv : 'a conv
+  ; fty : core_type
+  }
+
+type sub_ref =
+  { nesting : nesting
+  ; lid : longident loc
+  }
 
 type 'a source =
-  | Column of { col : string loc; conv : 'a conv; set : 'a option }
-  | Group of longident loc
+  | Column of 'a column
+  | Sub of sub_ref
 
-type 'a field =
+type 'src fld =
   { fname : string
   ; floc : location
-  ; fty : core_type
-  ; src : 'a source
+  ; src : 'src
   }
 
-type binder =
-  | Anon
-  | Named of string
-  | Named_opt of string * expression
+let columns fields =
+  List.filter_map
+    (fun f -> match f.src with Column c -> Some { f with src = c } | Sub _ -> None)
+    fields
 
-type param =
-  { pkind : binder
-  ; ppat : pattern
-  ; ploc : location
-  }
-
-let efun params body =
-  List.fold_right
-    (fun { pkind; ppat; ploc = loc } acc ->
-      let lbl, def =
-        match pkind with
-        | Anon -> Nolabel, None
-        | Named n -> Labelled n, None
-        | Named_opt (n, d) -> Optional n, Some d
-      in
-      D.pexp_fun ~loc lbl def ppat acc)
-    params body
+let subs fields =
+  List.filter_map
+    (fun f -> match f.src with Sub s -> Some { f with src = s } | Column _ -> None)
+    fields
 
 let col_ty ~loc t =
   [%type: ([%t t], 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col]
 
-let scope_vars ~loc =
-  [ [%type: 'sqlgg__brand]; [%type: 'sqlgg__row]; [%type: 'sqlgg__params] ]
+let cols_var ~loc = [%type: 'sqlgg__cols]
 
-let row_var ~loc = [%type: 'sqlgg__cols]
-
-let record_ty ~loc tname = D.ptyp_constr ~loc (Loc.make ~loc (Lident tname)) []
+let cols_params ~loc =
+  [ [%type: 'sqlgg__brand]
+  ; [%type: 'sqlgg__row]
+  ; [%type: 'sqlgg__params]
+  ; cols_var ~loc
+  ]
+let record_ty ~loc tname = D.ptyp_constr ~loc (D.Located.lident ~loc tname) []
 let opaque f = D.ptyp_var ~loc:f.floc (Printf.sprintf "sqlgg__raw_%s" f.fname)
-
-let intrinsic ~loc f = function
-  | { by = false; how = Plain } -> Some f.fty
-  | { by = false; how = Defaulted _ } -> Some [%type: [%t f.fty] option]
-  | { by = true; _ } | { how = Mapped _; _ } -> None
 let fill_default ~loc e = [%expr Stdlib.Option.value ~default:[%e e]]
 
-let analyze_field ~err ~pick ld =
-  let loc = ld.pld_loc in
-  let is_option ty =
-    match ty.ptyp_desc with
-    | Ptyp_constr ({ txt = Lident "option" | Ldot (_, "option"); _ }, [ _ ]) -> true
-    | _ -> false
+let match_ pat (ty : core_type) =
+  Ast_pattern.parse_res pat ty.ptyp_loc ty (fun r -> r) |> Result.to_option
+
+let option_arg =
+  match_
+    Ast_pattern.(
+      ptyp_constr
+        (lident (string "option") ||| ldot (lident (string "Stdlib")) (string "option"))
+        (__ ^:: nil))
+
+type presence =
+  | Witnesses
+  | Votes
+  | Silent
+
+let conv_presence { by; is_nullable; how } =
+  match how, is_nullable, by with
+  | Defaulted _, _, _ -> Votes
+  | (Plain | Mapped _), false, _ -> Witnesses
+  | Plain, true, false -> Votes
+  | Plain, true, true -> Silent
+  | Mapped _, true, _ -> Silent
+
+let presence f =
+  match f.src with
+  | Sub { nesting = Nested; _ } -> Witnesses
+  | Sub { nesting = Joined_opt | Joined_default_none; _ } -> Votes
+  | Column c -> conv_presence c.conv
+
+type 'a raw_kind =
+  | As_is
+  | Optional
+  | Opaque of 'a option
+
+let raw_kind { by; how; _ } =
+  match how, by with
+  | Plain, false -> As_is
+  | Defaulted _, _ -> Optional
+  | Plain, true -> Opaque None
+  | Mapped conv, _ -> Opaque (Some conv)
+
+let raw_ty ~loc ~converted f c =
+  match raw_kind c with
+  | As_is -> f.src.fty
+  | Optional -> [%type: [%t f.src.fty] option]
+  | Opaque x -> converted f x
+
+let impl_raw ~loc = raw_ty ~loc ~converted:(fun f _ -> opaque f)
+let sig_raw ~loc = raw_ty ~loc ~converted:(fun f t -> Option.value t ~default:(opaque f))
+
+let cols_obj ~loc ~is_nullable ~raw cols =
+  D.ptyp_object ~loc
+    (List.map
+       (fun c ->
+         let loc = c.src.col.loc in
+         let t = raw ~loc c c.src.conv in
+         let t =
+           match is_nullable, conv_presence c.src.conv with
+           | false, _ | true, (Votes | Silent) -> t
+           | true, Witnesses -> [%type: [%t t] option]
+         in
+         D.otag ~loc c.src.col (col_ty ~loc t))
+       cols)
+    Open
+
+let by_cols cols = List.filter (fun c -> c.src.conv.by) cols
+
+let by_label c =
+  match c.src.conv.how with
+  | Plain -> Labelled c.fname
+  | Mapped _ | Defaulted _ -> Optional c.fname
+
+let by_default ~loc = function
+  | Plain -> None
+  | Mapped conv -> Some conv
+  | Defaulted e -> Some (fill_default ~loc e)
+
+let child_reader rd nesting =
+  match rd, nesting with
+  | Read_direct, Nested -> Read_direct
+  | Read_nullable, _ -> Read_nullable
+  | _, Joined_opt -> Read_nullable_exn
+  | _, (Nested | Joined_default_none) -> Read_nullable
+
+type 'a witness =
+  { strict : 'a source fld list
+  ; extra : 'a source fld list
+  }
+
+let witness fields =
+  let strict, extra =
+    List.fold_right
+      (fun f (strict, extra) ->
+        match presence f with
+        | Witnesses -> f :: strict, extra
+        | Votes -> strict, f :: extra
+        | Silent -> strict, extra)
+      fields ([], [])
   in
-  let nullary_constr ty =
-    match ty.ptyp_desc with Ptyp_constr (lid, []) -> Some lid | _ -> None
-  in
-  let errf ~loc fmt =
+  match strict with
+  | [] -> None
+  | _ -> Some { strict; extra }
+
+let resolve_field ~pick_spec ld =
+  let ferr ~loc fmt =
     Printf.ksprintf
-      (fun msg -> err (loc, Printf.sprintf "field %s: %s" ld.pld_name.txt msg))
+      (fun m -> Error (error ~loc "field %s: %s" ld.pld_name.txt m))
       fmt
-  in
-  let picked name { txt; loc } =
-    match pick txt with
-    | Ok x -> Some x
-    | Error why ->
-      errf ~loc "%s: %s" name why;
-      None
   in
   let col = Attribute.get col_attr ld in
   let map = Attribute.get map_attr ld in
   let default = Attribute.get default_attr ld in
-  let set_attr_value = Attribute.get set_attr ld in
   let by = Attribute.has_flag by_attr ld in
-  let how =
-    match map, default with
-    | Some _, Some { loc; _ } ->
-      errf ~loc "[@sqlgg.map] and [@sqlgg.default] cannot be combined";
-      Some Plain
-    | Some m, None -> Option.map (fun x -> Mapped x) (picked "[@sqlgg.map]" m)
-    | None, Some { txt; loc } ->
-      if is_option ld.pld_type then
-        errf ~loc "[@sqlgg.default] replaces NULL, so the field cannot be an option";
-      Some (Defaulted txt)
-    | None, None -> Some Plain
+  let opt_ty = option_arg ld.pld_type in
+  let is_nullable = Option.is_some opt_ty in
+  let column how =
+    Column
+      { col = Option.value col ~default:ld.pld_name
+      ; conv = { by; is_nullable; how }
+      ; fty = ld.pld_type
+      }
   in
-  let set =
-    match set_attr_value with
-    | None -> Some None
-    | Some s -> Option.map Option.some (picked "[@sqlgg.set]" s)
-  in
-  let used =
-    List.filter_map
-      (fun (name, present) -> if present then Some name else None)
-      [ "[@sqlgg.col]", Option.is_some col
-      ; "[@sqlgg.map]", Option.is_some map
-      ; "[@sqlgg.default]", Option.is_some default
-      ; "[@sqlgg.set]", Option.is_some set_attr_value
-      ; "[@sqlgg.by]", by ]
-  in
-  match how, set with
-  | None, _ | _, None -> None
-  | Some how, Some set ->
-    let column () =
-      Column { col = Option.value col ~default:ld.pld_name; conv = { by; how }; set }
+  let nested nesting ty =
+    let clash =
+      List.filter_map
+        (fun (name, present) -> if present then Some name else None)
+        [ "[@sqlgg.col]", Option.is_some col
+        ; "[@sqlgg.map]", Option.is_some map
+        ; "[@sqlgg.default]", Option.is_some default
+        ; "[@sqlgg.by]", by
+        ]
     in
-    let src =
-      match Attribute.has_flag nested_attr ld, used, nullary_constr ld.pld_type with
-      | false, _, _ -> column ()
-      | true, (_ :: _ as names), _ ->
-        errf ~loc "[@sqlgg.nested] cannot be combined with %s"
-          (String.concat ", " names);
-        column ()
-      | true, [], Some lid -> Group lid
-      | true, [], None ->
-        errf ~loc "[@sqlgg.nested] needs a record type deriving sqlgg";
-        column ()
-    in
-    Some { fname = ld.pld_name.txt; floc = loc; fty = ld.pld_type; src }
-
-let cols_type ~loc tname fields =
-  let (module B) = Ast_builder.make loc in
-  let row = row_var ~loc in
-  let vars = scope_vars ~loc @ [ row ] in
-  let meth f conv = Option.map (col_ty ~loc) (intrinsic ~loc f conv) in
-  let step f acc =
-    Option.bind acc (fun (meths, cstrs) ->
-        match f.src with
-        | Group lid ->
-          Some
-            ( meths
-            , (row, B.ptyp_constr (derived_lid ~suffix:"cols" lid) vars, loc) :: cstrs )
-        | Column { col; conv; _ } ->
-          Option.map (fun t -> B.otag col t :: meths, cstrs) (meth f conv))
+    match clash, match_ Ast_pattern.(ptyp_constr __' nil) ty with
+    | (_ :: _ as names), _ ->
+      ferr ~loc:ld.pld_loc "[@sqlgg.nested] cannot be combined with %s"
+        (String.concat ", " names)
+    | [], Some lid -> Ok (Sub { nesting; lid })
+    | [], None ->
+      ferr ~loc:ld.pld_loc "[@sqlgg.nested] needs a record type deriving sqlgg"
   in
-  List.fold_right step fields (Some ([], []))
-  |> Option.map (fun (meths, cstrs) ->
-         B.type_declaration
-           ~name:(B.Located.mk (derived_name ~suffix:"cols" tname))
-           ~params:(List.map (fun v -> v, (NoVariance, NoInjectivity)) vars)
-           ~cstrs:((row, B.ptyp_object meths Open, loc) :: cstrs)
-           ~kind:Ptype_abstract ~private_:Public ~manifest:(Some row))
+  let source =
+    let default_none = Attribute.get nested_attr ld in
+    match default_none, opt_ty with
+    | Some false, None -> nested Nested ld.pld_type
+    | Some false, Some inner -> nested Joined_opt inner
+    | Some true, Some inner -> nested Joined_default_none inner
+    | Some true, None ->
+      ferr ~loc:ld.pld_loc "[@sqlgg.nested default_none] needs an option field"
+    | None, _ ->
+      match map, default with
+      | Some _, Some { loc; _ } ->
+        ferr ~loc "[@sqlgg.map] and [@sqlgg.default] cannot be combined"
+      | Some m, None ->
+        pick_spec m.txt
+        |> Result.map_error (fun why ->
+               error ~loc:m.loc "field %s: [@sqlgg.map]: %s" ld.pld_name.txt why)
+        |> Result.map (fun conv -> column (Mapped conv))
+      | None, Some { txt; loc } ->
+        if is_nullable then
+          ferr ~loc "[@sqlgg.default] replaces NULL, so the field cannot be an option"
+        else Ok (column (Defaulted txt))
+      | None, None -> Ok (column Plain)
+  in
+  Result.map
+    (fun src -> { fname = ld.pld_name.txt; floc = ld.pld_loc; src })
+    source
 
-let build ~loc tname first rest =
-  let fields = first :: rest in
-  let (module B) = Ast_builder.make loc in
+let cols_decls ~loc ~nullable tname subs cols =
+  let open (val Ast_builder.make loc) in
+  let cols_ty = cols_var ~loc in
+  let vars = cols_params ~loc in
+  let decl rd =
+    type_declaration
+      ~name:(Loc.make ~loc (derived_name (Cols { is_nullable = nullable_row rd }) tname))
+      ~params:(List.map (fun v -> v, (NoVariance, NoInjectivity)) vars)
+      ~cstrs:
+        ((cols_ty, cols_obj ~loc ~is_nullable:(nullable_row rd) ~raw:impl_raw cols, loc)
+        :: List.map
+             (fun { src = { nesting; lid }; _ } ->
+               ( cols_ty
+               , ptyp_constr
+                   (derived_lid
+                      (Cols { is_nullable = nullable_row (child_reader rd nesting) })
+                      lid)
+                   vars
+               , loc ))
+             subs)
+      ~kind:Ptype_abstract ~private_:Public ~manifest:(Some cols_ty)
+  in
+  let nameable c =
+    match c.src.conv.by, c.src.conv.how with true, Plain -> false | _ -> true
+  in
+  match List.for_all nameable cols, nullable with
+  | false, _ -> []
+  | true, false -> [ decl Read_direct ]
+  | true, true -> [ decl Read_direct; decl Read_nullable_exn ]
+
+type 'a resolved =
+  { loc : location
+  ; tname : string
+  ; first : 'a source fld
+  ; rest : 'a source fld list
+  ; fields : 'a source fld list
+  ; cols : 'a column fld list
+  ; subs : sub_ref fld list
+  ; witness : 'a witness option
+  ; decls : type_declaration list
+  }
+
+let build { loc; tname; first; rest; fields; cols; witness; decls; _ } =
+  let open (val Ast_builder.make loc) in
   let record_ty = record_ty ~loc tname in
-  let item ~suffix body =
-    [%stri let [%p B.pvar (derived_name ~suffix tname)] = [%e body]]
-  in
-
-  let gen_item =
+  let item suffix body = [%stri let [%p pvar (derived_name suffix tname)] = [%e body]] in
+  let scoped ~exp ~body =
     let bind op f =
-      let loc = f.floc in
-      let (module B) = Ast_builder.make loc in
-      B.binding_op ~op:(B.Located.mk op)
-        ~pat:(B.pvar (val_arg f.fname))
-        ~exp:(B.evar (col_arg f.fname))
-    in
-    let record =
-      B.pexp_record
-        (List.map (fun f -> B.Located.lident f.fname, B.evar (val_arg f.fname)) fields)
-        None
+      D.binding_op ~loc:f.floc
+        ~op:(Loc.make ~loc:f.floc op)
+        ~pat:(D.pvar ~loc:f.floc (val_arg f.fname))
+        ~exp:(exp f)
     in
     let letop =
-      B.pexp_letop
-        (B.letop ~let_:(bind "let+" first) ~ands:(List.map (bind "and+") rest)
-           ~body:[%expr ([%e record] : [%t record_ty])])
+      pexp_letop
+        (letop ~let_:(bind "let+" first) ~ands:(List.map (bind "and+") rest) ~body)
     in
-    let params =
-      List.map
-        (fun f ->
-          let loc = f.floc in
-          let (module B) = Ast_builder.make loc in
-          { pkind = Named f.fname
-          ; ppat = [%pat? ([%p B.pvar (col_arg f.fname)] : [%t col_ty ~loc f.fty])]
-          ; ploc = loc
-          })
-        fields
-    in
-    item ~suffix:"of_cols_gen"
-      (efun params
-         [%expr
-           ((let open Sqlgg_scope in
-             [%e letop])
-             : [%t col_ty ~loc record_ty])])
+    [%expr
+      let open Sqlgg_scope in
+      [%e letop]]
   in
-
-  let of_cols_item =
-    let column f col ({ by; how } as conv) =
-      let loc = col.loc in
-      let (module B) = Ast_builder.make loc in
-      let get = B.pexp_send (B.evar cols_arg) col in
-      let via e = [%expr Sqlgg_scope.map [%e e] [%e get]] in
-      let read =
-        match by, how with
-        | false, Plain -> get
-        | false, Defaulted e -> via (fill_default ~loc e)
-        | false, Mapped g -> via g
-        | true, _ -> via (B.evar (conv_arg f.fname))
-      in
-      let ty = Option.value (intrinsic ~loc f conv) ~default:(opaque f) in
-      Some (B.otag col (col_ty ~loc ty)), read
-    in
-    let meths, args =
-      List.split
-        (List.map
-           (fun f ->
-             let loc = f.floc in
-             let (module B) = Ast_builder.make loc in
-             let meth, read =
-               match f.src with
-               | Group lid ->
-                 ( None
-                 , [%expr
-                     [%e B.pexp_ident (derived_lid ~suffix:"of_cols" lid)]
-                       [%e B.evar cols_arg]] )
-               | Column { col; conv; _ } -> column f col conv
-             in
-             meth, (Labelled f.fname, read))
-           fields)
-    in
-    let params =
-      List.filter_map
-        (fun f ->
-          let loc = f.floc in
-          match f.src with
-          | Group _ | Column { conv = { by = false; _ }; _ } -> None
-          | Column { conv = { by = true; how }; _ } ->
-            let pkind =
-              match how with
-              | Plain -> Named f.fname
-              | Mapped e -> Named_opt (f.fname, e)
-              | Defaulted e -> Named_opt (f.fname, fill_default ~loc e)
-            in
-            Some { pkind; ppat = D.pvar ~loc (conv_arg f.fname); ploc = loc })
-        fields
-    in
-    let row =
-      { pkind = Anon
-      ; ppat =
-          B.ppat_constraint (B.pvar cols_arg)
-            (B.ptyp_object (List.filter_map Fun.id meths) Open)
-      ; ploc = loc
-      }
-    in
-    let call = B.pexp_apply (B.evar (derived_name ~suffix:"of_cols_gen" tname)) args in
-    item ~suffix:"of_cols"
-      (efun (params @ [ row ]) [%expr ([%e call] : [%t col_ty ~loc record_ty])])
+  let record ~value =
+    [%expr
+      ([%e
+         pexp_record
+           (List.map (fun f -> D.Located.lident ~loc:f.floc f.fname, value f) fields)
+           None]
+        : [%t record_ty])]
   in
-
-  let apply_item =
-    let field_of ?set f =
-      let loc = f.floc in
-      let (module B) = Ast_builder.make loc in
-      let v = B.pexp_field (B.evar rec_arg) (B.Located.lident f.fname) in
-      match set with None -> v | Some g -> [%expr [%e g] [%e v]]
-    in
-    let flush acc = function
-      | [] -> acc
-      | pending ->
-        B.pexp_apply acc
-          (List.rev_map (fun (f, col, set) -> Labelled col.txt, field_of ?set f) pending)
-    in
-    let rec chain acc pending = function
-      | [] -> flush acc pending
-      | ({ src = Group lid; _ } as f) :: tl ->
+  let readers =
+    let read rd f =
+      match f.src with
+      | Sub { nesting; lid } ->
         let loc = f.floc in
-        chain
-          [%expr
-            [%e D.pexp_ident ~loc (derived_lid ~suffix:"apply" lid)]
-              [%e flush acc pending] [%e field_of f]]
-          [] tl
-      | ({ src = Column { col; set; _ }; _ } as f) :: tl ->
-        chain acc ((f, col, set) :: pending) tl
+        [%expr
+          [%e
+            D.pexp_ident ~loc
+              (derived_lid (Read (child_reader rd nesting)) lid)]
+            [%e D.evar ~loc cols_arg]]
+      | Column { col; _ } -> D.pexp_send ~loc:col.loc (D.evar ~loc:col.loc cols_arg) col
     in
-    item ~suffix:"apply"
-      [%expr
-        fun [%p B.pvar fn_arg] ([%p B.pvar rec_arg] : [%t record_ty]) ->
-          [%e chain (B.evar fn_arg) [] fields]]
+    let value f =
+      let v = D.evar ~loc:f.floc (val_arg f.fname) in
+      match f.src with
+      | Sub _ -> v
+      | Column { col = { loc; _ }; conv; _ } ->
+        match conv with
+        | { by = false; how = Plain; _ } -> v
+        | { by = false; how = Defaulted e; _ } -> [%expr [%e fill_default ~loc e] [%e v]]
+        | { by = false; how = Mapped conv; _ } -> [%expr [%e conv] [%e v]]
+        | { by = true; _ } -> [%expr [%e D.evar ~loc (conv_arg f.fname)] [%e v]]
+    in
+    let bare = record ~value in
+    let reader_item rd ~result body =
+      item (Read rd)
+        (List.fold_right
+           (fun (lbl, default, p) acc -> D.pexp_fun ~loc:p.ppat_loc lbl default p acc)
+           (List.map
+              (fun c ->
+                ( by_label c
+                , by_default ~loc:c.floc c.src.conv.how
+                , D.pvar ~loc:c.floc (conv_arg c.fname) ))
+              (by_cols cols)
+           @ [ ( Nolabel
+               , None
+               , [%pat?
+                   ([%p pvar cols_arg]
+                     : [%t
+                         cols_obj ~loc ~is_nullable:(nullable_row rd) ~raw:impl_raw cols])]
+               )
+             ])
+           [%expr ([%e scoped ~exp:(read rd) ~body] : [%t col_ty ~loc result])])
+    in
+    let tuple_pat ~strict:pat ~rest strict extra =
+      ppat_tuple (List.map pat strict @ List.map rest extra)
+    in
+    let none f = let loc = f.floc in [%pat? None] in
+    let present =
+      tuple_pat
+        ~strict:(fun f ->
+          let loc = f.floc in
+          [%pat? Some [%p D.pvar ~loc (val_arg f.fname)]])
+        ~rest:(fun f -> D.ppat_any ~loc:f.floc)
+    in
+    let arm lhs rhs = case ~lhs ~guard:None ~rhs in
+    let missing strict extra =
+      List.mapi
+        (fun i f ->
+          let loc = f.floc in
+          arm
+            (ppat_tuple
+               (List.mapi
+                  (fun j g -> if i = j then [%pat? None] else D.ppat_any ~loc:g.floc)
+                  strict
+               @ List.map (fun g -> D.ppat_any ~loc:g.floc) extra))
+            [%expr
+              failwith
+                [%e
+                  D.estring ~loc (Printf.sprintf "sqlgg: %s.%s is NULL" tname f.fname)]])
+        strict
+    in
+    let opt_result = [%type: [%t record_ty] option] in
+    let witnessed =
+      match witness with
+      | None -> []
+      | Some { strict; extra } ->
+        let opt_arms =
+          [ arm (present strict extra) [%expr Some [%e bare]]
+          ; arm (tuple_pat ~strict:none ~rest:none strict extra) [%expr None]
+          ]
+          @
+          match strict, extra with
+          | [ _ ], [] -> []
+          | _ -> missing strict extra
+        in
+        [ reader_item Read_nullable ~result:opt_result
+            (List.fold_right
+               (fun f acc ->
+                 let loc = f.floc in
+                 [%expr
+                   Stdlib.Option.bind [%e D.evar ~loc (val_arg f.fname)] (fun
+                       [%p D.pvar ~loc (val_arg f.fname)] -> [%e acc])])
+               strict
+               [%expr Some [%e bare]])
+        ; reader_item Read_nullable_exn ~result:opt_result
+            (pexp_match
+               (pexp_tuple
+                  (List.map (fun f -> evar (val_arg f.fname)) (strict @ extra)))
+               opt_arms)
+        ]
+    in
+    reader_item Read_direct ~result:record_ty bare :: witnessed
   in
+  List.map (fun d -> pstr_type Recursive [ d ]) decls @ readers
 
-  let cols_item =
-    match cols_type ~loc tname fields with
-    | None -> []
-    | Some decl -> [ B.pstr_type Recursive [ decl ] ]
-  in
-  cols_item @ [ gen_item; of_cols_item; apply_item ]
-
-let sig_items ~loc tname first rest =
-  let fields = first :: rest in
-  let (module B) = Ast_builder.make loc in
+let sig_body { loc; tname; cols; subs; witness; decls; _ } =
+  let open (val Ast_builder.make loc) in
   let record_ty = record_ty ~loc tname in
-  let sraw f = function
-    | { how = Mapped t; _ } -> t
-    | { by = true; how = Plain } -> opaque f
-    | { how = Plain | Defaulted _; _ } as conv ->
-      Option.value (intrinsic ~loc f conv) ~default:[%type: [%t f.fty] option]
+  let value suffix type_ =
+    psig_value
+      (value_description
+         ~name:(Loc.make ~loc (derived_name suffix tname))
+         ~type_ ~prim:[])
   in
-  let cols_decl = cols_type ~loc tname fields in
-  let groups =
-    List.filter (fun f -> match f.src with Group _ -> true | Column _ -> false) fields
+  let reader ~is_nullable result =
+    List.fold_right
+      (fun c acc ->
+        ptyp_arrow (by_label c)
+          [%type: [%t sig_raw ~loc:c.floc c c.src.conv] -> [%t c.src.fty]]
+          acc)
+      (by_cols cols)
+      [%type:
+        [%t
+          match subs with
+          | [] -> cols_obj ~loc ~is_nullable ~raw:sig_raw cols
+          | _ :: _ ->
+            ptyp_constr
+              (D.Located.lident ~loc (derived_name (Cols { is_nullable }) tname))
+              (cols_params ~loc)]
+        -> [%t col_ty ~loc result]]
   in
-  match cols_decl, groups with
-  | None, (_ :: _ as blocked) ->
+  let opt_result = [%type: [%t record_ty] option] in
+  let witnessed =
+    match witness with
+    | None -> []
+    | Some _ ->
+      [ value (Read Read_nullable) (reader ~is_nullable:true opt_result)
+      ; value (Read Read_nullable_exn) (reader ~is_nullable:true opt_result)
+      ]
+  in
+  List.map (fun d -> psig_type Recursive [ d ]) decls
+  @ value (Read Read_direct) (reader ~is_nullable:false record_ty) :: witnessed
+
+let sig_items ({ loc; tname; subs; decls; _ } as a) =
+  let open (val Ast_builder.make loc) in
+  match subs, decls with
+  | (_ :: _ as ss), [] ->
     List.map
       (fun f ->
-        D.psig_extension ~loc:f.floc
-          (Location.error_extensionf ~loc:f.floc
-             "deriving sqlgg: [@sqlgg.nested] needs %s, which a converted column \
-              rules out"
-             (derived_name ~suffix:"cols" tname))
+        psig_extension
+          (Location.Error.to_extension
+             (error ~loc:f.floc
+                "[@sqlgg.nested] needs %s, and the parent cannot pass the \
+                 [@sqlgg.by] argument"
+                (derived_name (Cols { is_nullable = false }) tname)))
           [])
-      blocked
-  | _ ->
-    let nests = groups <> [] in
-    let value name type_ =
-      B.psig_value (B.value_description ~name:(B.Located.mk name) ~type_ ~prim:[])
-    in
-    let gen =
-      List.fold_right
-        (fun f acc -> B.ptyp_arrow (Labelled f.fname) (col_ty ~loc f.fty) acc)
-        fields (col_ty ~loc record_ty)
-    in
-    let of_cols =
-      let row =
-        if nests then
-          B.ptyp_constr
-            (B.Located.lident (derived_name ~suffix:"cols" tname))
-            (scope_vars ~loc @ [ row_var ~loc ])
-        else
-          B.ptyp_object
-            (List.filter_map
-               (fun f ->
-                 match f.src with
-                 | Group _ -> None
-                 | Column { col; conv; _ } ->
-                   Some (B.otag col (col_ty ~loc (sraw f conv))))
-               fields)
-            Open
-      in
-      let arg f conv =
-        let lbl =
-          match conv with
-          | { by = false; _ } -> None
-          | { by = true; how = Plain } -> Some (Labelled f.fname)
-          | { by = true; how = Defaulted _ | Mapped _ } -> Some (Optional f.fname)
-        in
-        Option.map (fun l -> l, [%type: [%t sraw f conv] -> [%t f.fty]]) lbl
-      in
-      List.fold_right
-        (fun f acc ->
-          match f.src with
-          | Group _ -> acc
-          | Column { conv; _ } ->
-            Option.fold (arg f conv) ~none:acc ~some:(fun (l, ty) ->
-                B.ptyp_arrow l ty acc))
-        fields
-        [%type: [%t row] -> [%t col_ty ~loc record_ty]]
-    in
-    let apply =
-      let callback =
-        List.fold_right
-          (fun f acc ->
-            match f.src with
-            | Group _ -> acc
-            | Column { col; set; _ } ->
-              B.ptyp_arrow (Labelled col.txt) (Option.value set ~default:f.fty) acc)
-          fields [%type: 'sqlgg__res]
-      in
-      [%type: [%t callback] -> [%t record_ty] -> 'sqlgg__res]
-    in
-    let cols_item =
-      match cols_decl with None -> [] | Some d -> [ B.psig_type Recursive [ d ] ]
-    in
-    cols_item
-    @ value (derived_name ~suffix:"of_cols_gen" tname) gen
-      :: value (derived_name ~suffix:"of_cols" tname) of_cols
-      :: (if nests then [] else [ value (derived_name ~suffix:"apply" tname) apply ])
+      ss
+  | _, _ -> sig_body a
 
-let dispatch ~loc ~ext ~pick ~record tds =
-  let reject ~loc msg =
-    [ ext ~loc (Location.error_extensionf ~loc "deriving sqlgg: %s" msg) ]
-  in
-
-  let derive ~tname ld lds =
-    let errs = ref [] in
-    let err e = errs := e :: !errs in
-    let first = analyze_field ~err ~pick ld in
-    let rest = List.filter_map (analyze_field ~err ~pick) lds in
-    match List.rev !errs, first with
-    | [], Some first -> record ~loc tname first rest
-    | msgs, _ -> List.concat_map (fun (loc, msg) -> reject ~loc msg) msgs
+let dispatch ~loc ~ext ~pick_spec ~record ~nullable tds =
+  let emit errs =
+    List.map
+      (fun e -> ext ~loc:(Location.Error.get_location e) (Location.Error.to_extension e))
+      errs
   in
   List.concat_map
     (fun td ->
       match td.ptype_params, td.ptype_kind with
-      | _ :: _, _ -> reject ~loc:td.ptype_loc "type parameters are not supported"
-      | [], Ptype_record [] -> reject ~loc:td.ptype_loc "record has no fields"
-      | [], Ptype_record (ld :: lds) -> derive ~tname:td.ptype_name.txt ld lds
+      | _ :: _, _ -> emit [ error ~loc:td.ptype_loc "type parameters are not supported" ]
+      | [], Ptype_record [] -> emit [ error ~loc:td.ptype_loc "record has no fields" ]
       | [], (Ptype_abstract | Ptype_variant _ | Ptype_open) ->
-        reject ~loc:td.ptype_loc "only record types are supported")
+        emit [ error ~loc:td.ptype_loc "only record types are supported" ]
+      | [], Ptype_record (ld :: lds) ->
+        let step ld (fs, es) =
+          match resolve_field ~pick_spec ld with
+          | Ok f -> f :: fs, es
+          | Error e -> fs, e :: es
+        in
+        match resolve_field ~pick_spec ld, List.fold_right step lds ([], []) with
+        | Error e, (_, es) -> emit (e :: es)
+        | Ok _, (_, (_ :: _ as es)) -> emit es
+        | Ok f, (fs, []) ->
+        let fields = f :: fs in
+        let witness =
+          match nullable, witness fields with
+          | false, _ -> Ok None
+          | true, (Some _ as w) -> Ok w
+          | true, None ->
+            Error
+              (error ~loc:td.ptype_loc
+                 "~nullable_cols needs a column that cannot be NULL, or drop the option")
+        in
+        match witness with
+        | Error e -> emit [ e ]
+        | Ok witness ->
+          let cols = columns fields in
+          let subs = subs fields in
+          record
+            { loc
+            ; tname = td.ptype_name.txt
+            ; first = f
+            ; rest = fs
+            ; fields
+            ; cols
+            ; subs
+            ; witness
+            ; decls =
+                cols_decls ~loc ~nullable:(Option.is_some witness) td.ptype_name.txt
+                  subs cols
+            })
     tds
 
-let expand ~ctxt (_rec_flag, tds) =
+let expand ~ctxt (_rec_flag, tds) nullable =
   dispatch
     ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
     ~ext:(fun ~loc e -> D.pstr_extension ~loc e [])
-    ~pick:(function Fn e -> Ok e | Raw _ -> Error "expected a conversion function")
-    ~record:build tds
+    ~pick_spec:
+      (function
+      | Either.Left e -> Ok e
+      | Either.Right _ -> Error "expected a conversion function")
+    ~record:build ~nullable tds
 
-let expand_sig ~ctxt (_rec_flag, tds) =
+let expand_sig ~ctxt (_rec_flag, tds) nullable =
   dispatch
     ~loc:(Expansion_context.Deriver.derived_item_loc ctxt)
     ~ext:(fun ~loc e -> D.psig_extension ~loc e [])
-    ~pick:
-      (function Raw t -> Ok t | Fn _ -> Error "expected a column type after a colon")
-    ~record:sig_items tds
+    ~pick_spec:
+      (function
+      | Either.Right t -> Ok t
+      | Either.Left _ -> Error "expected a column type after a colon")
+    ~record:sig_items ~nullable tds
 
 let () =
   Deriving.add "sqlgg"
-    ~str_type_decl:(Deriving.Generator.V2.make_noarg ~attributes expand)
-    ~sig_type_decl:(Deriving.Generator.V2.make_noarg ~attributes expand_sig)
+    ~str_type_decl:
+      (Deriving.Generator.V2.make ~attributes
+         Deriving.Args.(empty +> flag "nullable_cols")
+         expand)
+    ~sig_type_decl:
+      (Deriving.Generator.V2.make ~attributes
+         Deriving.Args.(empty +> flag "nullable_cols")
+         expand_sig)
   |> Deriving.ignore

--- a/test/cram/test_build_ppx/dune
+++ b/test/cram/test_build_ppx/dune
@@ -1,4 +1,5 @@
 (cram
  (deps
   %{bin:sqlgg}
+  (package sqlgg)
   ../print_impl.ml))

--- a/test/cram/test_build_ppx/field_attributes.t/run.ml
+++ b/test/cram/test_build_ppx/field_attributes.t/run.ml
@@ -3,8 +3,8 @@ type content = { text : string option [@sqlgg.col "body"] } [@@deriving sqlgg]
 type post = {
   id : int64;
   content : content; [@sqlgg.nested]
-  reply_count : int; [@sqlgg.map Int64.to_int] [@sqlgg.set Int64.of_int]
-  hits : int64; [@sqlgg.default 0L] [@sqlgg.set (fun h -> Some h)]
+  reply_count : int; [@sqlgg.map Int64.to_int]
+  hits : int64; [@sqlgg.default 0L]
 }
 [@@deriving sqlgg]
 
@@ -40,9 +40,12 @@ let () =
   run "the same post, columns picked by hand" (fun () ->
     rows [ [ mock_int 1L; mock_text "hi"; mock_int 7L; mock_null ] ];
     let col =
-      post_of_cols_gen ~id:cols#id ~content:(content_of_cols cols)
-        ~reply_count:(Sqlgg_scope.map Int64.to_int cols#reply_count)
-        ~hits:(Sqlgg_scope.map (fun h -> Option.value h ~default:(-1L)) cols#hits)
+      let open Sqlgg_scope in
+      let+ id = cols#id
+      and+ content = content_of_cols cols
+      and+ reply_count = map Int64.to_int cols#reply_count
+      and+ hits = map (fun h -> Option.value h ~default:(-1L)) cols#hits in
+      { id; content; reply_count; hits }
     in
     Stdlib.List.iter print_post (List.select () col ~min_id:0L))
 
@@ -76,4 +79,4 @@ let () =
     let p : post =
       { id = 5L; content = { text = Some "hello" }; reply_count = 2; hits = 11L }
     in
-    ignore (post_apply (Db.add_post ()) p))
+    ignore (Db.add_post () ~id:p.id ~body:p.content.text ~reply_count:(Int64.of_int p.reply_count) ~hits:(Some p.hits)))

--- a/test/cram/test_build_ppx/joined.t/by_without_conversion.ml
+++ b/test/cram/test_build_ppx/joined.t/by_without_conversion.ml
@@ -1,0 +1,4 @@
+type channel = { channel_id : int64; hits : int [@sqlgg.by] }
+[@@deriving sqlgg ~nullable_cols]
+
+type post = { id : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]

--- a/test/cram/test_build_ppx/joined.t/no_nullable_cols.ml
+++ b/test/cram/test_build_ppx/joined.t/no_nullable_cols.ml
@@ -1,0 +1,3 @@
+type ch = { cid : int64; cname : string } [@@deriving sqlgg]
+
+type top = { tid : int64; ch : ch option [@sqlgg.nested] } [@@deriving sqlgg]

--- a/test/cram/test_build_ppx/joined.t/no_strict_column.ml
+++ b/test/cram/test_build_ppx/joined.t/no_strict_column.ml
@@ -1,0 +1,5 @@
+type note = { note : string option; tag : string option }
+[@@deriving sqlgg ~nullable_cols]
+
+type row = { id : int64; note : note option [@sqlgg.nested] }
+[@@deriving sqlgg]

--- a/test/cram/test_build_ppx/joined.t/posts.sql
+++ b/test/cram/test_build_ppx/joined.t/posts.sql
@@ -1,0 +1,18 @@
+CREATE TABLE posts (
+  id INT NOT NULL PRIMARY KEY,
+  body TEXT NULL,
+  channel_id INT NULL
+);
+
+CREATE TABLE channels (
+  channel_id INT NOT NULL PRIMARY KEY,
+  channel_name TEXT NOT NULL,
+  image_url TEXT NULL
+);
+
+-- [sqlgg] dynamic_select=true
+-- @feed
+SELECT p.id, p.body, c.channel_id, c.channel_name, c.image_url
+FROM posts p
+LEFT JOIN channels c ON c.channel_id = p.channel_id
+WHERE p.id > @min_id;

--- a/test/cram/test_build_ppx/joined.t/run.ml
+++ b/test/cram/test_build_ppx/joined.t/run.ml
@@ -1,0 +1,31 @@
+type channel = {
+  channel_id : int64;
+  channel_name : string;
+  image_url : string option;
+}
+[@@deriving sqlgg ~nullable_cols]
+
+type post = {
+  id : int64;
+  body : string option;
+  channel : channel option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+module Db = Posts.Sqlgg (Print_impl)
+
+let () =
+  let open Print_impl in
+  let open Db.Feed in
+  clear_mock_responses ();
+  setup_select_response
+    [ make_mock_row
+        [ mock_int 1L; mock_text "hi"; mock_int 10L; mock_text "ocaml"
+        ; mock_text "pic"
+        ]
+    ];
+  match (Stdlib.List.hd (List.select () (post_of_cols cols) ~min_id:0L)).channel with
+  | None -> print_endline "channel none"
+  | Some c ->
+    Printf.printf "channel %Ld/%s img=%s\n" c.channel_id c.channel_name
+      (Stdlib.Option.value c.image_url ~default:"none")

--- a/test/cram/test_build_ppx/joined.t/run.t
+++ b/test/cram/test_build_ppx/joined.t/run.t
@@ -1,0 +1,18 @@
+  $ cat posts.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > posts.ml
+  $ cp ../../print_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c posts.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c run.ml
+  $ ocamlfind ocamlc -package unix,sqlgg.traits -I . -linkpkg -o run.exe posts.cmo print_impl.cmo run.cmo
+  $ ./run.exe | grep '^channel'
+  channel 10/ocaml img=pic
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c no_strict_column.ml 2>&1 | tail -4
+  1 | type note = { note : string option; tag : string option }
+  2 | [@@deriving sqlgg ~nullable_cols]
+  Error: deriving sqlgg: ~nullable_cols needs a column that cannot be NULL, or
+         drop the option
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c no_nullable_cols.ml 2>&1 | grep -o ch_nullable_cols | head -1
+  ch_nullable_cols
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c by_without_conversion.ml 2>&1 | grep -o channel_nullable_cols | head -1
+  channel_nullable_cols

--- a/test/cram/test_build_ppx/nesting.t/inner_alongside.ml
+++ b/test/cram/test_build_ppx/nesting.t/inner_alongside.ml
@@ -1,0 +1,13 @@
+type cc = { cid : int64; cname : string } [@@deriving sqlgg ~nullable_cols]
+type bb = { bid : int64; bname : string } [@@deriving sqlgg ~nullable_cols]
+
+type aa = {
+  aid : int64;
+  bb : bb option; [@sqlgg.nested]
+  cc : cc; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+module Db = Joins.Sqlgg (Print_impl)
+
+let _ = aa_of_cols Db.Left_then_inner.cols

--- a/test/cram/test_build_ppx/nesting.t/inner_in_left.ml
+++ b/test/cram/test_build_ppx/nesting.t/inner_in_left.ml
@@ -1,0 +1,8 @@
+type cc = { cid : int64; cname : string } [@@deriving sqlgg ~nullable_cols]
+type bb = { bid : int64; cc : cc option [@sqlgg.nested] }
+[@@deriving sqlgg ~nullable_cols]
+type aa = { aid : int64; bb : bb option [@sqlgg.nested] } [@@deriving sqlgg]
+
+module Db = Joins.Sqlgg (Print_impl)
+
+let _ = aa_of_cols Db.Left_then_inner.cols

--- a/test/cram/test_build_ppx/nesting.t/joins.sql
+++ b/test/cram/test_build_ppx/nesting.t/joins.sql
@@ -1,0 +1,15 @@
+CREATE TABLE a (aid INT NOT NULL PRIMARY KEY, bk INT NULL);
+CREATE TABLE b (bid INT NOT NULL PRIMARY KEY, ck INT NULL, bname TEXT NOT NULL);
+CREATE TABLE c (cid INT NOT NULL PRIMARY KEY, cname TEXT NOT NULL);
+
+-- [sqlgg] dynamic_select=true
+-- @chain
+SELECT a.aid, b.bid, b.bname, c.cid, c.cname
+FROM a LEFT JOIN b ON b.bid = a.bk LEFT JOIN c ON c.cid = b.ck
+WHERE a.aid > @min_id;
+
+-- [sqlgg] dynamic_select=true
+-- @left_then_inner
+SELECT a.aid, b.bid, b.bname, c.cid, c.cname
+FROM a LEFT JOIN b ON b.bid = a.bk JOIN c ON c.cid = b.ck
+WHERE a.aid > @min_id;

--- a/test/cram/test_build_ppx/nesting.t/run.ml
+++ b/test/cram/test_build_ppx/nesting.t/run.ml
@@ -1,0 +1,91 @@
+type cc = { cid : int64; cname : string } [@@deriving sqlgg ~nullable_cols]
+
+type deep = {
+  bid : int64;
+  bname : string;
+  cc : cc option; [@sqlgg.nested]
+}
+[@@deriving sqlgg ~nullable_cols]
+
+type chained = { aid : int64; deep : deep option [@sqlgg.nested] }
+[@@deriving sqlgg]
+
+type lax_chain = { aid : int64; deep : deep option [@sqlgg.nested default_none] }
+[@@deriving sqlgg]
+
+type inner_nested = { bid : int64; cc : cc [@sqlgg.nested] }
+[@@deriving sqlgg ~nullable_cols]
+
+type nested_under_option = {
+  aid : int64;
+  b : inner_nested option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type nested_under_option_lax = {
+  aid : int64;
+  b : inner_nested option; [@sqlgg.nested default_none]
+}
+[@@deriving sqlgg]
+
+module Db = Joins.Sqlgg (Print_impl)
+
+let row ~aid ~bid ~bname ~cid ~cname =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_select_response
+    [ Print_impl.make_mock_row [ aid; bid; bname; cid; cname ] ]
+
+let leaf = function None -> "none" | Some c -> Printf.sprintf "%Ld/%s" c.cid c.cname
+
+let shown : deep option -> string = function
+  | None -> "none"
+  | Some b -> Printf.sprintf "%Ld/%s c=%s" b.bid b.bname (leaf b.cc)
+
+let read one = try shown (one ()) with Failure w -> "raises " ^ w
+
+let () =
+  let open Print_impl in
+  let open Db.Chain in
+  let strict () =
+    (Stdlib.List.hd (List.select () (chained_of_cols cols) ~min_id:0L)).deep
+  in
+  let lax () =
+    (Stdlib.List.hd (List.select () (lax_chain_of_cols cols) ~min_id:0L)).deep
+  in
+  let pair name a b = Printf.printf "| %-19s | %-30s | %s\n%!" name a b in
+  let case2 name cells read one two =
+    cells ();
+    let a = read one in
+    cells ();
+    let b = read two in
+    pair name a b
+  in
+  let case name cells = case2 name cells read strict lax in
+  pair "row" "[@sqlgg.nested]" "default_none";
+  case "all present" (fun () ->
+    row ~aid:(mock_int 1L) ~bid:(mock_int 2L) ~bname:(mock_text "bb")
+      ~cid:(mock_int 3L) ~cname:(mock_text "cc"));
+  case "leaf absent" (fun () ->
+    row ~aid:(mock_int 1L) ~bid:(mock_int 2L) ~bname:(mock_text "bb") ~cid:mock_null
+      ~cname:mock_null);
+  case "middle absent" (fun () ->
+    row ~aid:(mock_int 1L) ~bid:mock_null ~bname:mock_null ~cid:mock_null
+      ~cname:mock_null);
+  case "half a leaf" (fun () ->
+    row ~aid:(mock_int 1L) ~bid:(mock_int 2L) ~bname:(mock_text "bb")
+      ~cid:(mock_int 3L) ~cname:mock_null);
+  let plain () =
+    (Stdlib.List.hd (List.select () (nested_under_option_of_cols cols) ~min_id:0L)).b
+  in
+  let soft () =
+    (Stdlib.List.hd (List.select () (nested_under_option_lax_of_cols cols) ~min_id:0L)).b
+  in
+  let inner : inner_nested option -> string = function
+    | None -> "none"
+    | Some b -> Printf.sprintf "%Ld c=%Ld" b.bid b.cc.cid
+  in
+  let read one = try inner (one ()) with Failure w -> "raises " ^ w in
+  case2 "plain child, absent" (fun () ->
+    row ~aid:(mock_int 1L) ~bid:mock_null ~bname:mock_null ~cid:mock_null
+      ~cname:mock_null)
+    read plain soft

--- a/test/cram/test_build_ppx/nesting.t/run.t
+++ b/test/cram/test_build_ppx/nesting.t/run.t
@@ -1,0 +1,18 @@
+  $ cat joins.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > joins.ml
+  $ cp ../../print_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c joins.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c run.ml
+  $ ocamlfind ocamlc -package unix,sqlgg.traits -I . -linkpkg -o run.exe joins.cmo print_impl.cmo run.cmo
+  $ ./run.exe | grep '^|'
+  | row                 | [@sqlgg.nested]                | default_none
+  | all present         | 2/bb c=3/cc                    | 2/bb c=3/cc
+  | leaf absent         | 2/bb c=none                    | 2/bb c=none
+  | middle absent       | none                           | none
+  | half a leaf         | raises sqlgg: cc.cname is NULL | 2/bb c=none
+  | plain child, absent | none                           | none
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c inner_in_left.ml 2>&1 | head -2
+  File "inner_in_left.ml", line 8, characters 19-42:
+  8 | let _ = aa_of_cols Db.Left_then_inner.cols
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c inner_alongside.ml

--- a/test/cram/test_build_ppx/readers.t/drop_join.ml
+++ b/test/cram/test_build_ppx/readers.t/drop_join.ml
@@ -1,0 +1,13 @@
+type bare = { iid : int64; tag : string option } [@@deriving sqlgg]
+
+module Db = Shop.Sqlgg (Print_impl)
+
+let () =
+  let open Print_impl in
+  let open Db.Wide in
+  clear_mock_responses ();
+  setup_select_response [ make_mock_row [ mock_int 1L; mock_text "red" ] ];
+  Stdlib.List.iter
+    (fun (r : bare) ->
+      Printf.printf "iid=%Ld tag=%s\n" r.iid (match r.tag with None -> "none" | Some s -> s))
+    (List.select () (bare_of_cols cols) ~min_id:0L)

--- a/test/cram/test_build_ppx/readers.t/run.ml
+++ b/test/cram/test_build_ppx/readers.t/run.ml
@@ -1,0 +1,64 @@
+type stock = {
+  sid : int64;
+  place : string;
+  hits : int64; [@sqlgg.default 0L]
+}
+[@@deriving sqlgg ~nullable_cols]
+
+type listing = {
+  iid : int64;
+  stock : stock option; [@sqlgg.nested]
+  tag : string option;
+}
+[@@deriving sqlgg]
+
+type listing_or_none = {
+  iid : int64;
+  stock : stock option; [@sqlgg.nested default_none]
+  tag : string option;
+}
+[@@deriving sqlgg]
+
+module Db = Shop.Sqlgg (Print_impl)
+
+let row ~iid ~sid ~place ~hits ~tag =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_select_response
+    [ Print_impl.make_mock_row [ iid; sid; place; hits; tag ] ]
+
+let shown = function
+  | None -> "none"
+  | Some s -> Printf.sprintf "%Ld/%s/%Ld" s.sid s.place s.hits
+
+let read one = try shown (one ()) with Failure w -> "raises " ^ w
+
+let () =
+  let open Print_impl in
+  let open Db.Wide in
+  let plain () =
+    (Stdlib.List.hd (List.select () (listing_of_cols cols) ~min_id:0L)).stock
+  in
+  let soft () =
+    (Stdlib.List.hd (List.select () (listing_or_none_of_cols cols) ~min_id:0L)).stock
+  in
+  let line = Printf.printf "| %-22s | %-34s | %s\n%!" in
+  let case name cells =
+    cells ();
+    let p = read plain in
+    cells ();
+    let s = read soft in
+    line name p s
+  in
+  line "row" "[@sqlgg.nested]" "default_none";
+  case "matched" (fun () ->
+    row ~iid:(mock_int 1L) ~sid:(mock_int 7L) ~place:(mock_text "shelf")
+      ~hits:(mock_int 3L) ~tag:(mock_text "red"));
+  case "no match" (fun () ->
+    row ~iid:(mock_int 2L) ~sid:mock_null ~place:mock_null ~hits:mock_null
+      ~tag:mock_null);
+  case "half a relation" (fun () ->
+    row ~iid:(mock_int 3L) ~sid:(mock_int 7L) ~place:mock_null ~hits:(mock_int 5L)
+      ~tag:(mock_text "blue"));
+  case "defaulted column NULL" (fun () ->
+    row ~iid:(mock_int 4L) ~sid:(mock_int 8L) ~place:(mock_text "bin") ~hits:mock_null
+      ~tag:(mock_text "x"))

--- a/test/cram/test_build_ppx/readers.t/run.t
+++ b/test/cram/test_build_ppx/readers.t/run.t
@@ -1,0 +1,22 @@
+  $ cat shop.sql | sqlgg -no-header -gen caml_io -params unnamed -gen caml -dialect mysql - > shop.ml
+  $ cp ../../print_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg -I . -c shop.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c run.ml
+  $ ocamlfind ocamlc -package unix,sqlgg.traits -I . -linkpkg -o run.exe shop.cmo print_impl.cmo run.cmo
+  $ ./run.exe | grep '^|'
+  | row                    | [@sqlgg.nested]                    | default_none
+  | matched                | 7/shelf/3                          | 7/shelf/3
+  | no match               | none                               | none
+  | half a relation        | raises sqlgg: stock.place is NULL  | none
+  | defaulted column NULL  | 8/bin/0                            | 8/bin/0
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c drop_join.ml
+  $ ocamlfind ocamlc -package unix,sqlgg.traits -I . -linkpkg -o drop_join.exe shop.cmo print_impl.cmo drop_join.cmo
+  $ ./drop_join.exe | grep -A1 "^\[SQL\]"
+  [SQL] SELECT i.iid, i.tag
+  FROM item i
+
+  $ ocamlfind ocamlc -package sqlgg.traits,sqlgg.ppx -I . -c strict_reader.ml 2>&1 | head -2
+  File "strict_reader.ml", line 5, characters 22-34:
+  5 | let _ = stock_of_cols Db.Wide.cols

--- a/test/cram/test_build_ppx/readers.t/shop.sql
+++ b/test/cram/test_build_ppx/readers.t/shop.sql
@@ -1,0 +1,8 @@
+CREATE TABLE item (iid INT NOT NULL PRIMARY KEY, tag TEXT NULL, sk INT NULL);
+CREATE TABLE stock (sid INT NOT NULL PRIMARY KEY, place TEXT NOT NULL, hits INT NULL);
+
+-- [sqlgg] dynamic_select=true
+-- @wide
+SELECT i.iid, i.tag, s.sid, s.place, s.hits
+FROM item i LEFT JOIN stock s ON s.sid = i.sk
+WHERE i.iid > @min_id;

--- a/test/cram/test_build_ppx/readers.t/strict_reader.ml
+++ b/test/cram/test_build_ppx/readers.t/strict_reader.ml
@@ -1,0 +1,5 @@
+type stock = { sid : int64; place : string } [@@deriving sqlgg]
+
+module Db = Shop.Sqlgg (Print_impl)
+
+let _ = stock_of_cols Db.Wide.cols

--- a/test/cram/test_build_ppx/signature.t/feed.ml
+++ b/test/cram/test_build_ppx/signature.t/feed.ml
@@ -1,2 +1,2 @@
 type channel = { channel_id : int64; channel_name : string option }
-[@@deriving sqlgg]
+[@@deriving sqlgg ~nullable_cols]

--- a/test/cram/test_build_ppx/signature.t/feed.mli
+++ b/test/cram/test_build_ppx/signature.t/feed.mli
@@ -1,2 +1,2 @@
 type channel = { channel_id : int64; channel_name : string option }
-[@@deriving sqlgg]
+[@@deriving sqlgg ~nullable_cols]

--- a/test/cram/test_build_ppx/signature.t/m.ml
+++ b/test/cram/test_build_ppx/signature.t/m.ml
@@ -9,7 +9,7 @@ type product = {
 type counted = {
   cid : int64;
   reply_count : int; [@sqlgg.map Int64.to_int]
-  label : string; [@sqlgg.set String.trim]
+  label : string;
 }
 [@@deriving sqlgg]
 
@@ -19,5 +19,11 @@ type post = {
   post_id : int64;
   content : content; [@sqlgg.nested]
   channel : Feed.channel; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type feed_item = {
+  item_id : int64;
+  channel : Feed.channel option; [@sqlgg.nested]
 }
 [@@deriving sqlgg]

--- a/test/cram/test_build_ppx/signature.t/m.mli
+++ b/test/cram/test_build_ppx/signature.t/m.mli
@@ -9,7 +9,7 @@ type product = {
 type counted = {
   cid : int64;
   reply_count : int; [@sqlgg.map: int64]
-  label : string; [@sqlgg.set: string]
+  label : string;
 }
 [@@deriving sqlgg]
 
@@ -19,5 +19,11 @@ type post = {
   post_id : int64;
   content : content; [@sqlgg.nested]
   channel : Feed.channel; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type feed_item = {
+  item_id : int64;
+  channel : Feed.channel option; [@sqlgg.nested]
 }
 [@@deriving sqlgg]

--- a/test/ppx_expansion/cases.expected.ml
+++ b/test/ppx_expansion/cases.expected.ml
@@ -1,6 +1,6 @@
 type product = {
   id: int64 ;
-  name: string option }[@@deriving sqlgg]
+  name: string option }[@@deriving sqlgg ~nullable_cols]
 include
   struct
     let _ = fun (_ : product) -> ()
@@ -15,23 +15,18 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    let product_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~name:(sqlgg__c_name :
-              (string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_name = sqlgg__c_name in
-         ({ id = sqlgg__v_id; name = sqlgg__v_name } : product) : (product,
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) product_nullable_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64 option, 'sqlgg__brand, 'sqlgg__row,
+                            'sqlgg__params) Sqlgg_scope.col  ;name: (string
+                                                                    option,
                                                                     'sqlgg__brand,
                                                                     'sqlgg__row,
                                                                     'sqlgg__params)
-                                                                    Sqlgg_scope.col)
-    let _ = product_of_cols_gen
+                                                                    Sqlgg_scope.col
+                                                                  ;.. > 
     let product_of_cols
       (sqlgg__cols :
         <
@@ -40,12 +35,54 @@ include
                                           'sqlgg__row, 'sqlgg__params)
                                           Sqlgg_scope.col   ;.. > )
       =
-      (product_of_cols_gen ~id:(sqlgg__cols#id) ~name:(sqlgg__cols#name) : 
-      (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_name = sqlgg__cols#name in
+         ({ id = sqlgg__v_id; name = sqlgg__v_name } : product) : (product,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
     let _ = product_of_cols
-    let product_apply sqlgg__f (sqlgg__r : product) =
-      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.name)
-    let _ = product_apply
+    let product_of_nullable_cols
+      (sqlgg__cols :
+        <
+          id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                          'sqlgg__row, 'sqlgg__params)
+                                          Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_name = sqlgg__cols#name in
+         Stdlib.Option.bind sqlgg__v_id
+           (fun sqlgg__v_id ->
+              Some ({ id = sqlgg__v_id; name = sqlgg__v_name } : product)) : 
+      (product option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = product_of_nullable_cols
+    let product_of_nullable_cols_exn
+      (sqlgg__cols :
+        <
+          id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                          'sqlgg__row, 'sqlgg__params)
+                                          Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_name = sqlgg__cols#name in
+         match (sqlgg__v_id, sqlgg__v_name) with
+         | (Some sqlgg__v_id, _) ->
+             Some ({ id = sqlgg__v_id; name = sqlgg__v_name } : product)
+         | (None, None) -> None
+         | (None, _) -> failwith "sqlgg: product.id is NULL" : (product
+                                                                  option,
+                                                                 'sqlgg__brand,
+                                                                 'sqlgg__row,
+                                                                 'sqlgg__params)
+                                                                 Sqlgg_scope.col)
+    let _ = product_of_nullable_cols_exn
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type renamed = {
   id: int64 ;
@@ -64,21 +101,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    let renamed_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~productName:(sqlgg__c_productName :
-                     (string option, 'sqlgg__brand, 'sqlgg__row,
-                       'sqlgg__params) Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_productName = sqlgg__c_productName in
-         ({ id = sqlgg__v_id; productName = sqlgg__v_productName } : 
-           renamed) : (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                        Sqlgg_scope.col)
-    let _ = renamed_of_cols_gen
     let renamed_of_cols
       (sqlgg__cols :
         <
@@ -87,14 +109,13 @@ include
                                           'sqlgg__row, 'sqlgg__params)
                                           Sqlgg_scope.col   ;.. > )
       =
-      (renamed_of_cols_gen ~id:(sqlgg__cols#id)
-         ~productName:(sqlgg__cols#name) : (renamed, 'sqlgg__brand,
-                                             'sqlgg__row, 'sqlgg__params)
-                                             Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_productName = sqlgg__cols#name in
+         ({ id = sqlgg__v_id; productName = sqlgg__v_productName } : 
+           renamed) : (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                        Sqlgg_scope.col)
     let _ = renamed_of_cols
-    let renamed_apply sqlgg__f (sqlgg__r : renamed) =
-      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.productName)
-    let _ = renamed_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type same_column_twice = {
   id: int64 ;
@@ -111,21 +132,6 @@ include
                                                     'sqlgg__row,
                                                     'sqlgg__params)
                                                     Sqlgg_scope.col   ;.. > 
-    let same_column_twice_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~also_id:(sqlgg__c_also_id :
-                 (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                   Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_also_id = sqlgg__c_also_id in
-         ({ id = sqlgg__v_id; also_id = sqlgg__v_also_id } : same_column_twice) : 
-      (same_column_twice, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-        Sqlgg_scope.col)
-    let _ = same_column_twice_of_cols_gen
     let same_column_twice_of_cols
       (sqlgg__cols :
         <
@@ -134,14 +140,13 @@ include
                                         'sqlgg__params) Sqlgg_scope.col   ;..
           > )
       =
-      (same_column_twice_of_cols_gen ~id:(sqlgg__cols#id)
-         ~also_id:(sqlgg__cols#id) : (same_column_twice, 'sqlgg__brand,
-                                       'sqlgg__row, 'sqlgg__params)
-                                       Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_also_id = sqlgg__cols#id in
+         ({ id = sqlgg__v_id; also_id = sqlgg__v_also_id } : same_column_twice) : 
+      (same_column_twice, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
     let _ = same_column_twice_of_cols
-    let same_column_twice_apply sqlgg__f (sqlgg__r : same_column_twice) =
-      sqlgg__f ~id:(sqlgg__r.id) ~id:(sqlgg__r.also_id)
-    let _ = same_column_twice_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type converted = {
   id: int64 ;
@@ -149,21 +154,17 @@ type converted = {
 include
   struct
     let _ = fun (_ : converted) -> ()
-    let converted_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~reply_count:(sqlgg__c_reply_count :
-                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                       Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
-         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
-           converted) : (converted, 'sqlgg__brand, 'sqlgg__row,
-                          'sqlgg__params) Sqlgg_scope.col)
-    let _ = converted_of_cols_gen
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) converted_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                             'sqlgg__brand,
+                                                             'sqlgg__row,
+                                                             'sqlgg__params)
+                                                             Sqlgg_scope.col   ;..
+                      > 
     let converted_of_cols
       (sqlgg__cols :
         <
@@ -173,13 +174,15 @@ include
                                                  'sqlgg__params)
                                                  Sqlgg_scope.col   ;.. > )
       =
-      (converted_of_cols_gen ~id:(sqlgg__cols#id)
-         ~reply_count:(Sqlgg_scope.map Int64.to_int sqlgg__cols#reply_count) : 
-      (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_reply_count = sqlgg__cols#reply_count in
+         ({
+            id = sqlgg__v_id;
+            reply_count = (Int64.to_int sqlgg__v_reply_count)
+          } : converted) : (converted, 'sqlgg__brand, 'sqlgg__row,
+                             'sqlgg__params) Sqlgg_scope.col)
     let _ = converted_of_cols
-    let converted_apply sqlgg__f (sqlgg__r : converted) =
-      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
-    let _ = converted_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type deferred = {
   id: int64 ;
@@ -187,21 +190,6 @@ type deferred = {
 include
   struct
     let _ = fun (_ : deferred) -> ()
-    let deferred_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~reply_count:(sqlgg__c_reply_count :
-                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                       Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
-         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
-           deferred) : (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                         Sqlgg_scope.col)
-    let _ = deferred_of_cols_gen
     let deferred_of_cols ~reply_count:sqlgg__conv_reply_count
       (sqlgg__cols :
         <
@@ -211,16 +199,15 @@ include
                                                  'sqlgg__params)
                                                  Sqlgg_scope.col   ;.. > )
       =
-      (deferred_of_cols_gen ~id:(sqlgg__cols#id)
-         ~reply_count:(Sqlgg_scope.map sqlgg__conv_reply_count
-                         sqlgg__cols#reply_count) : (deferred, 'sqlgg__brand,
-                                                      'sqlgg__row,
-                                                      'sqlgg__params)
-                                                      Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_reply_count = sqlgg__cols#reply_count in
+         ({
+            id = sqlgg__v_id;
+            reply_count = (sqlgg__conv_reply_count sqlgg__v_reply_count)
+          } : deferred) : (deferred, 'sqlgg__brand, 'sqlgg__row,
+                            'sqlgg__params) Sqlgg_scope.col)
     let _ = deferred_of_cols
-    let deferred_apply sqlgg__f (sqlgg__r : deferred) =
-      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
-    let _ = deferred_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type deferred_with_default =
   {
@@ -229,22 +216,17 @@ type deferred_with_default =
 include
   struct
     let _ = fun (_ : deferred_with_default) -> ()
-    let deferred_with_default_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~reply_count:(sqlgg__c_reply_count :
-                     (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                       Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_reply_count = sqlgg__c_reply_count in
-         ({ id = sqlgg__v_id; reply_count = sqlgg__v_reply_count } : 
-           deferred_with_default) : (deferred_with_default, 'sqlgg__brand,
-                                      'sqlgg__row, 'sqlgg__params)
-                                      Sqlgg_scope.col)
-    let _ = deferred_with_default_of_cols_gen
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) deferred_with_default_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                             'sqlgg__brand,
+                                                             'sqlgg__row,
+                                                             'sqlgg__params)
+                                                             Sqlgg_scope.col   ;..
+                      > 
     let deferred_with_default_of_cols ?reply_count:(sqlgg__conv_reply_count=
       Int64.to_int)
       (sqlgg__cols :
@@ -255,18 +237,16 @@ include
                                                  'sqlgg__params)
                                                  Sqlgg_scope.col   ;.. > )
       =
-      (deferred_with_default_of_cols_gen ~id:(sqlgg__cols#id)
-         ~reply_count:(Sqlgg_scope.map sqlgg__conv_reply_count
-                         sqlgg__cols#reply_count) : (deferred_with_default,
-                                                      'sqlgg__brand,
-                                                      'sqlgg__row,
-                                                      'sqlgg__params)
-                                                      Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_reply_count = sqlgg__cols#reply_count in
+         ({
+            id = sqlgg__v_id;
+            reply_count = (sqlgg__conv_reply_count sqlgg__v_reply_count)
+          } : deferred_with_default) : (deferred_with_default, 'sqlgg__brand,
+                                         'sqlgg__row, 'sqlgg__params)
+                                         Sqlgg_scope.col)
     let _ = deferred_with_default_of_cols
-    let deferred_with_default_apply sqlgg__f
-      (sqlgg__r : deferred_with_default) =
-      sqlgg__f ~id:(sqlgg__r.id) ~reply_count:(sqlgg__r.reply_count)
-    let _ = deferred_with_default_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type with_default = {
   id: int64 ;
@@ -285,21 +265,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    let with_default_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~hits:(sqlgg__c_hits :
-              (int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_hits = sqlgg__c_hits in
-         ({ id = sqlgg__v_id; hits = sqlgg__v_hits } : with_default) : 
-      (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-        Sqlgg_scope.col)
-    let _ = with_default_of_cols_gen
     let with_default_of_cols
       (sqlgg__cols :
         <
@@ -308,19 +273,19 @@ include
                                           'sqlgg__row, 'sqlgg__params)
                                           Sqlgg_scope.col   ;.. > )
       =
-      (with_default_of_cols_gen ~id:(sqlgg__cols#id)
-         ~hits:(Sqlgg_scope.map (Stdlib.Option.value ~default:0)
-                  sqlgg__cols#hits) : (with_default, 'sqlgg__brand,
-                                        'sqlgg__row, 'sqlgg__params)
-                                        Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_hits = sqlgg__cols#hits in
+         ({
+            id = sqlgg__v_id;
+            hits = ((Stdlib.Option.value ~default:0) sqlgg__v_hits)
+          } : with_default) : (with_default, 'sqlgg__brand, 'sqlgg__row,
+                                'sqlgg__params) Sqlgg_scope.col)
     let _ = with_default_of_cols
-    let with_default_apply sqlgg__f (sqlgg__r : with_default) =
-      sqlgg__f ~id:(sqlgg__r.id) ~hits:(sqlgg__r.hits)
-    let _ = with_default_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type trimmed = {
   id: int64 ;
-  name: string [@sqlgg.set String.trim]}[@@deriving sqlgg]
+  name: string }[@@deriving sqlgg]
 include
   struct
     let _ = fun (_ : trimmed) -> ()
@@ -334,23 +299,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    let trimmed_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~name:(sqlgg__c_name :
-              (string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_name = sqlgg__c_name in
-         ({ id = sqlgg__v_id; name = sqlgg__v_name } : trimmed) : (trimmed,
-                                                                    'sqlgg__brand,
-                                                                    'sqlgg__row,
-                                                                    'sqlgg__params)
-                                                                    Sqlgg_scope.col)
-    let _ = trimmed_of_cols_gen
     let trimmed_of_cols
       (sqlgg__cols :
         <
@@ -359,12 +307,15 @@ include
                                           'sqlgg__params) Sqlgg_scope.col   ;..
           > )
       =
-      (trimmed_of_cols_gen ~id:(sqlgg__cols#id) ~name:(sqlgg__cols#name) : 
-      (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_name = sqlgg__cols#name in
+         ({ id = sqlgg__v_id; name = sqlgg__v_name } : trimmed) : (trimmed,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col)
     let _ = trimmed_of_cols
-    let trimmed_apply sqlgg__f (sqlgg__r : trimmed) =
-      sqlgg__f ~id:(sqlgg__r.id) ~name:(String.trim sqlgg__r.name)
-    let _ = trimmed_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type nested = {
   id: int64 ;
@@ -384,35 +335,18 @@ include
                                                         'sqlgg__params,
                                                         'sqlgg__cols)
                                                         product_cols
-    let nested_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~product:(sqlgg__c_product :
-                 (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                   Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_product = sqlgg__c_product in
-         ({ id = sqlgg__v_id; product = sqlgg__v_product } : nested) : 
-      (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
-    let _ = nested_of_cols_gen
     let nested_of_cols
       (sqlgg__cols :
         <
           id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                 Sqlgg_scope.col   ;.. > )
       =
-      (nested_of_cols_gen ~id:(sqlgg__cols#id)
-         ~product:(product_of_cols sqlgg__cols) : (nested, 'sqlgg__brand,
-                                                    'sqlgg__row,
-                                                    'sqlgg__params)
-                                                    Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_cols sqlgg__cols in
+         ({ id = sqlgg__v_id; product = sqlgg__v_product } : nested) : 
+      (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col)
     let _ = nested_of_cols
-    let nested_apply sqlgg__f (sqlgg__r : nested) =
-      product_apply (sqlgg__f ~id:(sqlgg__r.id)) sqlgg__r.product
-    let _ = nested_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type nested_qualified = {
   id: int64 ;
@@ -432,37 +366,258 @@ include
                                                         'sqlgg__params,
                                                         'sqlgg__cols)
                                                         Feed.channel_cols
-    let nested_qualified_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~channel:(sqlgg__c_channel :
-                 (Feed.channel, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                   Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_channel = sqlgg__c_channel in
-         ({ id = sqlgg__v_id; channel = sqlgg__v_channel } : nested_qualified) : 
-      (nested_qualified, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-        Sqlgg_scope.col)
-    let _ = nested_qualified_of_cols_gen
     let nested_qualified_of_cols
       (sqlgg__cols :
         <
           id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                 Sqlgg_scope.col   ;.. > )
       =
-      (nested_qualified_of_cols_gen ~id:(sqlgg__cols#id)
-         ~channel:(Feed.channel_of_cols sqlgg__cols) : (nested_qualified,
-                                                         'sqlgg__brand,
-                                                         'sqlgg__row,
-                                                         'sqlgg__params)
-                                                         Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_channel = Feed.channel_of_cols sqlgg__cols in
+         ({ id = sqlgg__v_id; channel = sqlgg__v_channel } : nested_qualified) : 
+      (nested_qualified, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
     let _ = nested_qualified_of_cols
-    let nested_qualified_apply sqlgg__f (sqlgg__r : nested_qualified) =
-      Feed.channel_apply (sqlgg__f ~id:(sqlgg__r.id)) sqlgg__r.channel
-    let _ = nested_qualified_apply
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type optional_relation =
+  {
+  id: int64 ;
+  product: product option [@sqlgg.nested ]}[@@deriving sqlgg ~nullable_cols]
+include
+  struct
+    let _ = fun (_ : optional_relation) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) optional_relation_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        product_nullable_cols
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) optional_relation_nullable_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64 option, 'sqlgg__brand, 'sqlgg__row,
+                            'sqlgg__params) Sqlgg_scope.col   ;.. > 
+                                                                    constraint
+                                                                    'sqlgg__cols
+                                                                    =
+                                                                    ('sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params,
+                                                                    'sqlgg__cols)
+                                                                    product_nullable_cols
+    let optional_relation_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_nullable_cols_exn sqlgg__cols in
+         ({ id = sqlgg__v_id; product = sqlgg__v_product } : optional_relation) : 
+      (optional_relation, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = optional_relation_of_cols
+    let optional_relation_of_nullable_cols
+      (sqlgg__cols :
+        <
+          id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_nullable_cols sqlgg__cols in
+         Stdlib.Option.bind sqlgg__v_id
+           (fun sqlgg__v_id ->
+              Some
+                ({ id = sqlgg__v_id; product = sqlgg__v_product } : optional_relation)) : 
+      (optional_relation option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = optional_relation_of_nullable_cols
+    let optional_relation_of_nullable_cols_exn
+      (sqlgg__cols :
+        <
+          id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_nullable_cols_exn sqlgg__cols in
+         match (sqlgg__v_id, sqlgg__v_product) with
+         | (Some sqlgg__v_id, _) ->
+             Some
+               ({ id = sqlgg__v_id; product = sqlgg__v_product } : optional_relation)
+         | (None, None) -> None
+         | (None, _) -> failwith "sqlgg: optional_relation.id is NULL" : 
+      (optional_relation option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = optional_relation_of_nullable_cols_exn
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type relation_qualified =
+  {
+  id: int64 ;
+  channel: Feed.channel option [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : relation_qualified) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) relation_qualified_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        Feed.channel_nullable_cols
+    let relation_qualified_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_channel =
+           Feed.channel_of_nullable_cols_exn sqlgg__cols in
+         ({ id = sqlgg__v_id; channel = sqlgg__v_channel } : relation_qualified) : 
+      (relation_qualified, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = relation_qualified_of_cols
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type relation_and_conversions =
+  {
+  id: int64 ;
+  product: product option [@sqlgg.nested ];
+  reply_count: int [@sqlgg.map Int64.to_int];
+  hits: int [@sqlgg.default 0]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : relation_and_conversions) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) relation_and_conversions_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                             'sqlgg__brand,
+                                                             'sqlgg__row,
+                                                             'sqlgg__params)
+                                                             Sqlgg_scope.col  ;
+                      hits: (int option, 'sqlgg__brand, 'sqlgg__row,
+                              'sqlgg__params) Sqlgg_scope.col   ;.. > 
+       constraint 'sqlgg__cols =
+        ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+          product_nullable_cols
+    let relation_and_conversions_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                 'sqlgg__brand, 'sqlgg__row,
+                                                 'sqlgg__params)
+                                                 Sqlgg_scope.col  ;hits: 
+                                                                    (int
+                                                                    option,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col
+                                                                      ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_nullable_cols_exn sqlgg__cols
+         and+ sqlgg__v_reply_count = sqlgg__cols#reply_count
+         and+ sqlgg__v_hits = sqlgg__cols#hits in
+         ({
+            id = sqlgg__v_id;
+            product = sqlgg__v_product;
+            reply_count = (Int64.to_int sqlgg__v_reply_count);
+            hits = ((Stdlib.Option.value ~default:0) sqlgg__v_hits)
+          } : relation_and_conversions) : (relation_and_conversions,
+                                            'sqlgg__brand, 'sqlgg__row,
+                                            'sqlgg__params) Sqlgg_scope.col)
+    let _ = relation_and_conversions_of_cols
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type all_option = {
+  note: string option ;
+  tag: string option }[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : all_option) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) all_option_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      note: (string option, 'sqlgg__brand, 'sqlgg__row,
+                              'sqlgg__params) Sqlgg_scope.col  ;tag: 
+                                                                  (string
+                                                                    option,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col
+                                                                    ;.. > 
+    let all_option_of_cols
+      (sqlgg__cols :
+        <
+          note: (string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                  Sqlgg_scope.col  ;tag: (string option, 'sqlgg__brand,
+                                           'sqlgg__row, 'sqlgg__params)
+                                           Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_note = sqlgg__cols#note
+         and+ sqlgg__v_tag = sqlgg__cols#tag in
+         ({ note = sqlgg__v_note; tag = sqlgg__v_tag } : all_option) : 
+      (all_option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = all_option_of_cols
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type opaque_conversions =
+  {
+  id: int64 ;
+  note: string option [@sqlgg.map Fun.id];
+  tag: int option [@sqlgg.by ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : opaque_conversions) -> ()
+    let opaque_conversions_of_cols ~tag:sqlgg__conv_tag
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col  ;note: ('sqlgg__raw_note, 'sqlgg__brand,
+                                          'sqlgg__row, 'sqlgg__params)
+                                          Sqlgg_scope.col  ;tag: ('sqlgg__raw_tag,
+                                                                   'sqlgg__brand,
+                                                                   'sqlgg__row,
+                                                                   'sqlgg__params)
+                                                                   Sqlgg_scope.col
+                                                                ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_note = sqlgg__cols#note
+         and+ sqlgg__v_tag = sqlgg__cols#tag in
+         ({
+            id = sqlgg__v_id;
+            note = (Fun.id sqlgg__v_note);
+            tag = (sqlgg__conv_tag sqlgg__v_tag)
+          } : opaque_conversions) : (opaque_conversions, 'sqlgg__brand,
+                                      'sqlgg__row, 'sqlgg__params)
+                                      Sqlgg_scope.col)
+    let _ = opaque_conversions_of_cols
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t = {
   id: int64 ;
@@ -479,23 +634,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    let of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      ~label:(sqlgg__c_label :
-               (string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-                 Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-         and+ sqlgg__v_label = sqlgg__c_label in
-         ({ id = sqlgg__v_id; label = sqlgg__v_label } : t) : (t,
-                                                                'sqlgg__brand,
-                                                                'sqlgg__row,
-                                                                'sqlgg__params)
-                                                                Sqlgg_scope.col)
-    let _ = of_cols_gen
     let of_cols
       (sqlgg__cols :
         <
@@ -504,15 +642,15 @@ include
                                           'sqlgg__params) Sqlgg_scope.col   ;..
           > )
       =
-      (of_cols_gen ~id:(sqlgg__cols#id) ~label:(sqlgg__cols#name) : (t,
-                                                                    'sqlgg__brand,
-                                                                    'sqlgg__row,
-                                                                    'sqlgg__params)
-                                                                    Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_label = sqlgg__cols#name in
+         ({ id = sqlgg__v_id; label = sqlgg__v_label } : t) : (t,
+                                                                'sqlgg__brand,
+                                                                'sqlgg__row,
+                                                                'sqlgg__params)
+                                                                Sqlgg_scope.col)
     let _ = of_cols
-    let apply sqlgg__f (sqlgg__r : t) =
-      sqlgg__f ~id:(sqlgg__r.id) ~name:(sqlgg__r.label)
-    let _ = apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type variant =
   | A 
@@ -528,4 +666,186 @@ include
   struct
     let _ = fun (_ : 'a parameterised) -> ()
     [%%ocaml.error "deriving sqlgg: type parameters are not supported"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type default_none_relation =
+  {
+  id: int64 ;
+  product: product option [@sqlgg.nested default_none]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : default_none_relation) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) default_none_relation_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        product_nullable_cols
+    let default_none_relation_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_product = product_of_nullable_cols sqlgg__cols in
+         ({ id = sqlgg__v_id; product = sqlgg__v_product } : default_none_relation) : 
+      (default_none_relation, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = default_none_relation_of_cols
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_nested = {
+  a: int64 ;
+  product: product [@sqlgg.nested ]}[@@deriving sqlgg ~nullable_cols]
+include
+  struct
+    let _ = fun (_ : with_nested) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_nested_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      a: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                           Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols =
+                                                     ('sqlgg__brand,
+                                                       'sqlgg__row,
+                                                       'sqlgg__params,
+                                                       'sqlgg__cols)
+                                                       product_cols
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_nested_nullable_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      a: (int64 option, 'sqlgg__brand, 'sqlgg__row,
+                           'sqlgg__params) Sqlgg_scope.col   ;.. > 
+                                                                    constraint
+                                                                    'sqlgg__cols
+                                                                    =
+                                                                    ('sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params,
+                                                                    'sqlgg__cols)
+                                                                    product_nullable_cols
+    let with_nested_of_cols
+      (sqlgg__cols :
+        <
+          a: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+               Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_a = sqlgg__cols#a
+         and+ sqlgg__v_product = product_of_cols sqlgg__cols in
+         ({ a = sqlgg__v_a; product = sqlgg__v_product } : with_nested) : 
+      (with_nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = with_nested_of_cols
+    let with_nested_of_nullable_cols
+      (sqlgg__cols :
+        <
+          a: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+               Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_a = sqlgg__cols#a
+         and+ sqlgg__v_product = product_of_nullable_cols sqlgg__cols in
+         Stdlib.Option.bind sqlgg__v_a
+           (fun sqlgg__v_a ->
+              Stdlib.Option.bind sqlgg__v_product
+                (fun sqlgg__v_product ->
+                   Some
+                     ({ a = sqlgg__v_a; product = sqlgg__v_product } : 
+                     with_nested))) : (with_nested option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col)
+    let _ = with_nested_of_nullable_cols
+    let with_nested_of_nullable_cols_exn
+      (sqlgg__cols :
+        <
+          a: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+               Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_a = sqlgg__cols#a
+         and+ sqlgg__v_product = product_of_nullable_cols sqlgg__cols in
+         match (sqlgg__v_a, sqlgg__v_product) with
+         | (Some sqlgg__v_a, Some sqlgg__v_product) ->
+             Some
+               ({ a = sqlgg__v_a; product = sqlgg__v_product } : with_nested)
+         | (None, None) -> None
+         | (None, _) -> failwith "sqlgg: with_nested.a is NULL"
+         | (_, None) -> failwith "sqlgg: with_nested.product is NULL" : 
+      (with_nested option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = with_nested_of_nullable_cols_exn
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_in_relation =
+  {
+  id: int64 ;
+  inner: with_nested option [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_in_relation) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) nested_in_relation_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        with_nested_nullable_cols
+    let nested_in_relation_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_inner = with_nested_of_nullable_cols_exn sqlgg__cols in
+         ({ id = sqlgg__v_id; inner = sqlgg__v_inner } : nested_in_relation) : 
+      (nested_in_relation, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = nested_in_relation_of_cols
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type chains_to_optional =
+  {
+  id: int64 ;
+  rel: optional_relation [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : chains_to_optional) -> ()
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) chains_to_optional_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        optional_relation_cols
+    let chains_to_optional_of_cols
+      (sqlgg__cols :
+        <
+          id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > )
+      =
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+         and+ sqlgg__v_rel = optional_relation_of_cols sqlgg__cols in
+         ({ id = sqlgg__v_id; rel = sqlgg__v_rel } : chains_to_optional) : 
+      (chains_to_optional, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+        Sqlgg_scope.col)
+    let _ = chains_to_optional_of_cols
   end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/cases.input.ml
+++ b/test/ppx_expansion/cases.input.ml
@@ -1,4 +1,4 @@
-type product = { id : int64; name : string option } [@@deriving sqlgg]
+type product = { id : int64; name : string option } [@@deriving sqlgg ~nullable_cols]
 
 type renamed = { id : int64; productName : string option [@sqlgg.col "name"] }
 [@@deriving sqlgg]
@@ -20,7 +20,7 @@ type deferred_with_default = {
 type with_default = { id : int64; hits : int [@sqlgg.default 0] }
 [@@deriving sqlgg]
 
-type trimmed = { id : int64; name : string [@sqlgg.set String.trim] }
+type trimmed = { id : int64; name : string }
 [@@deriving sqlgg]
 
 type nested = { id : int64; product : product [@sqlgg.nested] } [@@deriving sqlgg]
@@ -28,8 +28,52 @@ type nested = { id : int64; product : product [@sqlgg.nested] } [@@deriving sqlg
 type nested_qualified = { id : int64; channel : Feed.channel [@sqlgg.nested] }
 [@@deriving sqlgg]
 
+type optional_relation = { id : int64; product : product option [@sqlgg.nested] }
+[@@deriving sqlgg ~nullable_cols]
+
+type relation_qualified = {
+  id : int64;
+  channel : Feed.channel option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type relation_and_conversions = {
+  id : int64;
+  product : product option; [@sqlgg.nested]
+  reply_count : int; [@sqlgg.map Int64.to_int]
+  hits : int; [@sqlgg.default 0]
+}
+[@@deriving sqlgg]
+
+type all_option = { note : string option; tag : string option } [@@deriving sqlgg]
+
+type opaque_conversions = {
+  id : int64;
+  note : string option; [@sqlgg.map Fun.id]
+  tag : int option; [@sqlgg.by]
+}
+[@@deriving sqlgg]
+
 type t = { id : int64; label : string [@sqlgg.col "name"] } [@@deriving sqlgg]
 
 type variant = A | B [@@deriving sqlgg]
 
 type 'a parameterised = { id : 'a } [@@deriving sqlgg]
+
+type default_none_relation = {
+  id : int64;
+  product : product option; [@sqlgg.nested default_none]
+}
+[@@deriving sqlgg]
+
+type with_nested = { a : int64; product : product [@sqlgg.nested] }
+[@@deriving sqlgg ~nullable_cols]
+
+type nested_in_relation = {
+  id : int64;
+  inner : with_nested option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type chains_to_optional = { id : int64; rel : optional_relation [@sqlgg.nested] }
+[@@deriving sqlgg]

--- a/test/ppx_expansion/errors.expected.ml
+++ b/test/ppx_expansion/errors.expected.ml
@@ -9,32 +9,19 @@ include
                     <
                       id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                             Sqlgg_scope.col   ;.. > 
-    let product_of_cols_gen
-      ~id:(sqlgg__c_id :
-            (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-              Sqlgg_scope.col)
-      =
-      (let open Sqlgg_scope in
-         let+ sqlgg__v_id = sqlgg__c_id
-          in ({ id = sqlgg__v_id } : product) : (product, 'sqlgg__brand,
-                                                  'sqlgg__row,
-                                                  'sqlgg__params)
-                                                  Sqlgg_scope.col)
-    let _ = product_of_cols_gen
     let product_of_cols
       (sqlgg__cols :
         <
           id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                 Sqlgg_scope.col   ;.. > )
       =
-      (product_of_cols_gen ~id:(sqlgg__cols#id) : (product, 'sqlgg__brand,
-                                                    'sqlgg__row,
-                                                    'sqlgg__params)
-                                                    Sqlgg_scope.col)
+      (let open Sqlgg_scope in
+         let+ sqlgg__v_id = sqlgg__cols#id
+          in ({ id = sqlgg__v_id } : product) : (product, 'sqlgg__brand,
+                                                  'sqlgg__row,
+                                                  'sqlgg__params)
+                                                  Sqlgg_scope.col)
     let _ = product_of_cols
-    let product_apply sqlgg__f (sqlgg__r : product) =
-      sqlgg__f ~id:(sqlgg__r.id)
-    let _ = product_apply
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type map_and_default =
   {
@@ -70,4 +57,41 @@ include
     let _ = fun (_ : nested_not_a_record) -> ()
     [%%ocaml.error
       "deriving sqlgg: field dimensions: [@sqlgg.nested] needs a record type deriving sqlgg"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_option_not_a_record =
+  {
+  dimensions: (int64 * int64) option [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_option_not_a_record) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field dimensions: [@sqlgg.nested] needs a record type deriving sqlgg"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_option_and_col =
+  {
+  product: product option [@sqlgg.nested ][@sqlgg.col "product_id"]}[@@deriving
+                                                                    sqlgg]
+include
+  struct
+    let _ = fun (_ : nested_option_and_col) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field product: [@sqlgg.nested] cannot be combined with [@sqlgg.col]"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type default_none_needs_option =
+  {
+  product: product [@sqlgg.nested default_none]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : default_none_needs_option) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field product: [@sqlgg.nested default_none] needs an option field"]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type map_without_a_function = {
+  id: int64 ;
+  n: int [@sqlgg.map : int64 -> int]}[@@deriving sqlgg]
+include
+  struct
+    let _ = fun (_ : map_without_a_function) -> ()
+    [%%ocaml.error
+      "deriving sqlgg: field n: [@sqlgg.map]: expected a conversion function"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/errors.input.ml
+++ b/test/ppx_expansion/errors.input.ml
@@ -15,3 +15,24 @@ type nested_and_col = {
 
 type nested_not_a_record = { dimensions : int64 * int64 [@sqlgg.nested] }
 [@@deriving sqlgg]
+
+type nested_option_not_a_record = {
+  dimensions : (int64 * int64) option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type nested_option_and_col = {
+  product : product option; [@sqlgg.nested] [@sqlgg.col "product_id"]
+}
+[@@deriving sqlgg]
+
+type default_none_needs_option = {
+  product : product; [@sqlgg.nested default_none]
+}
+[@@deriving sqlgg]
+
+type map_without_a_function = {
+  id : int64;
+  n : int; [@sqlgg.map : int64 -> int]
+}
+[@@deriving sqlgg]

--- a/test/ppx_expansion/sig.expected.mli
+++ b/test/ppx_expansion/sig.expected.mli
@@ -1,6 +1,6 @@
 type product = {
   id: int64 ;
-  name: string option }[@@deriving sqlgg]
+  name: string option }[@@deriving sqlgg ~nullable_cols]
 include
   sig
     [@@@ocaml.warning "-32"]
@@ -15,13 +15,18 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    val product_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        name:(string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) product_nullable_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64 option, 'sqlgg__brand, 'sqlgg__row,
+                            'sqlgg__params) Sqlgg_scope.col  ;name: (string
+                                                                    option,
+                                                                    'sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params)
+                                                                    Sqlgg_scope.col
+                                                                  ;.. > 
     val product_of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
@@ -30,9 +35,24 @@ include
                                         Sqlgg_scope.col   ;.. > 
         ->
         (product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-    val product_apply :
-      (id:int64 -> name:string option -> 'sqlgg__res) ->
-        product -> 'sqlgg__res
+    val product_of_nullable_cols :
+      <
+        id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col   ;.. > 
+        ->
+        (product option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+    val product_of_nullable_cols_exn :
+      <
+        id: (int64 option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+              Sqlgg_scope.col  ;name: (string option, 'sqlgg__brand,
+                                        'sqlgg__row, 'sqlgg__params)
+                                        Sqlgg_scope.col   ;.. > 
+        ->
+        (product option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type renamed = {
   id: int64 ;
@@ -51,13 +71,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    val renamed_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        productName:(string option, 'sqlgg__brand, 'sqlgg__row,
-          'sqlgg__params) Sqlgg_scope.col ->
-          (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
     val renamed_of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
@@ -66,9 +79,6 @@ include
                                         Sqlgg_scope.col   ;.. > 
         ->
         (renamed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-    val renamed_apply :
-      (id:int64 -> name:string option -> 'sqlgg__res) ->
-        renamed -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type with_default = {
   id: int64 ;
@@ -87,13 +97,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    val with_default_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        hits:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
     val with_default_of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
@@ -103,8 +106,6 @@ include
         ->
         (with_default, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
           Sqlgg_scope.col
-    val with_default_apply :
-      (id:int64 -> hits:int -> 'sqlgg__res) -> with_default -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type deferred = {
   id: int64 ;
@@ -112,13 +113,6 @@ type deferred = {
 include
   sig
     [@@@ocaml.warning "-32"]
-    val deferred_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        reply_count:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
     val deferred_of_cols :
       reply_count:('sqlgg__raw_reply_count -> int) ->
         <
@@ -130,8 +124,6 @@ include
           ->
           (deferred, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
             Sqlgg_scope.col
-    val deferred_apply :
-      (id:int64 -> reply_count:int -> 'sqlgg__res) -> deferred -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type t = {
   id: int64 }[@@deriving sqlgg]
@@ -143,15 +135,11 @@ include
                     <
                       id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
                             Sqlgg_scope.col   ;.. > 
-    val of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        -> (t, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
     val of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
               Sqlgg_scope.col   ;.. > 
         -> (t, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-    val apply : (id:int64 -> 'sqlgg__res) -> t -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type converted = {
   id: int64 ;
@@ -159,13 +147,17 @@ type converted = {
 include
   sig
     [@@@ocaml.warning "-32"]
-    val converted_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        reply_count:(int, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) converted_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col  ;reply_count: ('sqlgg__raw_reply_count,
+                                                             'sqlgg__brand,
+                                                             'sqlgg__row,
+                                                             'sqlgg__params)
+                                                             Sqlgg_scope.col   ;..
+                      > 
     val converted_of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
@@ -175,13 +167,10 @@ include
         ->
         (converted, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
           Sqlgg_scope.col
-    val converted_apply :
-      (id:int64 -> reply_count:int -> 'sqlgg__res) ->
-        converted -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type trimmed = {
   id: int64 ;
-  name: string [@sqlgg.set : string]}[@@deriving sqlgg]
+  name: string }[@@deriving sqlgg]
 include
   sig
     [@@@ocaml.warning "-32"]
@@ -195,13 +184,6 @@ include
                                                       'sqlgg__params)
                                                       Sqlgg_scope.col   ;..
                       > 
-    val trimmed_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        name:(string, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
     val trimmed_of_cols :
       <
         id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
@@ -209,8 +191,6 @@ include
                                         'sqlgg__params) Sqlgg_scope.col   ;..
         >  ->
         (trimmed, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-    val trimmed_apply :
-      (id:int64 -> name:string -> 'sqlgg__res) -> trimmed -> 'sqlgg__res
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type map_without_a_type = {
   id: int64 ;
@@ -239,15 +219,135 @@ include
                                                         'sqlgg__params,
                                                         'sqlgg__cols)
                                                         product_cols
-    val nested_of_cols_gen :
-      id:(int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
-        ->
-        product:(product, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-          Sqlgg_scope.col ->
-          (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
-            Sqlgg_scope.col
     val nested_of_cols :
       ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols) nested_cols
         ->
         (nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params) Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type optional_relation =
+  {
+  id: int64 ;
+  product: product option [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) optional_relation_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        product_nullable_cols
+    val optional_relation_of_cols :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+        optional_relation_cols ->
+        (optional_relation, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type all_option = {
+  note: string option }[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) all_option_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      note: (string option, 'sqlgg__brand, 'sqlgg__row,
+                              'sqlgg__params) Sqlgg_scope.col   ;.. > 
+    val all_option_of_cols :
+      <
+        note: (string option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                Sqlgg_scope.col   ;.. > 
+        ->
+        (all_option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type with_nested = {
+  a: int64 ;
+  product: product [@sqlgg.nested ]}[@@deriving sqlgg ~nullable_cols]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_nested_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      a: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                           Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols =
+                                                     ('sqlgg__brand,
+                                                       'sqlgg__row,
+                                                       'sqlgg__params,
+                                                       'sqlgg__cols)
+                                                       product_cols
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) with_nested_nullable_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      a: (int64 option, 'sqlgg__brand, 'sqlgg__row,
+                           'sqlgg__params) Sqlgg_scope.col   ;.. > 
+                                                                    constraint
+                                                                    'sqlgg__cols
+                                                                    =
+                                                                    ('sqlgg__brand,
+                                                                    'sqlgg__row,
+                                                                    'sqlgg__params,
+                                                                    'sqlgg__cols)
+                                                                    product_nullable_cols
+    val with_nested_of_cols :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+        with_nested_cols ->
+        (with_nested, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+    val with_nested_of_nullable_cols :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+        with_nested_nullable_cols ->
+        (with_nested option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+    val with_nested_of_nullable_cols_exn :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+        with_nested_nullable_cols ->
+        (with_nested option, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type nested_in_relation =
+  {
+  id: int64 ;
+  inner: with_nested option [@sqlgg.nested ]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    type ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params,
+      'sqlgg__cols) nested_in_relation_cols =
+      'sqlgg__cols constraint 'sqlgg__cols =
+                    <
+                      id: (int64, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+                            Sqlgg_scope.col   ;.. >  constraint 'sqlgg__cols
+                                                      =
+                                                      ('sqlgg__brand,
+                                                        'sqlgg__row,
+                                                        'sqlgg__params,
+                                                        'sqlgg__cols)
+                                                        with_nested_nullable_cols
+    val nested_in_relation_of_cols :
+      ('sqlgg__brand, 'sqlgg__row, 'sqlgg__params, 'sqlgg__cols)
+        nested_in_relation_cols ->
+        (nested_in_relation, 'sqlgg__brand, 'sqlgg__row, 'sqlgg__params)
+          Sqlgg_scope.col
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type relation_and_conversions =
+  {
+  id: int64 ;
+  product: product option [@sqlgg.nested ];
+  reply_count: int [@sqlgg.by ]}[@@deriving sqlgg]
+include
+  sig
+    [@@@ocaml.warning "-32"]
+    [%%ocaml.error
+      "deriving sqlgg: [@sqlgg.nested] needs relation_and_conversions_cols, and the parent cannot pass the [@sqlgg.by] argument"]
   end[@@ocaml.doc "@inline"][@@merlin.hide ]

--- a/test/ppx_expansion/sig.input.mli
+++ b/test/ppx_expansion/sig.input.mli
@@ -1,4 +1,4 @@
-type product = { id : int64; name : string option } [@@deriving sqlgg]
+type product = { id : int64; name : string option } [@@deriving sqlgg ~nullable_cols]
 
 type renamed = { id : int64; productName : string option [@sqlgg.col "name"] }
 [@@deriving sqlgg]
@@ -13,11 +13,32 @@ type t = { id : int64 } [@@deriving sqlgg]
 type converted = { id : int64; reply_count : int [@sqlgg.map: int64] }
 [@@deriving sqlgg]
 
-type trimmed = { id : int64; name : string [@sqlgg.set: string] }
+type trimmed = { id : int64; name : string }
 [@@deriving sqlgg]
 
 type map_without_a_type = { id : int64; n : int [@sqlgg.map Int64.to_int] }
 [@@deriving sqlgg]
 
 type nested = { id : int64; product : product [@sqlgg.nested] }
+[@@deriving sqlgg]
+
+type optional_relation = { id : int64; product : product option [@sqlgg.nested] }
+[@@deriving sqlgg]
+
+type all_option = { note : string option } [@@deriving sqlgg]
+
+type with_nested = { a : int64; product : product [@sqlgg.nested] }
+[@@deriving sqlgg ~nullable_cols]
+
+type nested_in_relation = {
+  id : int64;
+  inner : with_nested option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+type relation_and_conversions = {
+  id : int64;
+  product : product option; [@sqlgg.nested]
+  reply_count : int; [@sqlgg.by]
+}
 [@@deriving sqlgg]

--- a/test/ppx_expansion/unit/dune
+++ b/test/ppx_expansion/unit/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_readers)
+ (libraries oUnit sqlgg.traits)
+ (preprocess (pps sqlgg.ppx)))

--- a/test/ppx_expansion/unit/test_readers.ml
+++ b/test/ppx_expansion/unit/test_readers.ml
@@ -1,0 +1,158 @@
+open OUnit
+
+type voter = { vid : int64; note : string option } [@@deriving sqlgg ~nullable_cols]
+
+type single = { only : int64 } [@@deriving sqlgg ~nullable_cols]
+
+type quiet = { qid : int64; hush : string option [@sqlgg.map Fun.id] }
+[@@deriving sqlgg ~nullable_cols]
+
+type counted = {
+  kid : int; [@sqlgg.col "k_id"] [@sqlgg.map Int64.to_int]
+  seen : int; [@sqlgg.by] [@sqlgg.map Int64.to_int]
+  tag : string; [@sqlgg.col "t"] [@sqlgg.default "none"]
+}
+[@@deriving sqlgg ~nullable_cols]
+
+type holder = { hid : int64; counted : counted option [@sqlgg.nested] }
+[@@deriving sqlgg]
+
+type open_conv = { oid : int64; n : int [@sqlgg.by] }
+[@@deriving sqlgg ~nullable_cols]
+
+type joined = { jid : int64; voter : voter option [@sqlgg.nested] } [@@deriving sqlgg]
+
+type joined_lax = { jid : int64; voter : voter option [@sqlgg.nested default_none] }
+[@@deriving sqlgg]
+
+type alone = { aid : int64; single : single option [@sqlgg.nested] } [@@deriving sqlgg]
+
+type both = {
+  bid : int64;
+  voter : voter option; [@sqlgg.nested]
+  single : single option; [@sqlgg.nested]
+}
+[@@deriving sqlgg]
+
+let col v =
+  { Sqlgg_scope.set = (fun () -> ())
+  ; read = (fun () i -> v, i + 1)
+  ; column = "c"
+  ; count = 0
+  ; deps = []
+  }
+
+let read c = fst (c.Sqlgg_scope.read () 0)
+
+let cols ~vid ~note ~only =
+  object
+    method jid = col 1L
+    method aid = col 1L
+    method bid = col 1L
+    method vid = col vid
+    method note = col note
+    method only = col only
+  end
+
+let quiet_cols ~qid ~hush =
+  object
+    method qid = col qid
+    method hush = col hush
+  end
+
+let counted_cols ~kid ~seen ~tag =
+  object
+    method hid = col 1L
+    method k_id = col kid
+    method seen = col seen
+    method t = col tag
+  end
+
+let open_conv_cols ~oid ~n =
+  object
+    method oid = col oid
+    method n = col n
+  end
+
+let voter = function
+  | None -> "none"
+  | Some v -> Printf.sprintf "%Ld/%s" v.vid (Stdlib.Option.value v.note ~default:"-")
+
+let single = function None -> "none" | Some s -> Int64.to_string s.only
+
+let nested c = voter (read (joined_of_cols c)).voter
+let default_none c = voter (read (joined_lax_of_cols c)).voter
+let one c = single (read (alone_of_cols c)).single
+
+let hushed c =
+  match read (quiet_of_nullable_cols_exn c) with
+  | None -> "none"
+  | Some q -> Printf.sprintf "%Ld/%s" q.qid (Stdlib.Option.value q.hush ~default:"-")
+
+let counted c =
+  match (read (holder_of_cols c)).counted with
+  | None -> "none"
+  | Some c -> Printf.sprintf "%d/%d/%s" c.kid c.seen c.tag
+
+let open_conv c =
+  match read (open_conv_of_nullable_cols_exn ~n:Int64.to_int c) with
+  | None -> "none"
+  | Some r -> Printf.sprintf "%Ld/%d" r.oid r.n
+
+let side_by_side c =
+  let r = read (both_of_cols c) in
+  voter r.voter ^ " " ^ single r.single
+
+let case name got want =
+  name >:: fun () ->
+  let outcome = try got () with Failure w -> "raises " ^ w in
+  assert_equal ~printer:(fun s -> s) want outcome
+
+let suite =
+  "relation readers"
+  >::: [ case "an optional column proves the relation"
+           (fun () -> nested (cols ~vid:None ~note:(Some "x") ~only:None))
+           "raises sqlgg: voter.vid is NULL"
+       ; case "an optional column proves it, lax"
+           (fun () -> default_none (cols ~vid:None ~note:(Some "x") ~only:None))
+           "none"
+       ; case "a converted column does not prove it"
+           (fun () -> hushed (quiet_cols ~qid:None ~hush:(Some "x")))
+           "none"
+       ; case "an optional column may be absent"
+           (fun () -> nested (cols ~vid:(Some 5L) ~note:None ~only:None))
+           "5/-"
+       ; case "an open conversion reads on its own"
+           (fun () -> open_conv (open_conv_cols ~oid:(Some 4L) ~n:(Some 9L)))
+           "4/9"
+       ; case "an open conversion, relation absent"
+           (fun () -> open_conv (open_conv_cols ~oid:None ~n:None))
+           "none"
+       ; case "col, map, by and default together"
+           (fun () ->
+             counted (counted_cols ~kid:(Some 10L) ~seen:(Some 3L) ~tag:(Some "x")))
+           "10/3/x"
+       ; case "the default fills in"
+           (fun () -> counted (counted_cols ~kid:(Some 10L) ~seen:(Some 3L) ~tag:None))
+           "10/3/none"
+       ; case "converted columns are witnesses"
+           (fun () -> counted (counted_cols ~kid:None ~seen:(Some 3L) ~tag:None))
+           "raises sqlgg: counted.kid is NULL"
+       ; case "a converted relation can be absent"
+           (fun () -> counted (counted_cols ~kid:None ~seen:None ~tag:None))
+           "none"
+       ; case "the only column is the witness"
+           (fun () -> one (cols ~vid:None ~note:None ~only:(Some 7L)))
+           "7"
+       ; case "the only column is NULL"
+           (fun () -> one (cols ~vid:None ~note:None ~only:None))
+           "none"
+       ; case "relations stand on their own"
+           (fun () -> side_by_side (cols ~vid:(Some 5L) ~note:None ~only:None))
+           "5/- none"
+       ; case "both relations absent"
+           (fun () -> side_by_side (cols ~vid:None ~note:None ~only:None))
+           "none none"
+       ]
+
+let () = ignore (run_test_tt_main suite)


### PR DESCRIPTION
### Description

This PR puts a joined table into one field of the record, so where a LEFT JOIN used to give you an `option` on every column, now only that one field is an `option`

```sql
CREATE TABLE posts    (id INT NOT NULL PRIMARY KEY, body TEXT NULL, channel_id INT NULL);
CREATE TABLE channels (channel_id INT NOT NULL PRIMARY KEY, channel_name TEXT NOT NULL,
                       image_url TEXT NULL, owner_id INT NULL);
CREATE TABLE owners   (owner_id INT NOT NULL PRIMARY KEY, owner_name TEXT NOT NULL);

-- [sqlgg] dynamic_select=true
-- @feed
SELECT p.id, p.body, c.channel_id, c.channel_name, c.image_url
FROM posts p LEFT JOIN channels c ON c.channel_id = p.channel_id
WHERE p.id > @min_id;
```

`[@sqlgg.nested]` already exists, but it does not accept an `option` field

```ocaml
type channel = { channel_id : int64; channel_name : string } [@@deriving sqlgg]

type post = { id : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]
(* Error: deriving sqlgg: field channel: [@sqlgg.nested] needs a record type deriving sqlgg *)
```

so you map the row yourself

```ocaml
type row = {
  id : int64;
  body : string option;
  channel_id : int64 option;
  channel_name : string option;
  image_url : string option;
}
[@@deriving sqlgg]

type channel = { channel_id : int64; channel_name : string; image_url : string option }
(* no [@@deriving sqlgg] here *)

type post = { id : int64; body : string option; channel : channel option }
(* and no [@sqlgg.nested] on the field, it would not compile *)

let post_of_row (r : row) =
  let channel =
    match r.channel_id, r.channel_name, r.image_url with
    | Some channel_id, Some channel_name, image_url ->
      Some { channel_id; channel_name; image_url }
    | None, None, None -> None
    | None, _, _ -> failwith "sqlgg: channel.channel_id is NULL"
    | _, None, _ -> failwith "sqlgg: channel.channel_name is NULL"
  in
  { id = r.id; body = r.body; channel }

let () =
  let open Db.Feed in
  List.map post_of_row (List.select () (row_of_cols cols) ~min_id:0L)
```

and now

```ocaml
type channel = {
  channel_id : int64;
  channel_name : string;
  image_url : string option;
}
[@@deriving sqlgg ~nullable_cols]

type post = {
  id : int64;
  body : string option;
  channel : channel option; [@sqlgg.nested]
}
[@@deriving sqlgg]

let () =
  let open Db.Feed in
  List.select () (post_of_cols cols) ~min_id:0L
```

If a NULL turns up where it cannot be, this raises, and `default_none` below is the reader that gives `None` instead

#### `~nullable_cols`

This flag generates the reader that a `record option` field calls

```ocaml
type channel = { channel_id : int64; channel_name : string } [@@deriving sqlgg]

type post = { id : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]
(* Error: Unbound type constructor "channel_nullable_cols" *)
```

The record also needs one field that cannot be NULL

```ocaml
type channel = { channel_name : string option; image_url : string option }
[@@deriving sqlgg ~nullable_cols]

type post = { id : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]
(* Error: ... but an expression was expected of type "channel_needs_a_strict_column" *)
```

#### `[@sqlgg.nested default_none]`

Reads the same, but a broken row gives `None`, and it goes all the way down the tree

```ocaml
type post_lax = {
  id : int64;
  body : string option;
  channel : channel option; [@sqlgg.nested default_none]
}
[@@deriving sqlgg]
```

```ocaml
(* id=1 body="hi" channel_id=10 channel_name=NULL image_url=NULL *)
None
```

#### Other attributes inside a relation

They all compose inside a relation

```ocaml
type channel = {
  id : int; [@sqlgg.col "channel_id"] [@sqlgg.map Int64.to_int]
  seen : int; [@sqlgg.by] [@sqlgg.map Int64.to_int]
  image : string; [@sqlgg.col "image_url"] [@sqlgg.default "none"]
}
[@@deriving sqlgg ~nullable_cols]

type post = { pid : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]
```

`[@sqlgg.by]` without a conversion is the one that does not nest

```ocaml
type channel = { channel_id : int64; hits : int [@sqlgg.by] }
[@@deriving sqlgg ~nullable_cols]

type post = { id : int64; channel : channel option [@sqlgg.nested] } [@@deriving sqlgg]
(* Error: Unbound type constructor "channel_nullable_cols" *)
```

Reading such a record on its own is unchanged
