### PR TITLE
Get rid of dependency on `mybuild`

### DIFF
--- a/impl/ocaml/dune
+++ b/impl/ocaml/dune
@@ -2,4 +2,4 @@
  (wrapped false)
  (name sqlgg_traits)
  (public_name sqlgg.traits)
- (libraries integers sqlgg_json_path))
+ (libraries integers sqlgg_json_path unix))

--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -16,7 +16,6 @@ depends: [
   "dune" {>= "2.7"}
   "integers" {>= "0.4.0"}
   "menhir" {>= "20180523"}
-  "mybuild" {> "3"}
   "ppx_deriving" {>= "4.3"}
   "ppx_enumerate" {>= "v0.15.0"}
   "ppx_deriving_variant_string" {>= "1.0.1"}

--- a/src/dune
+++ b/src/dune
@@ -1,17 +1,6 @@
 (executable
- (name gen_version)
- (libraries mybuild)
- (modules gen_version)
- (preprocess (pps ppx_deriving.std)))
-
-(rule
- (target version.ml)
- (deps (universe))
- (action (run ./gen_version.exe %{target})))
-
-(executable
   (public_name sqlgg)
-  (modules :standard \ gen_version)
+  (modules :standard)
   (name cli)
   (promote (until-clean))
   (libraries

--- a/src/gen_version.ml
+++ b/src/gen_version.ml
@@ -1,3 +1,0 @@
-let () =
-  let file = Sys.argv.(1) in
-  Mybuild.Version.save ~identify:false file

--- a/src/sqlgg_config.ml
+++ b/src/sqlgg_config.ml
@@ -2,7 +2,7 @@
 open Sqlgg
 
 (** Sqlgg version *)
-let version = Version.id
+let version = "%%VERSION%%"
 
 (** Debug level *)
 let debug_level = ref 0


### PR DESCRIPTION
The `mybuild` dependency came only to provide the version numbers. I see two ways to replace it:

- Rely on `dune subst` and simply have `%%VERSION%%` in the code. This is the simplest but it will actually print the string `%%VERSION%%` during development as `dune subst` only runs during actual installation.

- Rely on something like [`dune-build-info`](https://dune.readthedocs.io/en/stable/dune-libs.html#dune-build-info-library) which can do it but would introduce another dependency.

This PR implements the former. While I'm at it, I also add the explicit dependency in `unix` to silence the corresponding >5.0 warning.