### PR TITLE
Add Sqlcommenter spec support

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -527,9 +527,9 @@ let no_params stmt =
 
 let close_stmt stmt = let open IO in M.Stmt.close stmt >>= fun _ -> return ()
 
-let with_stmt db sql f =
+let with_stmt db (q : Sqlgg_traits.Query.t) f =
   let open IO in
-  M.prepare db sql >>=
+  M.prepare db q.sql >>=
   check >>=
   fun stmt -> bracket (return stmt) close_stmt f
 
@@ -574,17 +574,17 @@ let execute_with_stmt stmt set_params =
     in
     return { affected_rows = Int64.of_int (M.Res.affected_rows res); insert_id }
 
-let select db sql set_params callback =
-  with_stmt db sql (fun stmt -> select_with_stmt stmt set_params callback)
+let select db q set_params callback =
+  with_stmt db q (fun stmt -> select_with_stmt stmt set_params callback)
 
-let select_one_maybe db sql set_params convert =
-  with_stmt db sql (fun stmt -> select_one_maybe_with_stmt stmt set_params convert)
+let select_one_maybe db q set_params convert =
+  with_stmt db q (fun stmt -> select_one_maybe_with_stmt stmt set_params convert)
 
-let select_one db sql set_params convert =
-  with_stmt db sql (fun stmt -> select_one_with_stmt stmt set_params convert)
+let select_one db q set_params convert =
+  with_stmt db q (fun stmt -> select_one_with_stmt stmt set_params convert)
 
-let execute db sql set_params =
-  with_stmt db sql (fun stmt -> execute_with_stmt stmt set_params)
+let execute db q set_params =
+  with_stmt db q (fun stmt -> execute_with_stmt stmt set_params)
 
 let prepare db sql =
   let open IO in

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -433,23 +433,23 @@ let select_one_with_stmt stmt set_params convert =
   | Some row -> convert row
   | None -> oops "no row but one expected in select_one_with_stmt"
 
-let with_stmt db sql f = 
-  bracket (prepare db sql) close_stmt f
+let with_stmt db (q : Sqlgg_traits.Query.t) f = 
+  bracket (prepare db q.sql) close_stmt f
 
-let select db sql set_params callback =
-  with_stmt db sql (fun stmt ->
+let select db q set_params callback =
+  with_stmt db q (fun stmt ->
     select_with_stmt stmt set_params callback)
 
-let execute db sql set_params =
-  with_stmt db sql (fun stmt ->
+let execute db q set_params =
+  with_stmt db q (fun stmt ->
     execute_with_stmt stmt set_params)
 
-let select_one_maybe db sql set_params convert =
-  with_stmt db sql (fun stmt ->
+let select_one_maybe db q set_params convert =
+  with_stmt db q (fun stmt ->
     select_one_maybe_with_stmt stmt set_params convert)
 
-let select_one db sql set_params convert =
-  with_stmt db sql (fun stmt ->
+let select_one db q set_params convert =
+  with_stmt db q (fun stmt ->
     select_one_with_stmt stmt set_params convert)
 
 end

--- a/impl/ocaml/sqlgg_query.ml
+++ b/impl/ocaml/sqlgg_query.ml
@@ -1,0 +1,50 @@
+type cardinality = Zero_one | One | Nat
+
+type kind =
+  | Select of cardinality
+  | Insert of string
+  | Create of string
+  | CreateIndex of string
+  | Update of string option
+  | Delete of string list
+  | Alter of string list
+  | Drop of string
+  | CreateRoutine of string
+  | CreateType of string
+  | DropType of string
+  | Other
+
+type t = {
+  sql : string;
+  name : string;
+  kind : kind;
+}
+
+let make ~sql ~name ~kind = { sql; name; kind }
+
+let append_comment q comment = { q with sql = q.sql ^ " " ^ comment }
+
+module Sqlcommenter = struct
+
+let url_encode s =
+  let b = Buffer.create (String.length s) in
+  String.iter (fun c ->
+    match c with
+    | 'A'..'Z' | 'a'..'z' | '0'..'9' | '-' | '_' | '.' | '~' -> Buffer.add_char b c
+    | c -> Buffer.add_string b (Printf.sprintf "%%%02X" (Char.code c))) s;
+  Buffer.contents b
+
+let comment attrs =
+  attrs
+  |> List.map (fun (k, v) -> url_encode k, url_encode v)
+  |> List.sort compare
+  |> List.map (fun (k, v) -> Printf.sprintf "%s='%s'" k v)
+  |> String.concat ","
+  |> Printf.sprintf "/*%s*/"
+
+let annotate attrs q =
+  match attrs with
+  | [] -> q
+  | attrs -> append_comment q (comment attrs)
+
+end

--- a/impl/ocaml/sqlgg_query.mli
+++ b/impl/ocaml/sqlgg_query.mli
@@ -1,0 +1,32 @@
+type cardinality = Zero_one | One | Nat
+
+type kind =
+  | Select of cardinality
+  | Insert of string
+  | Create of string
+  | CreateIndex of string
+  | Update of string option
+  | Delete of string list
+  | Alter of string list
+  | Drop of string
+  | CreateRoutine of string
+  | CreateType of string
+  | DropType of string
+  | Other
+
+type t = private {
+  sql : string;
+  name : string;
+  kind : kind;
+}
+
+val make : sql:string -> name:string -> kind:kind -> t
+
+(** https://google.github.io/sqlcommenter/spec/ *)
+module Sqlcommenter : sig
+
+  val comment : (string * string) list -> string
+
+  val annotate : (string * string) list -> t -> t
+
+end

--- a/impl/ocaml/sqlgg_stmt_cache.ml
+++ b/impl/ocaml/sqlgg_stmt_cache.ml
@@ -203,8 +203,9 @@ module Make_with_clock (Clock : Clock) (Config : Cache_config) (Impl : Cached_m)
     let state = { cache; ops_count = 0 } in
     { original; state }
 
-  let with_prepared_stmt cached_conn sql f =
+  let with_prepared_stmt cached_conn (q : Sqlgg_traits.Query.t) f =
     let open Impl.IO in
+    let sql = q.sql in
     let state = cached_conn.state in
     state.ops_count <- succ state.ops_count;
 
@@ -236,20 +237,20 @@ module Make_with_clock (Clock : Clock) (Config : Cache_config) (Impl : Cached_m)
         with_stmt_cleanup stmt
     end
 
-  let select cached_conn sql set_params callback =
-    with_prepared_stmt cached_conn sql (fun stmt ->
+  let select cached_conn q set_params callback =
+    with_prepared_stmt cached_conn q (fun stmt ->
       Impl.select_with_stmt stmt set_params callback)
 
-  let select_one cached_conn sql set_params convert =
-    with_prepared_stmt cached_conn sql (fun stmt ->
+  let select_one cached_conn q set_params convert =
+    with_prepared_stmt cached_conn q (fun stmt ->
       Impl.select_one_with_stmt stmt set_params convert)
 
-  let select_one_maybe cached_conn sql set_params convert =
-    with_prepared_stmt cached_conn sql (fun stmt ->
+  let select_one_maybe cached_conn q set_params convert =
+    with_prepared_stmt cached_conn q (fun stmt ->
       Impl.select_one_maybe_with_stmt stmt set_params convert)
 
-  let execute cached_conn sql set_params =
-    with_prepared_stmt cached_conn sql (fun stmt ->
+  let execute cached_conn q set_params =
+    with_prepared_stmt cached_conn q (fun stmt ->
       Impl.execute_with_stmt stmt set_params)
 
   let cache_stats cached_conn =
@@ -302,21 +303,21 @@ module SharedConnectionCache (MutexImpl : Mutex_intf) (Config : Cache_config)
       mutex = MutexImpl.create ();
     }
   
-  let select conn sql set_params callback =
+  let select conn q set_params callback =
     MutexImpl.with_lock conn.mutex (fun () -> 
-      select conn.base_conn sql set_params callback)
+      select conn.base_conn q set_params callback)
     
-  let select_one conn sql set_params convert =
+  let select_one conn q set_params convert =
     MutexImpl.with_lock conn.mutex (fun () -> 
-      select_one conn.base_conn sql set_params convert)
+      select_one conn.base_conn q set_params convert)
     
-  let select_one_maybe conn sql set_params convert =
+  let select_one_maybe conn q set_params convert =
     MutexImpl.with_lock conn.mutex (fun () -> 
-      select_one_maybe conn.base_conn sql set_params convert)
+      select_one_maybe conn.base_conn q set_params convert)
     
-  let execute conn sql set_params =
+  let execute conn q set_params =
     MutexImpl.with_lock conn.mutex (fun () -> 
-      execute conn.base_conn sql set_params)
+      execute conn.base_conn q set_params)
 
   let cache_stats conn =  cache_stats conn.base_conn
 

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -15,6 +15,8 @@
 
 open Sqlgg_trait_types
 
+module Query = Sqlgg_query
+
 module type Value = sig
   type t
 
@@ -48,24 +50,24 @@ module type FNS = sig
     Perform query (cardinality "any") and return results via callback for each row
     @raise Oops on error
   *)
-  val select : [>`RO] connection -> string -> (statement -> result io_future) -> (row -> unit) -> unit io_future
+  val select : [>`RO] connection -> Query.t -> (statement -> result io_future) -> (row -> unit) -> unit io_future
 
   (**
     Perform query (cardinality "zero or one") and return first row if available
     @raise Oops on error
   *)
-  val select_one_maybe : [>`RO] connection -> string -> (statement -> result io_future) -> (row -> 'b) -> 'b option io_future
+  val select_one_maybe : [>`RO] connection -> Query.t -> (statement -> result io_future) -> (row -> 'b) -> 'b option io_future
 
   (**
     Perform query (cardinality "one") and return first row
     @raise Oops on error
   *)
-  val select_one : [>`RO] connection -> string -> (statement -> result io_future) -> (row -> 'b) -> 'b io_future
+  val select_one : [>`RO] connection -> Query.t -> (statement -> result io_future) -> (row -> 'b) -> 'b io_future
 
   (** Execute non-query.
     @raise Oops on error
   *)
-  val execute : [>`WR] connection -> string -> (statement -> result io_future) -> execute_response io_future
+  val execute : [>`WR] connection -> Query.t -> (statement -> result io_future) -> execute_response io_future
 end
 
 module type M = sig

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -266,12 +266,12 @@ let try_finally final f x =
 
 let close_stmt (stmt, sql, _) = test_ok sql (S.finalize stmt)
 
-let prepare db (sql: string) = 
+let prepare db (sql : string) = 
   let stmt = S.prepare db sql in
   (stmt, sql, db)
 
-let with_stmt db sql f =
-  let full_stmt = prepare db sql in
+let with_stmt db (q : Sqlgg_traits.Query.t) f =
+  let full_stmt = prepare db q.sql in
   try_finally
     (fun () -> close_stmt full_stmt)
     f full_stmt
@@ -312,20 +312,20 @@ let select_one_with_stmt full_stmt set_params convert =
   else
     raise (Oops (sprintf "no row but one expected : %s" sql))
 
-let select db sql set_params callback =
-  with_stmt db sql (fun stmt ->
+let select db q set_params callback =
+  with_stmt db q (fun stmt ->
     select_with_stmt stmt set_params callback)
 
-let execute db sql set_params =
-  with_stmt db sql (fun stmt ->
+let execute db q set_params =
+  with_stmt db q (fun stmt ->
     execute_with_stmt stmt set_params)
 
-let select_one_maybe db sql set_params convert =
-  with_stmt db sql (fun stmt ->
+let select_one_maybe db q set_params convert =
+  with_stmt db q (fun stmt ->
     select_one_maybe_with_stmt stmt set_params convert)
 
-let select_one db sql set_params convert =
-  with_stmt db sql (fun stmt ->
+let select_one db q set_params convert =
+  with_stmt db q (fun stmt ->
     select_one_with_stmt stmt set_params convert)
 
 end

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -261,6 +261,32 @@ let select_func_of_kind = function
 | Stmt.Select `One -> "select_one"
 | _ -> "select"
 
+let query_expr ~sql index stmt =
+  let table t = quote (Sql.show_table_name t) in
+  let tables ts = sprintf "[%s]" (String.concat "; " (List.map table ts)) in
+  let k fmt = ksprintf (fun s -> sprintf "Sqlgg_traits.Query.(%s)" s) fmt in
+  let kind =
+    match stmt.Gen.kind with
+    | Stmt.Select `Zero_one -> k "Select Zero_one"
+    | Stmt.Select `One -> k "Select One"
+    | Stmt.Select `Nat -> k "Select Nat"
+    | Stmt.Insert (_, t) -> k "Insert %s" (table t)
+    | Stmt.Create t -> k "Create %s" (table t)
+    | Stmt.CreateIndex s -> k "CreateIndex %s" (quote s)
+    | Stmt.Update (Some t) -> k "Update (Some %s)" (table t)
+    | Stmt.Update None -> k "Update None"
+    | Stmt.Delete ts -> k "Delete %s" (tables ts)
+    | Stmt.Alter ts -> k "Alter %s" (tables ts)
+    | Stmt.Drop t -> k "Drop %s" (table t)
+    | Stmt.CreateRoutine t -> k "CreateRoutine %s" (table t)
+    | Stmt.CreateType s -> k "CreateType %s" (quote s)
+    | Stmt.DropType s -> k "DropType %s" (quote s)
+    | Stmt.Other -> "Sqlgg_traits.Query.Other"
+  in
+  let name = choose_name stmt.Gen.props stmt.Gen.kind index |> String.uncapitalize_ascii in
+  sprintf "(Sqlgg_traits.Query.make ~sql:%s ~name:%s ~kind:%s)"
+    sql (quote name) kind
+
 let is_single_row_select stmt =
   match stmt.Gen.kind, stmt.Gen.schema with
   | Stmt.Select (`One | `Zero_one), _ :: _ -> true
@@ -752,7 +778,7 @@ type callback_build_state = {
   idx_expr: string option;
 }
 
-let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module ~with_callback stmt =
+let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module ~with_callback index stmt =
   let sql_pieces = get_sql stmt in
   let join_ctors = join_ctors_of_vars stmt.Gen.vars in
 
@@ -887,11 +913,11 @@ let emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module ~with_callba
   let (bind_start, bind_end) = c.c_bind in
 
   output "%sT.%s db" bind_start (select_func_of_kind stmt.kind);
-  output "  (%s)" sql_expr;
+  output "  %s" (query_expr ~sql:(sprintf "(%s)" sql_expr) index stmt);
   output "  set_params %s%s" full_callback bind_end;
   complete_func c
 
-let emit_dynamic_module_select ~module_kind ~dynamic_infos stmt =
+let emit_dynamic_module_select ~module_kind ~dynamic_infos index stmt =
   if not (supports_module_kind module_kind stmt) then () else
   let dynamic_names = List.map (fun di -> di.param_name) dynamic_infos in
   let format_input = format_func_input dynamic_names ~dyn_annot:(fun _ -> "_ t") in
@@ -904,7 +930,7 @@ let emit_dynamic_module_select ~module_kind ~dynamic_infos stmt =
     emit_func_header ~name:"select" ~extra_params:""
       ~has_callback:with_callback ~format_input ~module_kind stmt
   in
-  emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:true ~with_callback stmt
+  emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:true ~with_callback index stmt
 
 let emit_sql_with_subst subst stmt =
   let sql = make_sql ~join_ctors:(join_ctors_of_vars stmt.Gen.vars) @@ get_sql stmt in
@@ -955,7 +981,7 @@ let generate_stmt ~module_kind index stmt =
       ~list:(sprintf "(fun x -> r_acc := %s x :: !r_acc)" callback)
   in
   let (bind, bind_end) = c.c_bind in
-  let exec = sprintf "T.%s db %s %s %s%s" func sql params_binder_name callback bind_end in
+  let exec = sprintf "T.%s db %s %s %s%s" func (query_expr ~sql index stmt) params_binder_name callback bind_end in
   let exec =
     match
       List.find_map
@@ -1148,9 +1174,9 @@ let generate_dynamic_select_modules stmts =
 
         if single_di then begin
           empty_line ();
-          emit_dynamic_module_select ~module_kind:`Direct ~dynamic_infos:[di] stmt;
+          emit_dynamic_module_select ~module_kind:`Direct ~dynamic_infos:[di] index stmt;
           emit_module_kind_variants stmt (fun module_kind ->
-            emit_dynamic_module_select ~module_kind ~dynamic_infos:[di] stmt)
+            emit_dynamic_module_select ~module_kind ~dynamic_infos:[di] index stmt)
         end);
       empty_line ()
     )
@@ -1164,7 +1190,7 @@ let generate_stmt_wrapper ~module_kind index stmt =
   | _ :: _ :: _ ->
     if supports_module_kind module_kind stmt then begin
       let _subst = gen_func_signature ~dynamic_infos ~module_kind ~index stmt in
-      emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:false ~with_callback:true stmt
+      emit_dynamic_select_body ~module_kind ~dynamic_infos ~in_module:false ~with_callback:true index stmt
     end
 
 let generate ~gen_io ~migration_names name stmts =

--- a/test/cram/create_type.t
+++ b/test/cram/create_type.t
@@ -10,20 +10,20 @@ CREATE TYPE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db ("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
   
     let create_shirt db  =
-      T.execute db ("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt")) T.no_params
   
     let select_2 db  callback =
       let invoke_callback stmt =
         callback
           ~id:(T.get_column_Int stmt 0)
       in
-      T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let drop_type_color db  =
-      T.execute db ("DROP TYPE \"color\"") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color")) T.no_params
   
     module Fold = struct
       let select_2 db  callback acc =
@@ -32,7 +32,7 @@ CREATE TYPE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -44,7 +44,7 @@ CREATE TYPE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -89,23 +89,23 @@ CREATE DROP CREATE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db ("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
   
     let drop_type_color db  =
-      T.execute db ("DROP TYPE \"color\"") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color")) T.no_params
   
     let create_type_color db  =
-      T.execute db ("CREATE TYPE \"color\" AS ENUM ('black', 'white')") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('black', 'white')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
   
     let create_shirt db  =
-      T.execute db ("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt")) T.no_params
   
     let select_4 db  callback =
       let invoke_callback stmt =
         callback
           ~id:(T.get_column_Int stmt 0)
       in
-      T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_4 db  callback acc =
@@ -114,7 +114,7 @@ CREATE DROP CREATE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -126,7 +126,7 @@ CREATE DROP CREATE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)

--- a/test/cram/dynamic_subquery.t
+++ b/test/cram/dynamic_subquery.t
@@ -61,7 +61,7 @@ Full generated code:
           T.finish_params p
         in
         T.select db
-        ("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub")
+        (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -75,7 +75,7 @@ Full generated code:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub")
+          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -92,7 +92,7 @@ Full generated code:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub")
+          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -135,7 +135,7 @@ Full generated code:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -149,7 +149,7 @@ Full generated code:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -166,7 +166,7 @@ Full generated code:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -176,7 +176,7 @@ Full generated code:
   
   
     let create_products db  =
-      T.execute db ("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/enum_literals.compare.ml
+++ b/test/cram/enum_literals.compare.ml
@@ -15,9 +15,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end)
 
   let create_test_status db  =
-    T.execute db ("CREATE TABLE test_status (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_status (\n\
   status ENUM('Failed','Skipped','Passed') NOT NULL\n\
-)") T.no_params
+)") ~name:"create_test_status" ~kind:Sqlgg_traits.Query.(Create "test_status")) T.no_params
 
   let test1 db ~status_list callback =
     let invoke_callback stmt =
@@ -28,16 +28,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match status_list with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db ("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
   id INT NOT NULL,\n\
   status ENUM('Active','Inactive','Pending') NOT NULL\n\
-)") T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let test2 db ~rows =
-    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db ("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) T.no_params )
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"test2" ~kind:Sqlgg_traits.Query.(Insert "users")) T.no_params )
 
   module Fold = struct
     let test1 db ~status_list callback acc =
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -66,7 +66,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/json_functions.compare.ml
+++ b/test/cram/json_functions.compare.ml
@@ -3,25 +3,25 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_people db  =
-    T.execute db ("CREATE TABLE people (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") T.no_params
+)") ~name:"create_people" ~kind:Sqlgg_traits.Query.(Create "people")) T.no_params
 
   let create_people_data_json_kind_never_null_but_col_nullable db  =
-    T.execute db ("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") T.no_params
+)") ~name:"create_people_data_json_kind_never_null_but_col_nullable" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_but_col_nullable")) T.no_params
 
   let create_people_data_json_kind_never_null_and_col_strict db  =
-    T.execute db ("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON NOT NULL\n\
-)") T.no_params
+)") ~name:"create_people_data_json_kind_never_null_and_col_strict" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_and_col_strict")) T.no_params
 
   let one db  =
-    T.execute db ("INSERT INTO people (data) VALUES\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO people (data) VALUES\n\
   (JSON_OBJECT(\n\
     'name', 'Alice',\n\
     'age', 30,\n\
@@ -43,7 +43,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   (JSON_OBJECT(\n\
     'name', NULL,\n\
     'age', NULL\n\
-  ))") T.no_params
+  ))") ~name:"one" ~kind:Sqlgg_traits.Query.(Insert "people")) T.no_params
 
   let two db  callback =
     let invoke_callback stmt =
@@ -51,9 +51,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~id:(T.get_column_Int stmt 0)
         ~name:(T.get_column_Json_nullable stmt 1)
     in
-    T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params invoke_callback
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let three db  callback =
     let invoke_callback stmt =
@@ -61,10 +61,10 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params
         ~id:(T.get_column_Int stmt 0)
         ~data_with_active:(T.get_column_Json_nullable stmt 1)
     in
-    T.select db ("SELECT\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") T.no_params invoke_callback
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let four db  callback =
     let invoke_callback stmt =
@@ -72,10 +72,10 @@ FROM people") T.no_params invoke_callback
         ~id:(T.get_column_Int stmt 0)
         ~data_with_active:(T.get_column_Json_nullable stmt 1)
     in
-    T.select db ("SELECT\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") T.no_params invoke_callback
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let five db  callback =
     let invoke_callback stmt =
@@ -83,10 +83,10 @@ FROM people_data_json_kind_never_null_but_col_nullable") T.no_params invoke_call
         ~id:(T.get_column_Int stmt 0)
         ~data_with_active:(T.get_column_Json stmt 1)
     in
-    T.select db ("SELECT\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") T.no_params invoke_callback
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   module Fold = struct
     let two db  callback acc =
@@ -96,9 +96,9 @@ FROM people_data_json_kind_never_null_and_col_strict") T.no_params invoke_callba
           ~name:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let three db  callback acc =
@@ -108,10 +108,10 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params
           ~data_with_active:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let four db  callback acc =
@@ -121,10 +121,10 @@ FROM people") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
           ~data_with_active:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let five db  callback acc =
@@ -134,10 +134,10 @@ FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r
           ~data_with_active:(T.get_column_Json stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -150,9 +150,9 @@ FROM people_data_json_kind_never_null_and_col_strict") T.no_params (fun x -> r_a
           ~name:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let three db  callback =
@@ -162,10 +162,10 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") T.no_params
           ~data_with_active:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let four db  callback =
@@ -175,10 +175,10 @@ FROM people") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
           ~data_with_active:(T.get_column_Json_nullable stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let five db  callback =
@@ -188,10 +188,10 @@ FROM people_data_json_kind_never_null_but_col_nullable") T.no_params (fun x -> r
           ~data_with_active:(T.get_column_Json stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/not_null_refine.compare.ml
+++ b/test/cram/not_null_refine.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -145,18 +145,18 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_items db  =
-    T.execute db ("CREATE TABLE items (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (\n\
   id INT NOT NULL,\n\
   name TEXT NULL,\n\
   descr TEXT NULL\n\
-)") T.no_params
+)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
 
   let static_not_null db  callback =
     let invoke_callback stmt =
       callback
         ~name:(T.get_column_Text stmt 0)
     in
-    T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   module Fold = struct
     let static_not_null db  callback acc =
@@ -165,7 +165,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -177,7 +177,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT name FROM items WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/print_impl.ml
+++ b/test/cram/print_impl.ml
@@ -261,11 +261,11 @@ module IO = struct
   end
 end
 
-let prepare _conn sql =
+let prepare _conn (sql : string) =
   incr stmt_counter;
   let stmt = { id = !stmt_counter; sql; is_closed = false } in
   prepared_statements := stmt :: !prepared_statements;
-  log_operation (sprintf "PREPARE[%d]: %s" stmt.id sql);
+  log_operation (sprintf "PREPARE[%d]: %s" stmt.id stmt.sql);
   match List.find_opt (function MockError _ -> true | _ -> false) !response_queue with
   | Some (MockError msg) -> raise (Oops msg)
   | _ -> stmt
@@ -550,9 +550,9 @@ module Make_enum (E: Enum) = struct
   let to_literal v = Types.Text.to_literal (E.proj v)
 end
 
-let select (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (callback : row -> unit) : unit =
+let select (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (callback : row -> unit) : unit =
   printf "[MOCK SELECT] Connection type: [> `RO ]\n";
-  let stmt = prepare db sql in
+  let stmt = prepare db q.Sqlgg_traits.Query.sql in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelect rows ->
@@ -577,9 +577,9 @@ let select (db : [> `RO ] connection) (sql : string) (set_params : statement -> 
   | MockError msg -> raise (Oops msg)
   | _ -> failwith "Expected MockSelect response"
 
-let execute (db : [> `WR ] connection) (sql : string) (set_params : statement -> result) : execute_response =
+let execute (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) : execute_response =
   printf "[MOCK EXECUTE] Connection type: [> `WR ]\n";
-  let stmt = prepare db sql in
+  let stmt = prepare db q.Sqlgg_traits.Query.sql in
   let _ = set_params stmt in
   match get_next_response () with
   | MockExecute { affected_rows; insert_id } ->
@@ -591,9 +591,9 @@ let execute (db : [> `WR ] connection) (sql : string) (set_params : statement ->
   | MockError msg -> raise (Oops msg)
   | _ -> failwith "Expected MockExecute response"
 
-let select_one_maybe (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
+let select_one_maybe (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
   printf "[MOCK SELECT_ONE_MAYBE] Connection type: [> `RO ]\n";
-  let stmt = prepare db sql in
+  let stmt = prepare db q.Sqlgg_traits.Query.sql in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelectOne (Some row) ->
@@ -607,9 +607,9 @@ let select_one_maybe (db : [> `RO ] connection) (sql : string) (set_params : sta
   | MockError msg -> raise (Oops msg)
   | _ -> failwith "Expected MockSelectOne response"
 
-let select_one (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (convert : row -> 'a) : 'a =
+let select_one (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a =
   printf "[MOCK SELECT_ONE] Connection type: [> `RO ]\n";
-  let stmt = prepare db sql in
+  let stmt = prepare db q.Sqlgg_traits.Query.sql in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelectOne (Some row) ->

--- a/test/cram/print_ocaml_impl.ml
+++ b/test/cram/print_ocaml_impl.ml
@@ -423,9 +423,9 @@ module Make_enum (E: Enum) = struct
   let to_literal v = Types.Text.to_literal (E.proj v)
 end
 
-let select (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (callback : row -> unit) : unit =
+let select (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (callback : row -> unit) : unit =
   printf "[MOCK SELECT] Connection type: [> `RO ]\n";
-  let stmt = (sql, 0) in
+  let stmt = (q.Sqlgg_traits.Query.sql, 0) in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelect rows ->
@@ -449,9 +449,9 @@ let select (db : [> `RO ] connection) (sql : string) (set_params : statement -> 
     flush stdout
   | _ -> failwith "Expected MockSelect response"
 
-let execute (db : [> `WR ] connection) (sql : string) (set_params : statement -> result) : execute_response =
+let execute (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) : execute_response =
   printf "[MOCK EXECUTE] Connection type: [> `WR ]\n";
-  let stmt = (sql, 0) in
+  let stmt = (q.Sqlgg_traits.Query.sql, 0) in
   let _ = set_params stmt in
   match get_next_response () with
   | MockExecute { affected_rows; insert_id } ->
@@ -462,9 +462,9 @@ let execute (db : [> `WR ] connection) (sql : string) (set_params : statement ->
     { affected_rows; insert_id }
   | _ -> failwith "Expected MockExecute response"
 
-let select_one_maybe (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
+let select_one_maybe (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
   printf "[MOCK SELECT_ONE_MAYBE] Connection type: [> `RO ]\n";
-  let stmt = (sql, 0) in
+  let stmt = (q.Sqlgg_traits.Query.sql, 0) in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelectOne (Some row) ->
@@ -477,9 +477,9 @@ let select_one_maybe (db : [> `RO ] connection) (sql : string) (set_params : sta
     None
   | _ -> failwith "Expected MockSelectOne response"
 
-let select_one (db : [> `RO ] connection) (sql : string) (set_params : statement -> result) (convert : row -> 'a) : 'a =
+let select_one (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a =
   printf "[MOCK SELECT_ONE] Connection type: [> `RO ]\n";
-  let stmt = (sql, 0) in
+  let stmt = (q.Sqlgg_traits.Query.sql, 0) in
   let _ = set_params stmt in
   match get_next_response () with
   | MockSelectOne (Some row) ->

--- a/test/cram/registration_feedbacks.compare.ml
+++ b/test/cram/registration_feedbacks.compare.ml
@@ -3,12 +3,12 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_registration_feedbacks db  =
-    T.execute db ("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   `user_message_2` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks")) T.no_params
 
   let test_name db ~id ~search =
     let get_row stmt =
@@ -32,7 +32,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       end;
       T.finish_params p
     in
-    T.select_one_maybe db ("SELECT * FROM registration_feedbacks WHERE\n\
+    T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM registration_feedbacks WHERE\n\
   id = ? AND\n\
  " ^ (match search with Some (_, _, xs, xss) -> " ( " ^ " \n\
   `user_message` = " ^ "?" ^ " \n\
@@ -40,7 +40,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     OR `user_message_2` = " ^ "?" ^ " \n\
     OR " ^ (match xs with [] -> "FALSE" | _ :: _ -> "`user_message_2` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal xs) ^ ")") ^ "\n\
     OR " ^ (match xss with `A _ -> " ( user_message_2 = ? ) " | `B _ -> " ( user_message_2 = ? ) ") ^ "\n\
- " ^ " ) " | None -> " TRUE ")) set_params get_row
+ " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
 
   module Single = struct
     let test_name db ~id ~search callback =
@@ -68,7 +68,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         end;
         T.finish_params p
       in
-      T.select_one_maybe db ("SELECT * FROM registration_feedbacks WHERE\n\
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM registration_feedbacks WHERE\n\
   id = ? AND\n\
  " ^ (match search with Some (_, _, xs, xss) -> " ( " ^ " \n\
   `user_message` = " ^ "?" ^ " \n\
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     OR `user_message_2` = " ^ "?" ^ " \n\
     OR " ^ (match xs with [] -> "FALSE" | _ :: _ -> "`user_message_2` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal xs) ^ ")") ^ "\n\
     OR " ^ (match xss with `A _ -> " ( user_message_2 = ? ) " | `B _ -> " ( user_message_2 = ? ) ") ^ "\n\
- " ^ " ) " | None -> " TRUE ")) set_params invoke_callback
+ " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params invoke_callback
 
   end (* module Single *)
 end (* module Sqlgg *)

--- a/test/cram/reusable_queries_as_ctes.compare.ml
+++ b/test/cram/reusable_queries_as_ctes.compare.ml
@@ -3,19 +3,19 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_categories db  =
-    T.execute db ("CREATE TABLE categories (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE categories (\n\
     id SERIAL PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL\n\
-)") T.no_params
+)") ~name:"create_categories" ~kind:Sqlgg_traits.Query.(Create "categories")) T.no_params
 
   let create_products db  =
-    T.execute db ("CREATE TABLE products (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
     id SERIAL PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL,\n\
     category_id INTEGER,\n\
     price NUMERIC(10, 2) NOT NULL,\n\
     FOREIGN KEY (category_id) REFERENCES categories(id)\n\
-)") T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
 
   let test2 db ~five ~param ~test ~test2 ~test5 callback =
     let invoke_callback stmt =
@@ -30,7 +30,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p test5;
       T.finish_params p
     in
-    T.select db ("WITH x AS (SELECT \n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -40,7 +40,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params invoke_callback
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let test3 db ~five ~param ~test ~test2 ~test5 callback =
     let invoke_callback stmt =
@@ -55,7 +55,7 @@ FROM x") set_params invoke_callback
       T.set_param_Int p test5;
       T.finish_params p
     in
-    T.select db ("WITH x AS (SELECT \n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -65,7 +65,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params invoke_callback
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let reuseme db  callback =
     let invoke_callback stmt =
@@ -75,14 +75,14 @@ FROM x") set_params invoke_callback
         ~category_id:(T.get_column_Int_nullable stmt 2)
         ~category_name:(T.get_column_Text stmt 3)
     in
-    T.select db ("WITH inner_cte AS (\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") T.no_params invoke_callback
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let reuse_reusable db  callback =
     let invoke_callback stmt =
@@ -96,7 +96,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params invoke_callback
       let p = T.start_params stmt (0) in
       T.finish_params p
     in
-    T.select db ("WITH outer_cte AS (WITH inner_cte AS (\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("WITH outer_cte AS (WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
@@ -104,7 +104,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params invoke_callback
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") set_params invoke_callback
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let test2 db ~five ~param ~test ~test2 ~test5 callback acc =
@@ -121,7 +121,7 @@ SELECT * FROM outer_cte") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("WITH x AS (SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -131,7 +131,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let test3 db ~five ~param ~test ~test2 ~test5 callback acc =
@@ -148,7 +148,7 @@ FROM x") set_params (fun x -> r_acc := invoke_callback x !r_acc))
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("WITH x AS (SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -158,7 +158,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let reuseme db  callback acc =
@@ -170,14 +170,14 @@ FROM x") set_params (fun x -> r_acc := invoke_callback x !r_acc))
           ~category_name:(T.get_column_Text stmt 3)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("WITH inner_cte AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let reuse_reusable db  callback acc =
@@ -193,7 +193,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc 
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("WITH outer_cte AS (WITH inner_cte AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH outer_cte AS (WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
@@ -201,7 +201,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc 
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -221,7 +221,7 @@ SELECT * FROM outer_cte") set_params (fun x -> r_acc := invoke_callback x !r_acc
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("WITH x AS (SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -231,7 +231,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let test3 db ~five ~param ~test ~test2 ~test5 callback =
@@ -248,7 +248,7 @@ FROM x") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("WITH x AS (SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH x AS (SELECT \n\
     1 as y, \n\
     4 + ? as y1\n\
 FROM ( \n\
@@ -258,7 +258,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let reuseme db  callback =
@@ -270,14 +270,14 @@ FROM x") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
           ~category_name:(T.get_column_Text stmt 3)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("WITH inner_cte AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let reuse_reusable db  callback =
@@ -293,7 +293,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc 
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("WITH outer_cte AS (WITH inner_cte AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH outer_cte AS (WITH inner_cte AS (\n\
         SELECT id, name, category_id \n\
         FROM products \n\
         WHERE price > 100\n\
@@ -301,7 +301,7 @@ JOIN categories c ON inner_cte.category_id = c.id") T.no_params (fun x -> r_acc 
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/reusable_queries_postgresql_params.t
+++ b/test/cram/reusable_queries_postgresql_params.t
@@ -36,13 +36,13 @@ PostgreSQL parameter numbering in reusable queries, distinct parameters:
         T.set_param_Int p min_id;
         T.finish_params p
       in
-      T.select db ("WITH person AS (SELECT *\n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("WITH person AS (SELECT *\n\
   FROM person\n\
   WHERE name LIKE $1)\n\
   SELECT *\n\
   FROM \"user\"\n\
   JOIN person ON person.user_id = \"user\".id\n\
-  WHERE \"user\".id > $2") set_params invoke_callback
+  WHERE \"user\".id > $2") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
 PostgreSQL parameter numbering in reusable queries, shared parameter:
 
@@ -88,7 +88,7 @@ PostgreSQL parameter numbering in reusable queries, shared parameter:
         T.set_param_Int p min_id;
         T.finish_params p
       in
-      T.select db ("WITH person AS (SELECT *\n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("WITH person AS (SELECT *\n\
   FROM person\n\
   WHERE\n\
     name LIKE $1\n\
@@ -98,7 +98,7 @@ PostgreSQL parameter numbering in reusable queries, shared parameter:
   JOIN person ON person.user_id = \"user\".id\n\
   WHERE\n\
     username LIKE $3\n\
-    AND \"user\".id > $4") set_params invoke_callback
+    AND \"user\".id > $4") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
 PostgreSQL parameter numbering with two reusable queries in one outer query:
 
@@ -135,10 +135,10 @@ PostgreSQL parameter numbering with two reusable queries in one outer query:
         T.set_param_Int p min_id;
         T.finish_params p
       in
-      T.select db ("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $2)\n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $2)\n\
   SELECT p.id, a.username\n\
   FROM p JOIN a ON a.id = p.user_id\n\
-  WHERE p.id > $3") set_params invoke_callback
+  WHERE p.id > $3") ~name:"two_ctes" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
 PostgreSQL parameter numbering with reusable queries threaded into each other:
 
@@ -171,6 +171,6 @@ PostgreSQL parameter numbering with reusable queries threaded into each other:
         T.set_param_Int p outer_min;
         T.finish_params p
       in
-      T.select db ("WITH p AS (WITH inner_p AS (SELECT * FROM person WHERE name LIKE $1)\n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("WITH p AS (WITH inner_p AS (SELECT * FROM person WHERE name LIKE $1)\n\
   SELECT * FROM inner_p WHERE inner_p.id > $2)\n\
-  SELECT * FROM p WHERE p.user_id > $3") set_params invoke_callback
+  SELECT * FROM p WHERE p.user_id > $3") ~name:"outer_q" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback

--- a/test/cram/set_default_syntax.compare.ml
+++ b/test/cram/set_default_syntax.compare.ml
@@ -3,12 +3,12 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_registration_feedbacks db  =
-    T.execute db ("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),\n\
   `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks")) T.no_params
 
   let insert_registration_feedbacks_1 db ~user_message ~grant_types =
     let set_params stmt =
@@ -20,9 +20,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       end;
       T.finish_params p
     in
-    T.execute db ("INSERT INTO `registration_feedbacks`\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO `registration_feedbacks`\n\
 SET\n\
   `user_message` = " ^ (match user_message with Some _ -> " ( " ^ " CONCAT(" ^ "?" ^ ", '22222') " ^ " ) " | None -> " DEFAULT ") ^ ",\n\
-  `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> " ('2') " | `B -> " ('2') ") ^ " " ^ " ) " | None -> " DEFAULT ")) set_params
+  `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> " ('2') " | `B -> " ('2') ") ^ " " ^ " ) " | None -> " DEFAULT ")) ~name:"insert_registration_feedbacks_1" ~kind:Sqlgg_traits.Query.(Insert "registration_feedbacks")) set_params
 
 end (* module Sqlgg *)

--- a/test/cram/sqlcommenter.t
+++ b/test/cram/sqlcommenter.t
@@ -1,0 +1,88 @@
+sqlcommenter serializes attributes into a trailing comment: keys and values are
+url encoded, pairs are sorted, and an empty list leaves the query untouched.
+Only [sql] changes, so [name] and [kind] stay usable after annotating.
+
+  $ cat > sqlcommenter_test.ml <<'EOF'
+  > let q = Sqlgg_traits.Query.make ~sql:"SELECT id FROM users WHERE id = ?" ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)
+  > let show (q : Sqlgg_traits.Query.t) = Printf.printf "name=%s sql=%s\n" q.name q.sql
+  > let () =
+  >   show q;
+  >   show (Sqlgg_traits.Query.Sqlcommenter.annotate [ "query", q.name; "app", "billing api"; "route", "/users/1?full=1" ] q);
+  >   show (Sqlgg_traits.Query.Sqlcommenter.annotate [] q);
+  >   print_endline (Sqlgg_traits.Query.Sqlcommenter.comment [ "b", "2"; "a", "1" ])
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -linkpkg -o sqlcommenter_test.exe sqlcommenter_test.ml
+  $ ./sqlcommenter_test.exe
+  name=find_user sql=SELECT id FROM users WHERE id = ?
+  name=find_user sql=SELECT id FROM users WHERE id = ? /*app='billing%20api',query='find_user',route='%2Fusers%2F1%3Ffull%3D1'*/
+  name=find_user sql=SELECT id FROM users WHERE id = ?
+  /*a='1',b='2'*/
+
+A query is a black box for the user: fields are readable, but rewriting the sql
+behind the metadata is rejected, so the only way to change it is a helper.
+
+  $ cat > rewrite.ml <<'EOF'
+  > let evil (q : Sqlgg_traits.Query.t) = { q with Sqlgg_traits.Query.sql = "DROP TABLE users" }
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -c rewrite.ml
+  File "rewrite.ml", line 1, characters 38-92:
+  1 | let evil (q : Sqlgg_traits.Query.t) = { q with Sqlgg_traits.Query.sql = "DROP TABLE users" }
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Cannot create values of the private type Sqlgg_traits.Query.t
+  [2]
+
+  $ cat > forge.ml <<'EOF'
+  > let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other }
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -c forge.ml
+  File "forge.ml", line 1, characters 14-114:
+  1 | let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other }
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Cannot create values of the private type Sqlgg_traits.Query.t
+  [2]
+
+  $ cat > append.ml <<'EOF'
+  > let evil (q : Sqlgg_traits.Query.t) = Sqlgg_traits.Query.append_comment q "/*anything*/"
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -c append.ml
+  File "append.ml", line 1, characters 38-71:
+  1 | let evil (q : Sqlgg_traits.Query.t) = Sqlgg_traits.Query.append_comment q "/*anything*/"
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: Unbound value Sqlgg_traits.Query.append_comment
+  [2]
+
+A value cannot escape the comment it is serialized into: only the unreserved
+set survives encoding, so [*] and [/] cannot close the comment early, quotes
+cannot break out of the value, and utf8 is encoded byte by byte. Duplicate keys
+keep a deterministic order.
+
+  $ cat > escaping.ml <<'EOF'
+  > let () = List.iter (fun attrs -> print_endline (Sqlgg_traits.Query.Sqlcommenter.comment attrs)) [
+  >   [ "route", "*/ DROP TABLE users; /*" ];
+  >   [ "name", "O'Brien" ];
+  >   [ "city", "\xd0\x9a\xd0\xb8\xd1\x80\xd0\xb8\xd1\x88\xd0\xb8" ];
+  >   [ "k", "2"; "k", "1" ];
+  >   [ "", "" ];
+  > ]
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -linkpkg -o escaping.exe escaping.ml
+  $ ./escaping.exe
+  /*route='%2A%2F%20DROP%20TABLE%20users%3B%20%2F%2A'*/
+  /*name='O%27Brien'*/
+  /*city='%D0%9A%D0%B8%D1%80%D0%B8%D1%88%D0%B8'*/
+  /*k='1',k='2'*/
+  /*=''*/
+
+Annotating twice appends a second comment instead of replacing the first, so a
+query that is already annotated should not be handed to another annotator.
+
+  $ cat > twice.ml <<'EOF'
+  > let q = Sqlgg_traits.Query.make ~sql:"SELECT 1" ~name:"one" ~kind:Sqlgg_traits.Query.(Select One)
+  > let () =
+  >   let q = Sqlgg_traits.Query.Sqlcommenter.annotate [ "a", "1" ] q in
+  >   let q = Sqlgg_traits.Query.Sqlcommenter.annotate [ "b", "2" ] q in
+  >   print_endline q.Sqlgg_traits.Query.sql
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits -linkpkg -o twice.exe twice.ml
+  $ ./twice.exe
+  SELECT 1 /*a='1'*/ /*b='2'*/

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -919,13 +919,13 @@ Test Single style for SELECT 1/0..1 and hide empty modules:
     module IO = Sqlgg_io.Blocking
   
     let create_test20250902 db  =
-      T.execute db ("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") ~name:"create_test20250902" ~kind:Sqlgg_traits.Query.(Create "test20250902")) T.no_params
   
     let select_1 db  =
       let get_row stmt =
         (T.get_column_Int stmt 0)
       in
-      T.select_one db ("SELECT COUNT(*) FROM test20250902") T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
   
     module Single = struct
       let select_1 db  callback =
@@ -933,7 +933,7 @@ Test Single style for SELECT 1/0..1 and hide empty modules:
           callback
             ~r:(T.get_column_Int stmt 0)
         in
-        T.select_one db ("SELECT COUNT(*) FROM test20250902") T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -969,11 +969,11 @@ Test non_nullifiable when update:
     module IO = Sqlgg_io.Blocking
   
     let create_non_nullifiable db  =
-      T.execute db ("CREATE TABLE non_nullifiable (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE non_nullifiable (\n\
       name TEXT,\n\
           updated_at DATETIME NULL,\n\
       updated_at_not_nullable DATETIME NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_non_nullifiable" ~kind:Sqlgg_traits.Query.(Create "non_nullifiable")) T.no_params
   
     let update_non_nullifiable_1 db ~updated_at =
       let set_params stmt =
@@ -981,7 +981,7 @@ Test non_nullifiable when update:
         T.set_param_Datetime p updated_at;
         T.finish_params p
       in
-      T.execute db ("UPDATE non_nullifiable SET updated_at = ? WHERE name = 'example'") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE non_nullifiable SET updated_at = ? WHERE name = 'example'") ~name:"update_non_nullifiable_1" ~kind:Sqlgg_traits.Query.(Update (Some "non_nullifiable"))) set_params
   
   end (* module Sqlgg *)
 
@@ -1067,14 +1067,14 @@ Test non_nullifiable with multi-row INSERT (NULL allowed on insert):
     module IO = Sqlgg_io.Blocking
   
     let create_nn_insert_multi db  =
-      T.execute db ("CREATE TABLE nn_insert_multi (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_multi (\n\
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") T.no_params
+  )") ~name:"create_nn_insert_multi" ~kind:Sqlgg_traits.Query.(Create "nn_insert_multi")) T.no_params
   
     let insert_nn_insert_multi_1 db  =
-      T.execute db ("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") ~name:"insert_nn_insert_multi_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_multi")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1121,11 +1121,11 @@ Test non_nullifiable with INSERT ... ON DUPLICATE KEY UPDATE (values nullable, N
     module IO = Sqlgg_io.Blocking
   
     let create_nn_upsert db  =
-      T.execute db ("CREATE TABLE nn_upsert (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_upsert (\n\
       id INT PRIMARY KEY,\n\
           column1 INT NULL,\n\
           column2 VARCHAR(255) NULL\n\
-  )") T.no_params
+  )") ~name:"create_nn_upsert" ~kind:Sqlgg_traits.Query.(Create "nn_upsert")) T.no_params
   
     let insert_nn_upsert_1 db ~v1 ~v2 =
       let set_params stmt =
@@ -1134,11 +1134,11 @@ Test non_nullifiable with INSERT ... ON DUPLICATE KEY UPDATE (values nullable, N
         T.set_param_Text p v2;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO nn_upsert (id, column1, column2)\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_upsert (id, column1, column2)\n\
   VALUES (1, ?, ?)\n\
   ON DUPLICATE KEY UPDATE \n\
     column1 = VALUES(column1),\n\
-    column2 = VALUES(column2)") set_params
+    column2 = VALUES(column2)") ~name:"insert_nn_upsert_1" ~kind:Sqlgg_traits.Query.(Insert "nn_upsert")) set_params
   
   end (* module Sqlgg *)
 
@@ -1162,20 +1162,20 @@ Test non_nullifiable with INSERT ... SELECT (source may produce NULLs):
     module IO = Sqlgg_io.Blocking
   
     let create_nn_src db  =
-      T.execute db ("CREATE TABLE nn_src (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_src (\n\
       id INT PRIMARY KEY,\n\
       ts DATETIME\n\
-  )") T.no_params
+  )") ~name:"create_nn_src" ~kind:Sqlgg_traits.Query.(Create "nn_src")) T.no_params
   
     let create_nn_dst db  =
-      T.execute db ("CREATE TABLE nn_dst (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_dst (\n\
       id INT PRIMARY KEY,\n\
           published_at DATETIME\n\
-  )") T.no_params
+  )") ~name:"create_nn_dst" ~kind:Sqlgg_traits.Query.(Create "nn_dst")) T.no_params
   
     let insert_nn_dst_2 db  =
-      T.execute db ("INSERT INTO nn_dst (id, published_at)\n\
-  SELECT id, ts FROM nn_src") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_dst (id, published_at)\n\
+  SELECT id, ts FROM nn_src") ~name:"insert_nn_dst_2" ~kind:Sqlgg_traits.Query.(Insert "nn_dst")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1194,14 +1194,14 @@ Test INSERT (.. ) VALUES @rows with non_nullifiable column (NULL allowed on inse
     module IO = Sqlgg_io.Blocking
   
     let create_nn_insert_param db  =
-      T.execute db ("CREATE TABLE nn_insert_param (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_param (\n\
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") T.no_params
+  )") ~name:"create_nn_insert_param" ~kind:Sqlgg_traits.Query.(Create "nn_insert_param")) T.no_params
   
     let insert_nn_insert_param_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db ("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_nn_insert_param_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_param")) T.no_params )
   
   end (* module Sqlgg *)
 
@@ -1215,10 +1215,10 @@ Test INSERT (..) VALUES @rows with columns whose names are OCaml keywords (must 
     module IO = Sqlgg_io.Blocking
   
     let create_kw_rows db  =
-      T.execute db ("CREATE TABLE kw_rows (type INTEGER, val TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw_rows (type INTEGER, val TEXT)") ~name:"create_kw_rows" ~kind:Sqlgg_traits.Query.(Create "kw_rows")) T.no_params
   
     let insert_kw_rows_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db ("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_kw_rows_1" ~kind:Sqlgg_traits.Query.(Insert "kw_rows")) T.no_params )
   
   end (* module Sqlgg *)
 
@@ -1352,10 +1352,10 @@ order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let update_1 db  =
-      T.execute db ("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1369,7 +1369,7 @@ parametrized order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let update_1 db ~order ~direction ~limit =
       let set_params stmt =
@@ -1377,7 +1377,7 @@ parametrized order by and limit are supported with update stmt + table alias:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db ("UPDATE test t SET t.column_a = 'value' ORDER BY " ^ (match order with `Id -> " (t.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY " ^ (match order with `Id -> " (t.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) set_params
   
   end (* module Sqlgg *)
 
@@ -1391,7 +1391,7 @@ limit is supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let update_1 db ~limit =
       let set_params stmt =
@@ -1399,7 +1399,7 @@ limit is supported with update stmt + table alias:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db ("UPDATE test t SET t.column_a = 'value' LIMIT ?") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) set_params
   
   end (* module Sqlgg *)
 
@@ -1414,10 +1414,10 @@ order by and limit are supported with update stmt + table alias + join:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let create_test2 db  =
-      T.execute db ("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") ~name:"create_test2" ~kind:Sqlgg_traits.Query.(Create "test2")) T.no_params
   
     let update_2 db ~value ~order ~direction ~limit =
       let set_params stmt =
@@ -1427,7 +1427,7 @@ order by and limit are supported with update stmt + table alias + join:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db ("UPDATE test t JOIN test2 t2 ON t.id = t2.test_id SET t.column_a = ?, t2.column_a = ? ORDER BY " ^ (match order with `Id_1 -> " (t.id) " | `Id_2 -> " (t2.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t JOIN test2 t2 ON t.id = t2.test_id SET t.column_a = ?, t2.column_a = ? ORDER BY " ^ (match order with `Id_1 -> " (t.id) " | `Id_2 -> " (t2.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_2" ~kind:Sqlgg_traits.Query.(Update None)) set_params
   
   end (* module Sqlgg *)
 
@@ -1467,18 +1467,18 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
     module IO = Sqlgg_io.Blocking
   
     let create_table_1_2025_09_26 db  =
-      T.execute db ("CREATE TABLE table_1_2025_09_26 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_1_2025_09_26 (\n\
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_1 DATE,\n\
       table_no INT\n\
-  )") T.no_params
+  )") ~name:"create_table_1_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_1_2025_09_26")) T.no_params
   
     let create_table_2_2025_09_26 db  =
-      T.execute db ("CREATE TABLE table_2_2025_09_26 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_2_2025_09_26 (\n\
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_2 DATE,\n\
       table_no INT\n\
-  )") T.no_params
+  )") ~name:"create_table_2_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_2_2025_09_26")) T.no_params
   
     let select_2 db ~order_kind ~par callback =
       let invoke_callback stmt =
@@ -1494,7 +1494,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
         T.set_param_Int p par;
         T.finish_params p
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
       t1.table_no,\n\
       GROUP_CONCAT(\n\
           t1.date_1 \n\
@@ -1510,7 +1510,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") set_params invoke_callback
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
   
     module Fold = struct
       let select_2 db ~order_kind ~par callback acc =
@@ -1528,7 +1528,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
       t1.table_no,\n\
       GROUP_CONCAT(\n\
           t1.date_1 \n\
@@ -1544,7 +1544,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1565,7 +1565,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
       t1.table_no,\n\
       GROUP_CONCAT(\n\
           t1.date_1 \n\
@@ -1581,7 +1581,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1605,9 +1605,9 @@ INSERT ... SELECT with UNION ALL and enum meta propagation (short):
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum_union db  =
-      T.execute db ("CREATE TABLE t_enum_union (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_union (\n\
       pending_type ENUM('downgrade','upgrade') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_enum_union" ~kind:Sqlgg_traits.Query.(Create "t_enum_union")) T.no_params
   
     let insert_t_enum_union_1 db ~p =
       let set_params stmt =
@@ -1616,10 +1616,10 @@ INSERT ... SELECT with UNION ALL and enum meta propagation (short):
         T.set_param_string p (Custom.set_param p);
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t_enum_union (pending_type)\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t_enum_union (pending_type)\n\
   SELECT pending_type FROM t_enum_union WHERE pending_type = ?\n\
   UNION ALL\n\
-  SELECT ?") set_params
+  SELECT ?") ~name:"insert_t_enum_union_1" ~kind:Sqlgg_traits.Query.(Insert "t_enum_union")) set_params
   
   end (* module Sqlgg *)
   $ echo $?
@@ -1644,9 +1644,9 @@ INSERT ... SELECT with meta propagation:
       end)
   
     let create_t_dst db  =
-      T.execute db ("CREATE TABLE t_dst (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_dst (\n\
     status ENUM('a','b') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_dst" ~kind:Sqlgg_traits.Query.(Create "t_dst")) T.no_params
   
     let insert_t_dst_1 db ~s =
       let set_params stmt =
@@ -1654,8 +1654,8 @@ INSERT ... SELECT with meta propagation:
         Enum_0.set_param p s;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t_dst (status)\n\
-  SELECT ?") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t_dst (status)\n\
+  SELECT ?") ~name:"insert_t_dst_1" ~kind:Sqlgg_traits.Query.(Insert "t_dst")) set_params
   
   end (* module Sqlgg *)
   $ echo $?
@@ -1717,7 +1717,7 @@ Test UINT64 mapping for UNSIGNED INT:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db ("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1727,7 +1727,7 @@ Test UINT64 mapping for UNSIGNED INT:
           ~calc_2:(T.get_column_Float_nullable stmt 2)
           ~v:(T.get_column_Int_nullable stmt 3)
       in
-      T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1735,7 +1735,7 @@ Test UINT64 mapping for UNSIGNED INT:
         begin match id with None -> T.set_param_null p | Some v -> T.set_param_UInt64 p v end;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t1 (id, v) VALUES (?, 123)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1747,7 +1747,7 @@ Test UINT64 mapping for UNSIGNED INT:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1762,7 +1762,7 @@ Test UINT64 mapping for UNSIGNED INT:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1783,10 +1783,10 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db ("CREATE TABLE t1 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (\n\
    id BIGINT UNSIGNED,\n\
    v INT\n\
-  )") T.no_params
+  )") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1796,7 +1796,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
           ~calc_2:(T.get_column_Float_nullable stmt 2)
           ~v:(T.get_column_Int_nullable stmt 3)
       in
-      T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1804,7 +1804,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
         begin match id with None -> T.set_param_null p | Some id -> T.set_param_uint64 p (Wrap_it.set_param id); end;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t1 (id, v) VALUES (?, 123)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1816,7 +1816,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1831,7 +1831,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1849,7 +1849,7 @@ Test UINT64 in type spec:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db ("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
   
     let insert_t1_1 db ~id =
       let set_params stmt =
@@ -1857,7 +1857,7 @@ Test UINT64 in type spec:
         T.set_param_UInt64 p id;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t1 (id, v) VALUES (?, 123)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_1" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1865,7 +1865,7 @@ Test UINT64 in type spec:
         begin match id with None -> T.set_param_null p | Some v -> T.set_param_UInt64 p v end;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t1 (id, v) VALUES (?, 123)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
   
     let insert_t1_3 db ~id =
       let set_params stmt =
@@ -1873,7 +1873,7 @@ Test UINT64 in type spec:
         T.set_param_Int p id;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO t1 (id, v) VALUES (?, 123)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_3" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
   
   end (* module Sqlgg *)
 
@@ -1893,14 +1893,14 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db ("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Enum_0.get_column stmt 0)
       in
-      T.select db ("SELECT status FROM t_enum1") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1909,7 +1909,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum1") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1921,7 +1921,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum1") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1944,14 +1944,14 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db ("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Enum_0.get_column stmt 0)
       in
-      T.select db ("SELECT status FROM t_enum1") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1960,7 +1960,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum1") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1972,7 +1972,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum1") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1993,16 +1993,16 @@ Enum generation with custom module (should not generate open variants, should us
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum2 db  =
-      T.execute db ("CREATE TABLE t_enum2 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Custom.get_column (T.get_column_string stmt 0))
       in
-      T.select db ("SELECT status FROM t_enum2") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2011,7 +2011,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum2") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2023,7 +2023,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum2") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2043,16 +2043,16 @@ Enum generation with custom module (should not generate open variants, should us
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum2 db  =
-      T.execute db ("CREATE TABLE t_enum2 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Custom.get_column (T.get_column_string stmt 0))
       in
-      T.select db ("SELECT status FROM t_enum2") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2061,7 +2061,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum2") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2073,7 +2073,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT status FROM t_enum2") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2102,10 +2102,10 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
       end)
   
     let create_t_enum_mix db  =
-      T.execute db ("CREATE TABLE t_enum_mix (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_mix (\n\
     col_a ENUM('a','b') NOT NULL,\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_enum_mix" ~kind:Sqlgg_traits.Query.(Create "t_enum_mix")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2113,7 +2113,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
           ~col_a:(Enum_0.get_column stmt 0)
           ~col_b:(Custom.get_column (T.get_column_string stmt 1))
       in
-      T.select db ("SELECT col_a, col_b FROM t_enum_mix") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2123,7 +2123,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
             ~col_b:(Custom.get_column (T.get_column_string stmt 1))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT col_a, col_b FROM t_enum_mix") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2136,7 +2136,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
             ~col_b:(Custom.get_column (T.get_column_string stmt 1))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT col_a, col_b FROM t_enum_mix") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2155,9 +2155,9 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum_tuple db  =
-      T.execute db ("CREATE TABLE t_enum_tuple (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_tuple (\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_t_enum_tuple" ~kind:Sqlgg_traits.Query.(Create "t_enum_tuple")) T.no_params
   
     let select_1 db ~vals callback =
       let invoke_callback stmt =
@@ -2168,7 +2168,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
         let p = T.start_params stmt (0 + (match vals with [] -> 0 | _ :: _ -> 0)) in
         T.finish_params p
       in
-      T.select db ("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~vals callback acc =
@@ -2181,7 +2181,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2197,7 +2197,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2216,16 +2216,16 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
     module IO = Sqlgg_io.Blocking
   
     let create_test_ifnull_enum db  =
-      T.execute db ("CREATE TABLE test_ifnull_enum (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_ifnull_enum (\n\
       priority ENUM('low','medium','high') NULL\n\
-  )") T.no_params
+  )") ~name:"create_test_ifnull_enum" ~kind:Sqlgg_traits.Query.(Create "test_ifnull_enum")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~r:(Priority.get_column (T.get_column_string stmt 0))
       in
-      T.select db ("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2234,7 +2234,7 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
             ~r:(Priority.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2246,7 +2246,7 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
             ~r:(Priority.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2265,9 +2265,9 @@ Test meta propagation: INSERT with Choices should propagate ENUM metadata to cho
     module IO = Sqlgg_io.Blocking
   
     let create_test_insert_choices db  =
-      T.execute db ("CREATE TABLE test_insert_choices (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_insert_choices (\n\
       status ENUM('pending','completed') NOT NULL\n\
-  )") T.no_params
+  )") ~name:"create_test_insert_choices" ~kind:Sqlgg_traits.Query.(Create "test_insert_choices")) T.no_params
   
     let insert_test_insert_choices_1 db ~x =
       let set_params stmt =
@@ -2279,7 +2279,7 @@ Test meta propagation: INSERT with Choices should propagate ENUM metadata to cho
         end;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO test_insert_choices SET status = " ^ (match x with `Set _ -> " ( ? ) " | `Default -> " ( 'pending' ) ")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_insert_choices SET status = " ^ (match x with `Set _ -> " ( ? ) " | `Default -> " ( 'pending' ) ")) ~name:"insert_test_insert_choices_1" ~kind:Sqlgg_traits.Query.(Insert "test_insert_choices")) set_params
   
   end (* module Sqlgg *)
 
@@ -2295,8 +2295,8 @@ Test FloatingLiteral:
       let get_row stmt =
         (T.get_column_Float stmt 0)
       in
-      T.select_one db ("SELECT 1.2\n\
-  ") T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT 1.2\n\
+  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
   
     module Single = struct
       let select_0 db  callback =
@@ -2304,8 +2304,8 @@ Test FloatingLiteral:
           callback
             ~r:(T.get_column_Float stmt 0)
         in
-        T.select_one db ("SELECT 1.2\n\
-  ") T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT 1.2\n\
+  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -2324,10 +2324,10 @@ Test numeric literals and decimal types:
     module IO = Sqlgg_io.Blocking
   
     let create_shop_items db  =
-      T.execute db ("CREATE TABLE shop_items (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shop_items (\n\
    id INT PRIMARY KEY,\n\
    pending_price DECIMAL(12,3)\n\
-  )") T.no_params
+  )") ~name:"create_shop_items" ~kind:Sqlgg_traits.Query.(Create "shop_items")) T.no_params
   
     let select_1 db ~pending_price callback =
       let invoke_callback stmt =
@@ -2340,8 +2340,8 @@ Test numeric literals and decimal types:
         T.set_param_Float p pending_price;
         T.finish_params p
       in
-      T.select db ("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~pending_price callback acc =
@@ -2356,8 +2356,8 @@ Test numeric literals and decimal types:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2375,8 +2375,8 @@ Test numeric literals and decimal types:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2392,10 +2392,10 @@ Test numeric literal to float:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price FLOAT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let insert_items_1 db  =
-      T.execute db ("INSERT INTO items VALUES (99.99)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2409,10 +2409,10 @@ Test numeric literal to decimal - valid:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price DECIMAL(5,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let insert_items_1 db  =
-      T.execute db ("INSERT INTO items VALUES (99.99)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2435,10 +2435,10 @@ Test numeric literal to decimal - invalid (too many decimals):
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price DECIMAL(5,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let insert_items_1 db  =
-      T.execute db ("INSERT INTO items VALUES (99.999)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.999)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2470,7 +2470,7 @@ Test decimal to float - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2478,7 +2478,7 @@ Test decimal to float - allowed:
           ~price:(T.get_column_Decimal_nullable stmt 0)
           ~price_float:(T.get_column_Float_nullable stmt 1)
       in
-      T.select db ("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2488,7 +2488,7 @@ Test decimal to float - allowed:
             ~price_float:(T.get_column_Float_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2501,7 +2501,7 @@ Test decimal to float - allowed:
             ~price_float:(T.get_column_Float_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2517,10 +2517,10 @@ Test int to decimal - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let insert_items_1 db  =
-      T.execute db ("INSERT INTO items VALUES (100)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (100)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2535,17 +2535,17 @@ Test decimal arithmetic preserves scale:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db ("CREATE TABLE t1 (col1 DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (col1 DECIMAL(10,2))") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
   
     let create_t2 db  =
-      T.execute db ("CREATE TABLE t2 (col2 DECIMAL(12,3))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t2 (col2 DECIMAL(12,3))") ~name:"create_t2" ~kind:Sqlgg_traits.Query.(Create "t2")) T.no_params
   
     let select_2 db  callback =
       let invoke_callback stmt =
         callback
           ~total:(T.get_column_Decimal_nullable stmt 0)
       in
-      T.select db ("SELECT col1 + col2 as total FROM t1, t2") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_2 db  callback acc =
@@ -2554,7 +2554,7 @@ Test decimal arithmetic preserves scale:
             ~total:(T.get_column_Decimal_nullable stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT col1 + col2 as total FROM t1, t2") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2566,7 +2566,7 @@ Test decimal arithmetic preserves scale:
             ~total:(T.get_column_Decimal_nullable stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT col1 + col2 as total FROM t1, t2") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2582,7 +2582,7 @@ Test parameter with decimal cast:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (price DECIMAL(12,3))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(12,3))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     let select_1 db ~price callback =
       let invoke_callback stmt =
@@ -2594,7 +2594,7 @@ Test parameter with decimal cast:
         T.set_param_Any p price;
         T.finish_params p
       in
-      T.select db ("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~price callback acc =
@@ -2608,7 +2608,7 @@ Test parameter with decimal cast:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2625,7 +2625,7 @@ Test parameter with decimal cast:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2641,10 +2641,10 @@ Test REPLACE function for string substitution:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db ("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025")) T.no_params
   
     let update_table_24_10_2025_1 db  =
-      T.execute db ("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") ~name:"update_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Update (Some "table_24_10_2025"))) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2658,7 +2658,7 @@ Test REPLACE function with INSERT REPLACE in same query:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db ("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025")) T.no_params
   
     let insert_table_24_10_2025_1 db ~value =
       let set_params stmt =
@@ -2666,7 +2666,7 @@ Test REPLACE function with INSERT REPLACE in same query:
         T.set_param_Text p value;
         T.finish_params p
       in
-      T.execute db ("REPLACE INTO table_24_10_2025 (col_1, col_2) VALUES (REPLACE(?, ',', ' '), 'data')") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("REPLACE INTO table_24_10_2025 (col_1, col_2) VALUES (REPLACE(?, ',', ' '), 'data')") ~name:"insert_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Insert "table_24_10_2025")) set_params
   
   end (* module Sqlgg *)
 
@@ -2688,12 +2688,12 @@ Test BIGINT(20) UNSIGNED with module annotation:
     module IO = Sqlgg_io.Blocking
   
     let create_test_table db  =
-      T.execute db ("CREATE TABLE test_table (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_table (\n\
     id BIGINT(20) UNSIGNED NOT NULL,\n\
     counter INT(10) UNSIGNED NOT NULL,\n\
     counter2 BIGINT(10) UNSIGNED NOT NULL DEFAULT 0,\n\
     name TEXT\n\
-  )") T.no_params
+  )") ~name:"create_test_table" ~kind:Sqlgg_traits.Query.(Create "test_table")) T.no_params
   
     let select_1 db ~id callback =
       let invoke_callback stmt =
@@ -2708,7 +2708,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         T.set_param_uint64 p (TestModule.set_param id);
         T.finish_params p
       in
-      T.select db ("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
   
     let insert_test_table_2 db ~id ~counter ~counter2 ~name =
       let set_params stmt =
@@ -2719,7 +2719,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         begin match name with None -> T.set_param_null p | Some v -> T.set_param_Text p v end;
         T.finish_params p
       in
-      T.execute db ("INSERT INTO test_table (id, counter, counter2, name) VALUES (?, ?, ?, ?)") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_table (id, counter, counter2, name) VALUES (?, ?, ?, ?)") ~name:"insert_test_table_2" ~kind:Sqlgg_traits.Query.(Insert "test_table")) set_params
   
     let update_test_table_3 db ~counter ~counter2 ~name ~id =
       let set_params stmt =
@@ -2730,7 +2730,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         T.set_param_uint64 p (TestModule.set_param id);
         T.finish_params p
       in
-      T.execute db ("UPDATE test_table SET counter = ?, counter2 = ?, name = ? WHERE id = ?") set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test_table SET counter = ?, counter2 = ?, name = ? WHERE id = ?") ~name:"update_test_table_3" ~kind:Sqlgg_traits.Query.(Update (Some "test_table"))) set_params
   
     module Fold = struct
       let select_1 db ~id callback acc =
@@ -2747,7 +2747,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2767,7 +2767,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2834,14 +2834,14 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     module IO = Sqlgg_io.Blocking
   
     let create_orders db  =
-      T.execute db ("CREATE TABLE orders (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
     id INT PRIMARY KEY,\n\
     customer_id INT NOT NULL,\n\
     product TEXT NOT NULL,\n\
     quantity INT NOT NULL,\n\
     price DECIMAL(10,2) NOT NULL,\n\
     description TEXT\n\
-  )") T.no_params
+  )") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2849,11 +2849,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~products_with_qty:(T.get_column_Text stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_2 db  callback =
       let invoke_callback stmt =
@@ -2861,11 +2861,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~unique_combos:(T.get_column_Text stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_3 db  callback =
       let invoke_callback stmt =
@@ -2873,11 +2873,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~products_json:(T.get_column_Json stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_4 db  callback =
       let invoke_callback stmt =
@@ -2885,11 +2885,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~unique_products:(T.get_column_Json stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_5 db  callback =
       let invoke_callback stmt =
@@ -2897,11 +2897,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~products_by_price:(T.get_column_Json stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_6 db  callback =
       let invoke_callback stmt =
@@ -2909,11 +2909,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~sorted_unique_products:(T.get_column_Json stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_7 db  callback =
       let invoke_callback stmt =
@@ -2921,11 +2921,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~top_3_products:(T.get_column_Json stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_8 db  callback =
       let invoke_callback stmt =
@@ -2933,11 +2933,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~descriptions:(T.get_column_Json_nullable stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     let select_9 db  callback =
       let invoke_callback stmt =
@@ -2945,11 +2945,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
           ~customer_id:(T.get_column_Int stmt 0)
           ~ordered_descriptions:(T.get_column_Json_nullable stmt 1)
       in
-      T.select db ("SELECT \n\
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2959,11 +2959,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_with_qty:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_2 db  callback acc =
@@ -2973,11 +2973,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~unique_combos:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_3 db  callback acc =
@@ -2987,11 +2987,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_json:(T.get_column_Json stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_4 db  callback acc =
@@ -3001,11 +3001,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~unique_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_5 db  callback acc =
@@ -3015,11 +3015,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_by_price:(T.get_column_Json stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_6 db  callback acc =
@@ -3029,11 +3029,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~sorted_unique_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_7 db  callback acc =
@@ -3043,11 +3043,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~top_3_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_8 db  callback acc =
@@ -3057,11 +3057,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~descriptions:(T.get_column_Json_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_9 db  callback acc =
@@ -3071,11 +3071,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~ordered_descriptions:(T.get_column_Json_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3088,11 +3088,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_with_qty:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_2 db  callback =
@@ -3102,11 +3102,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~unique_combos:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_3 db  callback =
@@ -3116,11 +3116,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_json:(T.get_column_Json stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_4 db  callback =
@@ -3130,11 +3130,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~unique_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_5 db  callback =
@@ -3144,11 +3144,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~products_by_price:(T.get_column_Json stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_6 db  callback =
@@ -3158,11 +3158,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~sorted_unique_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_7 db  callback =
@@ -3172,11 +3172,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~top_3_products:(T.get_column_Json stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_8 db  callback =
@@ -3186,11 +3186,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~descriptions:(T.get_column_Json_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_9 db  callback =
@@ -3200,11 +3200,11 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
             ~ordered_descriptions:(T.get_column_Json_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT \n\
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3223,14 +3223,14 @@ Test test date functions that are both expressions and functions:
       let get_row stmt =
         (T.get_column_Datetime stmt 0), (T.get_column_Datetime stmt 1), (T.get_column_Datetime stmt 2)
       in
-      T.select_one db ("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
   
     let select_1 db  =
       let get_row stmt =
         (T.get_column_Int stmt 0)
       in
-      T.select_one db ("SELECT DAY(CURRENT_DATE)\n\
-  ") T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT DAY(CURRENT_DATE)\n\
+  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
   
     module Single = struct
       let select_0 db  callback =
@@ -3240,15 +3240,15 @@ Test test date functions that are both expressions and functions:
             ~r0:(T.get_column_Datetime stmt 1)
             ~r1:(T.get_column_Datetime stmt 2)
         in
-        T.select_one db ("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
   
       let select_1 db  callback =
         let invoke_callback stmt =
           callback
             ~r:(T.get_column_Int stmt 0)
         in
-        T.select_one db ("SELECT DAY(CURRENT_DATE)\n\
-  ") T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT DAY(CURRENT_DATE)\n\
+  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -3271,19 +3271,19 @@ Test DEFAULT dialect feature valid for mysql:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_ts_interval db  =
-      T.execute db ("CREATE TABLE ok_ts_interval (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_interval (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") T.no_params
+  )") ~name:"create_ok_ts_interval" ~kind:Sqlgg_traits.Query.(Create "ok_ts_interval")) T.no_params
   
     let create_ok_ts_func db  =
-      T.execute db ("CREATE TABLE ok_ts_func (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_func (\n\
     ts DATETIME DEFAULT (DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 DAY))\n\
-  )") T.no_params
+  )") ~name:"create_ok_ts_func" ~kind:Sqlgg_traits.Query.(Create "ok_ts_func")) T.no_params
   
     let create_ok_tidb_ts db  =
-      T.execute db ("CREATE TABLE ok_tidb_ts (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3319,9 +3319,9 @@ Test DEFAULT dialect feature valid for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_tidb_ts db  =
-      T.execute db ("CREATE TABLE ok_tidb_ts (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3346,9 +3346,9 @@ Test DEFAULT dialect feature valid for sqlite:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_tidb_ts db  =
-      T.execute db ("CREATE TABLE ok_tidb_ts (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3364,10 +3364,10 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_t4 db  =
-      T.execute db ("CREATE TABLE t4 (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t4 (\n\
     id bigint PRIMARY KEY,\n\
     j json DEFAULT (JSON_OBJECT(\"a\", 1, \"b\", 2))\n\
-  )") T.no_params
+  )") ~name:"create_t4" ~kind:Sqlgg_traits.Query.(Create "t4")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3394,9 +3394,9 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_user_status db  =
-      T.execute db ("CREATE TABLE user_status (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE user_status (\n\
    status ENUM('active', 'inactive', 'banned') NOT NULL DEFAULT 'active'\n\
-  )") T.no_params
+  )") ~name:"create_user_status" ~kind:Sqlgg_traits.Query.(Create "user_status")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3412,9 +3412,9 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_tbl db  =
-      T.execute db ("CREATE TABLE tbl (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE tbl (\n\
    f1 INT NOT NULL DEFAULT 1\n\
-  )") T.no_params
+  )") ~name:"create_tbl" ~kind:Sqlgg_traits.Query.(Create "tbl")) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3439,7 +3439,7 @@ Test IS NOT NULL type refinement:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT, str TEXT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3447,7 +3447,7 @@ Test IS NOT NULL type refinement:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text stmt 1)
       in
-      T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3457,7 +3457,7 @@ Test IS NOT NULL type refinement:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3470,7 +3470,7 @@ Test IS NOT NULL type refinement:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3486,7 +3486,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3494,7 +3494,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text stmt 1)
       in
-      T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3504,7 +3504,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3517,7 +3517,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NOT NULL") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3533,7 +3533,7 @@ Test IS NOT NULL type refinement with IS NULL:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db ("CREATE TABLE test (id INT, str TEXT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3541,7 +3541,7 @@ Test IS NOT NULL type refinement with IS NULL:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text_nullable stmt 1)
       in
-      T.select db ("SELECT str, name FROM test WHERE name IS NULL") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3551,7 +3551,7 @@ Test IS NOT NULL type refinement with IS NULL:
             ~name:(T.get_column_Text_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NULL") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3564,7 +3564,7 @@ Test IS NOT NULL type refinement with IS NULL:
             ~name:(T.get_column_Text_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT str, name FROM test WHERE name IS NULL") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3594,7 +3594,7 @@ independently, so precedence is protected at each depth:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'WHERE FALSE AND' | head -1
   > SELECT 1 WHERE FALSE AND @a { Outer { @b { P { TRUE } | Q { FALSE OR TRUE } } } | Other { 1 = 1 } };
   > EOF
-      T.select_one_maybe db ("SELECT 1 WHERE FALSE AND " ^ (match a with `Outer (b) -> " ( " ^ (match b with `P -> " ( TRUE ) " | `Q -> " ( FALSE OR TRUE ) ") ^ " ) " | `Other -> " ( 1 = 1 ) ")) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match a with `Outer (b) -> " ( " ^ (match b with `P -> " ( TRUE ) " | `Q -> " ( FALSE OR TRUE ) ") ^ " ) " | `Other -> " ( 1 = 1 ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
 
 Composite: a choice branch with bound params and a compound AND body is wrapped
 as a whole:
@@ -3602,7 +3602,7 @@ as a whole:
   > CREATE TABLE t (a INT, b INT, c INT);
   > SELECT a FROM t WHERE TRUE OR @b { S { a = @p AND b = @q } | T { c > @r } };
   > EOF
-      T.select db ("SELECT a FROM t WHERE TRUE OR " ^ (match b with `S _ -> " ( a = ? AND b = ? ) " | `T _ -> " ( c > ? ) ")) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE TRUE OR " ^ (match b with `S _ -> " ( a = ? AND b = ? ) " | `T _ -> " ( c > ? ) ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
 Composite: a bool-choice ({...}?) whose body itself contains a nested choice —
 the bool-choice wraps the active branch and the inner choice wraps each branch:
@@ -3610,19 +3610,19 @@ the bool-choice wraps the active branch and the inner choice wraps each branch:
   > CREATE TABLE t (a INT, b INT);
   > SELECT a FROM t WHERE FALSE AND { a = @v OR @c { A { b = 1 } | B { b = 2 } } }?;
   > EOF
-      T.select db ("SELECT a FROM t WHERE FALSE AND " ^ (match v with Some (_, c) -> " ( " ^ " a = " ^ "?" ^ " OR " ^ (match c with `A -> " ( b = 1 ) " | `B -> " ( b = 2 ) ") ^ " " ^ " ) " | None -> " TRUE ")) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE FALSE AND " ^ (match v with Some (_, c) -> " ( " ^ " a = " ^ "?" ^ " OR " ^ (match c with `A -> " ( b = 1 ) " | `B -> " ( b = 2 ) ") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
 PoC: without hand-written parentheses, the branch body is grouped correctly as
 FALSE AND ( FALSE OR TRUE ) instead of leaking into FALSE AND FALSE OR TRUE:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'SELECT 1 WHERE' | head -1
   > SELECT 1 WHERE FALSE AND @b { None { TRUE } | Some { FALSE OR TRUE } };
   > EOF
-      T.select_one_maybe db ("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( FALSE OR TRUE ) ")) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( FALSE OR TRUE ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
 
 PoC: hand-written parentheses are now redundant — same semantics, just an extra
 harmless pair:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'SELECT 1 WHERE' | head -1
   > SELECT 1 WHERE FALSE AND @b { None { TRUE } | Some { (FALSE OR TRUE) } };
   > EOF
-      T.select_one_maybe db ("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( (FALSE OR TRUE) ) ")) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( (FALSE OR TRUE) ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
 

--- a/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -133,7 +133,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -150,7 +150,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -193,7 +193,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -207,7 +207,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -224,7 +224,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -234,13 +234,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_orders db  =
-    T.execute db ("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
+++ b/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -86,13 +86,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_avatars db  =
-    T.execute db ("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -137,7 +137,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -151,7 +151,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -168,7 +168,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -220,7 +220,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -234,7 +234,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -251,7 +251,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -312,7 +312,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -326,7 +326,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -343,7 +343,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -353,16 +353,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_avatars db  =
-    T.execute db ("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
 
   let create_badges db  =
-    T.execute db ("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") ~name:"create_badges" ~kind:Sqlgg_traits.Query.(Create "badges")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/example.t/example.compare.ml
+++ b/test/cram/test_build_dynamic_join/example.t/example.compare.ml
@@ -117,9 +117,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ "\n\
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE")
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -133,9 +133,9 @@ WHERE u.org_id = ? AND u.deleted = FALSE")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE")
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -152,9 +152,9 @@ WHERE u.org_id = ? AND u.deleted = FALSE")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE")
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -164,31 +164,31 @@ WHERE u.org_id = ? AND u.deleted = FALSE")
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
   id INT PRIMARY KEY,\n\
   org_id INT NOT NULL,\n\
   name TEXT NOT NULL,\n\
   email TEXT NOT NULL,\n\
   created_at TIMESTAMP NOT NULL,\n\
   deleted BOOLEAN NOT NULL\n\
-)") T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (\n\
   user_id INT PRIMARY KEY,\n\
   bio TEXT,\n\
   avatar_url TEXT,\n\
   location TEXT,\n\
   website TEXT\n\
-)") T.no_params
+)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_billing db  =
-    T.execute db ("CREATE TABLE billing (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (\n\
   user_id INT PRIMARY KEY,\n\
   plan TEXT NOT NULL,\n\
   paid_until DATETIME,\n\
   balance INT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -267,7 +267,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -281,7 +281,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -298,7 +298,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -350,7 +350,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -364,7 +364,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -381,7 +381,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -424,7 +424,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -438,7 +438,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -455,7 +455,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -498,7 +498,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -512,7 +512,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -529,7 +529,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -581,7 +581,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -595,7 +595,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -612,7 +612,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -622,16 +622,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_orders db  =
-    T.execute db ("CREATE TABLE orders (bio TEXT, amount INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (bio TEXT, amount INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
 
   let create_shipments db  =
-    T.execute db ("CREATE TABLE shipments (user_id INT, status TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shipments (user_id INT, status TEXT)") ~name:"create_shipments" ~kind:Sqlgg_traits.Query.(Create "shipments")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -225,13 +225,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_accounts db  =
-    T.execute db ("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
 
   let create_memberships db  =
-    T.execute db ("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") ~name:"create_memberships" ~kind:Sqlgg_traits.Query.(Create "memberships")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
+++ b/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -128,7 +128,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -142,7 +142,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -159,7 +159,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -211,7 +211,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -225,7 +225,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -242,7 +242,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -252,13 +252,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_avatars db  =
-    T.execute db ("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
@@ -37,7 +37,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -52,7 +52,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -70,7 +70,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -113,7 +113,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -127,7 +127,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -144,7 +144,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -187,7 +187,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -201,7 +201,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -218,7 +218,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -261,7 +261,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -275,7 +275,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -292,7 +292,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -335,7 +335,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -349,7 +349,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -366,7 +366,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -409,7 +409,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -423,7 +423,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -440,7 +440,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -483,7 +483,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -497,7 +497,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -514,7 +514,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -557,7 +557,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -571,7 +571,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -588,7 +588,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -598,10 +598,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -177,7 +177,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -190,7 +190,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -206,7 +206,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -249,7 +249,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -263,7 +263,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -280,7 +280,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -322,7 +322,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -335,7 +335,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -351,7 +351,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -393,7 +393,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -406,7 +406,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -422,7 +422,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -465,7 +465,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -479,7 +479,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -496,7 +496,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -506,10 +506,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
+++ b/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else ""))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else ""))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else ""))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -145,7 +145,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
+++ b/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -257,7 +257,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else ""))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -270,7 +270,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else ""))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -286,7 +286,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else ""))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -296,10 +296,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
+++ b/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
@@ -54,9 +54,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ "\n\
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -70,9 +70,9 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -89,9 +89,9 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -101,13 +101,13 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?")
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let create_profiles db  =
-    T.execute db ("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
 
   let create_billing db  =
-    T.execute db ("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_cached_prepared_stmts.ml
+++ b/test/cram/test_cached_prepared_stmts.ml
@@ -27,6 +27,8 @@ module Small_Cache = Sqlgg_stmt_cache.Make(Small_Cache_Config)(Print_impl)
 module Medium_Cache = Sqlgg_stmt_cache.Make(Medium_Cache_Config)(Print_impl)
 module Large_Cache = Sqlgg_stmt_cache.Make(Large_Cache_Config)(Print_impl)
 
+let q sql = Sqlgg_traits.Query.make ~sql ~name:"test" ~kind:Sqlgg_traits.Query.(Select Nat)
+
 let setup_mock_responses n =
   for i = 1 to n do
     Print_impl.setup_select_response [Print_impl.make_mock_row [Print_impl.mock_int (Int64.of_int i)]]
@@ -39,7 +41,7 @@ let () =
   Print_impl.clear_mock_responses ();
   
   setup_mock_responses 1;
-  Tiny_Cache.select tiny_conn "SELECT 1" 
+  Tiny_Cache.select tiny_conn (q "SELECT 1") 
     (fun stmt -> Tiny_Cache.finish_params (Tiny_Cache.start_params stmt 0)) 
     (fun _ -> ());
   printf "After query 1: %d prepared, %s\n" !Print_impl.stmt_counter (Tiny_Cache.cache_stats tiny_conn);
@@ -49,7 +51,7 @@ let () =
   printf "Filled tiny cache: %d/1\n" after_fill;
   
   Print_impl.setup_select_response [Print_impl.make_mock_row [Print_impl.mock_int 1L]];
-  Tiny_Cache.select tiny_conn "SELECT 1" 
+  Tiny_Cache.select tiny_conn (q "SELECT 1") 
     (fun stmt -> Tiny_Cache.finish_params (Tiny_Cache.start_params stmt 0)) 
     (fun _ -> ());
   
@@ -66,7 +68,7 @@ let () =
   setup_mock_responses 2;
   for i = 1 to 2 do
     let sql = sprintf "SELECT %d" i in
-    Small_Cache.select small_conn sql 
+    Small_Cache.select small_conn (q sql) 
       (fun stmt -> Small_Cache.finish_params (Small_Cache.start_params stmt 0)) 
       (fun _ -> ());
     printf "  After query %d: %d prepared, %s\n" i !Print_impl.stmt_counter (Small_Cache.cache_stats small_conn);
@@ -87,7 +89,7 @@ let () =
   
   for i = 1 to total_queries do
     let sql = sprintf "SELECT %d" i in
-    Small_Cache.select small_conn2 sql 
+    Small_Cache.select small_conn2 (q sql) 
       (fun stmt -> Small_Cache.finish_params (Small_Cache.start_params stmt 0)) 
       (fun _ -> ());
     
@@ -106,7 +108,7 @@ let () =
   for i = 1 to 3 do
     let sql = sprintf "SELECT %d" i in
     let before_prep = !Print_impl.stmt_counter in
-    Small_Cache.select small_conn2 sql 
+    Small_Cache.select small_conn2 (q sql) 
       (fun stmt -> Small_Cache.finish_params (Small_Cache.start_params stmt 0)) 
       (fun _ -> ());
     let after_prep = !Print_impl.stmt_counter in
@@ -126,27 +128,27 @@ let () =
   
   for i = 1 to 5 do
     let sql = sprintf "SELECT %d" i in
-    Medium_Cache.select medium_conn sql 
+    Medium_Cache.select medium_conn (q sql) 
       (fun stmt -> Medium_Cache.finish_params (Medium_Cache.start_params stmt 0)) 
       (fun _ -> ());
   done;
   
   printf "Filled cache: %d prepared\n" !Print_impl.stmt_counter;
   
-  Medium_Cache.select medium_conn "SELECT 1" 
+  Medium_Cache.select medium_conn (q "SELECT 1") 
     (fun stmt -> Medium_Cache.finish_params (Medium_Cache.start_params stmt 0)) 
     (fun _ -> ());
   
   printf "Used first query (made it recent)\n";
   
-  Medium_Cache.select medium_conn "SELECT 6"
+  Medium_Cache.select medium_conn (q "SELECT 6")
     (fun stmt -> Medium_Cache.finish_params (Medium_Cache.start_params stmt 0)) 
     (fun _ -> ());
   
   printf "Added new query: %d prepared, %s\n" !Print_impl.stmt_counter (Medium_Cache.cache_stats medium_conn);
   
   let before_first = !Print_impl.stmt_counter in
-  Medium_Cache.select medium_conn "SELECT 1" 
+  Medium_Cache.select medium_conn (q "SELECT 1") 
     (fun stmt -> Medium_Cache.finish_params (Medium_Cache.start_params stmt 0)) 
     (fun _ -> ());
   let after_first = !Print_impl.stmt_counter in
@@ -155,7 +157,7 @@ let () =
   assert (after_first = before_first);
   
   let before_second = !Print_impl.stmt_counter in
-  Medium_Cache.select medium_conn "SELECT 2" 
+  Medium_Cache.select medium_conn (q "SELECT 2") 
     (fun stmt -> Medium_Cache.finish_params (Medium_Cache.start_params stmt 0)) 
     (fun _ -> ());
   let after_second = !Print_impl.stmt_counter in
@@ -177,7 +179,7 @@ let () =
   for cycle = 1 to cycle_count do
     for i = 1 to cache_size do
       let sql = sprintf "SELECT %d" i in
-      Large_Cache.select large_conn sql 
+      Large_Cache.select large_conn (q sql) 
         (fun stmt -> Large_Cache.finish_params (Large_Cache.start_params stmt 0)) 
         (fun _ -> ());
     done;
@@ -201,13 +203,13 @@ let () =
   Print_impl.clear_mock_responses ();
 
   setup_mock_responses 1;
-  TTL3_Cache.select ttl3_conn "SELECT 42"
+  TTL3_Cache.select ttl3_conn (q "SELECT 42")
     (fun stmt -> TTL3_Cache.finish_params (TTL3_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
 
   setup_mock_responses 1;
-  TTL3_Cache.select ttl3_conn "SELECT 42"
+  TTL3_Cache.select ttl3_conn (q "SELECT 42")
     (fun stmt -> TTL3_Cache.finish_params (TTL3_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
@@ -223,7 +225,7 @@ let () =
   Print_impl.Clock.set 0.0;
 
   setup_mock_responses 1;
-  TTL2_Cache.select ttl2_conn "SELECT 7"
+  TTL2_Cache.select ttl2_conn (q "SELECT 7")
     (fun stmt -> TTL2_Cache.finish_params (TTL2_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
@@ -231,14 +233,14 @@ let () =
   Print_impl.Clock.travel 0.6;
 
   setup_mock_responses 1;
-  TTL2_Cache.select ttl2_conn "SELECT 7"
+  TTL2_Cache.select ttl2_conn (q "SELECT 7")
     (fun stmt -> TTL2_Cache.finish_params (TTL2_Cache.start_params stmt 0))
     (fun _ -> ());
     Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:1 ~expected_open:0 ();
   printf "TTL=0.5s reuse after >0.5s closed cached — OK\n";
  
   setup_mock_responses 1;
-  TTL2_Cache.select ttl2_conn "SELECT 7"
+  TTL2_Cache.select ttl2_conn (q "SELECT 7")
     (fun stmt -> TTL2_Cache.finish_params (TTL2_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:2 ~expected_closed:1 ~expected_open:1 ();
@@ -259,19 +261,19 @@ let () =
 
   setup_mock_responses 8;
 
-  TTL2B_Cache.select ttl2b_conn q1
+  TTL2B_Cache.select ttl2b_conn (q q1)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
   printf "MISS (prepare) %s — OK\n" q1;
 
-  TTL2B_Cache.select ttl2b_conn q1
+  TTL2B_Cache.select ttl2b_conn (q q1)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
   printf "HIT within TTL %s — OK\n" q1;
 
-  TTL2B_Cache.select ttl2b_conn q2
+  TTL2B_Cache.select ttl2b_conn (q q2)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:2 ~expected_closed:0 ~expected_open:2 ();
@@ -279,25 +281,25 @@ let () =
 
   Print_impl.Clock.travel 0.6;
 
-  TTL2B_Cache.select ttl2b_conn q1
+  TTL2B_Cache.select ttl2b_conn (q q1)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:2 ~expected_closed:1 ~expected_open:1 ();
   printf "EXPIRED-USE (closed, no prepare) %s — OK\n" q1;
 
-  TTL2B_Cache.select ttl2b_conn q2
+  TTL2B_Cache.select ttl2b_conn (q q2)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:2 ~expected_closed:2 ~expected_open:0 ();
   printf "EXPIRED-USE (closed, no prepare) %s — OK\n" q2;
 
-  TTL2B_Cache.select ttl2b_conn q1
+  TTL2B_Cache.select ttl2b_conn (q q1)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:3 ~expected_closed:2 ~expected_open:1 ();
   printf "MISS after expiry (re-prepare) %s — OK\n" q1;
 
-  TTL2B_Cache.select ttl2b_conn q2
+  TTL2B_Cache.select ttl2b_conn (q q2)
     (fun stmt -> TTL2B_Cache.finish_params (TTL2B_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:4 ~expected_closed:2 ~expected_open:2 ();
@@ -315,7 +317,7 @@ let () =
   setup_mock_responses 10;
   for i = 1 to cache_size do
     let sql = sprintf "SELECT %d" i in
-    TTL_LRU_Cache.select lru_conn sql
+    TTL_LRU_Cache.select lru_conn (q sql)
       (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
       (fun _ -> ());
   done;
@@ -324,7 +326,7 @@ let () =
   Print_impl.Clock.travel 10.0;
 
   setup_mock_responses 1;
-  TTL_LRU_Cache.select lru_conn "SELECT 11"
+  TTL_LRU_Cache.select lru_conn (q "SELECT 11")
     (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
     (fun _ -> ());
   printf "Added 11th (should evict one old): %s\n" (TTL_LRU_Cache.cache_stats lru_conn);
@@ -332,7 +334,7 @@ let () =
 
   let before_hit10 = !Print_impl.stmt_counter in
   setup_mock_responses 1;
-  TTL_LRU_Cache.select lru_conn "SELECT 10"
+  TTL_LRU_Cache.select lru_conn (q "SELECT 10")
     (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
     (fun _ -> ());
   let after_hit10 = !Print_impl.stmt_counter in
@@ -341,7 +343,7 @@ let () =
 
   let before_hit11 = !Print_impl.stmt_counter in
   setup_mock_responses 1;
-  TTL_LRU_Cache.select lru_conn "SELECT 11"
+  TTL_LRU_Cache.select lru_conn (q "SELECT 11")
     (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
     (fun _ -> ());
   let after_hit11 = !Print_impl.stmt_counter in
@@ -353,12 +355,12 @@ let () =
   setup_mock_responses 8;
   for i = 2 to 9 do
     let sql = sprintf "SELECT %d" i in
-    TTL_LRU_Cache.select lru_conn sql
+    TTL_LRU_Cache.select lru_conn (q sql)
       (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
       (fun _ -> ());
   done;
   setup_mock_responses 1;
-  TTL_LRU_Cache.select lru_conn "SELECT 10"
+  TTL_LRU_Cache.select lru_conn (q "SELECT 10")
     (fun stmt -> TTL_LRU_Cache.finish_params (TTL_LRU_Cache.start_params stmt 0))
     (fun _ -> ());
 
@@ -376,19 +378,19 @@ let () =
   Print_impl.clear_mock_responses ();
 
   setup_mock_responses 1;
-  TTL_Cache.select ttl_conn "SELECT 1"
+  TTL_Cache.select ttl_conn (q "SELECT 1")
     (fun stmt -> TTL_Cache.finish_params (TTL_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:0 ~expected_open:1 ();
 
   setup_mock_responses 1;
-  TTL_Cache.select ttl_conn "SELECT 1"
+  TTL_Cache.select ttl_conn (q "SELECT 1")
     (fun stmt -> TTL_Cache.finish_params (TTL_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:1 ~expected_closed:1 ~expected_open:0 ();
 
   setup_mock_responses 1;
-  TTL_Cache.select ttl_conn "SELECT 1"
+  TTL_Cache.select ttl_conn (q "SELECT 1")
     (fun stmt -> TTL_Cache.finish_params (TTL_Cache.start_params stmt 0))
     (fun _ -> ());
   Print_impl.assert_mock_stats ~expected_prepared:2 ~expected_closed:1 ~expected_open:1 ();
@@ -409,7 +411,7 @@ let () =
 
   (* Fill the cache *)
   setup_mock_responses 1;
-  Sync_Cache.select sync_conn "SELECT 1"
+  Sync_Cache.select sync_conn (q "SELECT 1")
     (fun stmt -> Sync_Cache.finish_params (Sync_Cache.start_params stmt 0))
     (fun _ -> ());
   
@@ -417,7 +419,7 @@ let () =
   
   (* Trigger eviction by adding second entry *)
   setup_mock_responses 1;
-  Sync_Cache.select sync_conn "SELECT 2"
+  Sync_Cache.select sync_conn (q "SELECT 2")
     (fun stmt -> Sync_Cache.finish_params (Sync_Cache.start_params stmt 0))
     (fun _ -> ());
   

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -464,7 +464,7 @@ Test DynamicSelect edge: single column:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -477,7 +477,7 @@ Test DynamicSelect edge: single column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -493,7 +493,7 @@ Test DynamicSelect edge: single column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -503,7 +503,7 @@ Test DynamicSelect edge: single column:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -556,7 +556,7 @@ DynamicSelect: SELECT * remains static select:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -569,7 +569,7 @@ DynamicSelect: SELECT * remains static select:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -585,7 +585,7 @@ DynamicSelect: SELECT * remains static select:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -595,7 +595,7 @@ DynamicSelect: SELECT * remains static select:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -657,7 +657,7 @@ DynamicSelect: SELECT * with expression in same list:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -670,7 +670,7 @@ DynamicSelect: SELECT * with expression in same list:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -686,7 +686,7 @@ DynamicSelect: SELECT * with expression in same list:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -696,7 +696,7 @@ DynamicSelect: SELECT * with expression in same list:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -758,7 +758,7 @@ DynamicSelect: auto names for expressions without alias:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -771,7 +771,7 @@ DynamicSelect: auto names for expressions without alias:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -787,7 +787,7 @@ DynamicSelect: auto names for expressions without alias:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -797,7 +797,7 @@ DynamicSelect: auto names for expressions without alias:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -841,7 +841,7 @@ Test DynamicSelect edge: expression at first position:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -854,7 +854,7 @@ Test DynamicSelect edge: expression at first position:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -870,7 +870,7 @@ Test DynamicSelect edge: expression at first position:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -880,7 +880,7 @@ Test DynamicSelect edge: expression at first position:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -933,7 +933,7 @@ Test DynamicSelect edge: literal only:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -946,7 +946,7 @@ Test DynamicSelect edge: literal only:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -962,7 +962,7 @@ Test DynamicSelect edge: literal only:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -972,7 +972,7 @@ Test DynamicSelect edge: literal only:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1052,7 +1052,7 @@ Test DynamicSelect edge: many columns:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1065,7 +1065,7 @@ Test DynamicSelect edge: many columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1081,7 +1081,7 @@ Test DynamicSelect edge: many columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1091,7 +1091,7 @@ Test DynamicSelect edge: many columns:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1153,7 +1153,7 @@ Test DynamicSelect edge: no space after commas:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1166,7 +1166,7 @@ Test DynamicSelect edge: no space after commas:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1182,7 +1182,7 @@ Test DynamicSelect edge: no space after commas:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1192,7 +1192,7 @@ Test DynamicSelect edge: no space after commas:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1245,7 +1245,7 @@ Test DynamicSelect edge: minimal spacing:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1258,7 +1258,7 @@ Test DynamicSelect edge: minimal spacing:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1274,7 +1274,7 @@ Test DynamicSelect edge: minimal spacing:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1284,7 +1284,7 @@ Test DynamicSelect edge: minimal spacing:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (a INT, b INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1328,7 +1328,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1341,7 +1341,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1357,7 +1357,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1367,7 +1367,7 @@ Test DynamicSelect edge: column without alias gets auto name:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1447,7 +1447,7 @@ Test DynamicSelect with dynamic_select flag:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1461,7 +1461,7 @@ Test DynamicSelect with dynamic_select flag:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1478,7 +1478,7 @@ Test DynamicSelect with dynamic_select flag:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1488,7 +1488,7 @@ Test DynamicSelect with dynamic_select flag:
   
   
     let create_accounts db  =
-      T.execute db ("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1559,7 +1559,7 @@ Test DynamicSelect with two dynamic columns:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM items")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1572,7 +1572,7 @@ Test DynamicSelect with two dynamic columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM items")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1588,7 +1588,7 @@ Test DynamicSelect with two dynamic columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM items")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1598,7 +1598,7 @@ Test DynamicSelect with two dynamic columns:
   
   
     let create_items db  =
-      T.execute db ("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1660,7 +1660,7 @@ Test DynamicSelect with Verbatim branches:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM users")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1673,7 +1673,7 @@ Test DynamicSelect with Verbatim branches:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM users")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1689,7 +1689,7 @@ Test DynamicSelect with Verbatim branches:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM users")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1699,7 +1699,7 @@ Test DynamicSelect with Verbatim branches:
   
   
     let create_users db  =
-      T.execute db ("CREATE TABLE users (id INT, status TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT, status TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1752,7 +1752,7 @@ Test DynamicSelect at beginning of SELECT:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM data")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1765,7 +1765,7 @@ Test DynamicSelect at beginning of SELECT:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM data")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1781,7 +1781,7 @@ Test DynamicSelect at beginning of SELECT:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM data")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1791,7 +1791,7 @@ Test DynamicSelect at beginning of SELECT:
   
   
     let create_data db  =
-      T.execute db ("CREATE TABLE data (a INT, b TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE data (a INT, b TEXT)") ~name:"create_data" ~kind:Sqlgg_traits.Query.(Create "data")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1844,7 +1844,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t1")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1857,7 +1857,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t1")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1873,7 +1873,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t1")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1883,7 +1883,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
   
   
     let create_t1 db  =
-      T.execute db ("CREATE TABLE t1 (id INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1951,18 +1951,18 @@ Test DynamicSelect with module annotation:
           T.finish_params p
         in
         T.select_one_maybe db
-        ("SELECT " ^ col.column ^ " FROM wrapped WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM wrapped WHERE id = ?") ~name:"with_module" ~kind:Sqlgg_traits.Query.(Select Zero_one))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
   
     end
   
   
     let create_wrapped db  =
-      T.execute db ("CREATE TABLE wrapped (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE wrapped (\n\
           id INT PRIMARY KEY,\n\
       name TEXT,\n\
       price DECIMAL(10,2)\n\
-  )") T.no_params
+  )") ~name:"create_wrapped" ~kind:Sqlgg_traits.Query.(Create "wrapped")) T.no_params
   
     module Single = struct
     end (* module Single *)
@@ -2013,14 +2013,14 @@ Test DynamicSelect with LIMIT 1 (select_one):
           T.finish_params p
         in
         T.select_one_maybe db
-        ("SELECT " ^ col.column ^ " FROM products WHERE id = ? LIMIT 1")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ? LIMIT 1") ~name:"select_one_product" ~kind:Sqlgg_traits.Query.(Select Zero_one))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
   
     end
   
   
     let create_products db  =
-      T.execute db ("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
   
     module Single = struct
     end (* module Single *)
@@ -2112,9 +2112,9 @@ Test DynamicSelect comprehensive list:
           T.finish_params p
         in
         T.select db
-        ("SELECT\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products")
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2127,9 +2127,9 @@ Test DynamicSelect comprehensive list:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT\n\
+          (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products")
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2145,9 +2145,9 @@ Test DynamicSelect comprehensive list:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT\n\
+          (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products")
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2157,13 +2157,13 @@ Test DynamicSelect comprehensive list:
   
   
     let create_products db  =
-      T.execute db ("CREATE TABLE products (\n\
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
    id INT PRIMARY KEY,\n\
    name TEXT,\n\
    price DECIMAL(10,2),\n\
    category TEXT,\n\
    stock INT\n\
-  )") T.no_params
+  )") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2221,7 +2221,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2235,7 +2235,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2252,7 +2252,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2262,7 +2262,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, val TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, val TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2323,7 +2323,7 @@ Virtual select: consecutive params as columns:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2336,7 +2336,7 @@ Virtual select: consecutive params as columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2352,7 +2352,7 @@ Virtual select: consecutive params as columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2362,7 +2362,7 @@ Virtual select: consecutive params as columns:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2438,7 +2438,7 @@ Virtual select: mixed columns and params without spaces after commas:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2452,7 +2452,7 @@ Virtual select: mixed columns and params without spaces after commas:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2469,7 +2469,7 @@ Virtual select: mixed columns and params without spaces after commas:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2479,7 +2479,7 @@ Virtual select: mixed columns and params without spaces after commas:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2532,7 +2532,7 @@ Virtual select: subquery expression as dynamic column:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2545,7 +2545,7 @@ Virtual select: subquery expression as dynamic column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2561,7 +2561,7 @@ Virtual select: subquery expression as dynamic column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2571,7 +2571,7 @@ Virtual select: subquery expression as dynamic column:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2630,7 +2630,7 @@ Virtual select: CASE WHEN as dynamic column:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2643,7 +2643,7 @@ Virtual select: CASE WHEN as dynamic column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2659,7 +2659,7 @@ Virtual select: CASE WHEN as dynamic column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2669,7 +2669,7 @@ Virtual select: CASE WHEN as dynamic column:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, status INT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, status INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2722,7 +2722,7 @@ Virtual select: function call with multiple args as column:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2735,7 +2735,7 @@ Virtual select: function call with multiple args as column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2751,7 +2751,7 @@ Virtual select: function call with multiple args as column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2761,7 +2761,7 @@ Virtual select: function call with multiple args as column:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2819,7 +2819,7 @@ Virtual select: arithmetic with param at expression start:
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2833,7 +2833,7 @@ Virtual select: arithmetic with param at expression start:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2850,7 +2850,7 @@ Virtual select: arithmetic with param at expression start:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t WHERE id = ?")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2860,7 +2860,7 @@ Virtual select: arithmetic with param at expression start:
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (id INT, price DECIMAL(10,2))") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2920,7 +2920,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           T.finish_params p
         in
         T.select db
-        ("SELECT " ^ col.column ^ " FROM t")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2933,7 +2933,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2949,7 +2949,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          ("SELECT " ^ col.column ^ " FROM t")
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2959,7 +2959,7 @@ Virtual select: tab-separated columns (non-space whitespace):
   
   
     let create_t db  =
-      T.execute db ("CREATE TABLE t (a INT, b TEXT)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -109,7 +109,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +122,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +138,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -185,7 +185,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -203,7 +203,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -224,7 +224,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -266,7 +266,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -279,7 +279,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -295,7 +295,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -337,7 +337,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -350,7 +350,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -366,7 +366,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -413,7 +413,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -431,7 +431,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -452,7 +452,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -504,9 +504,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t\n\
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -529,9 +529,9 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -557,9 +557,9 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)")
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -616,13 +616,13 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t\n\
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
   AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -650,13 +650,13 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
   AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -687,13 +687,13 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
   AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -703,10 +703,10 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
 
 
   let create_t db  =
-    T.execute db ("CREATE TABLE t (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT,\n\
     name TEXT\n\
-)") T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -37,8 +37,8 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+      (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -53,8 +53,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -72,8 +72,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -117,8 +117,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         T.finish_params p
       in
       T.select db
-      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+      (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -133,8 +133,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -152,8 +152,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -200,8 +200,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?")
         T.finish_params p
       in
       T.select db
-      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+      (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -219,8 +219,8 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -241,8 +241,8 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) ")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -289,8 +289,8 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         T.finish_params p
       in
       T.select db
-      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+      (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -308,8 +308,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -330,8 +330,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -383,8 +383,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         T.finish_params p
       in
       T.select db
-      ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+      (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -407,8 +407,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -434,8 +434,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")))
+        (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -491,8 +491,8 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         T.finish_params p
       in
       T.select db
-      ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent")
+      (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -506,8 +506,8 @@ SELECT " ^ col.column ^ " FROM recent")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent")
+        (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -524,8 +524,8 @@ SELECT " ^ col.column ^ " FROM recent")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent")
+        (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -568,8 +568,8 @@ SELECT " ^ col.column ^ " FROM recent")
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -583,8 +583,8 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -601,8 +601,8 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -612,11 +612,11 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
 
 
   let create_t db  =
-    T.execute db ("CREATE TABLE t (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT,\n\
     name TEXT,\n\
     status INT\n\
-)") T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_meta/meta.compare.ml
+++ b/test/cram/test_meta/meta.compare.ml
@@ -3,93 +3,93 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_accounts db  =
-    T.execute db ("CREATE TABLE accounts (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (\n\
   id BIGINT NOT NULL,\n\
     cid BIGINT NOT NULL,\n\
     status TEXT NOT NULL,\n\
   plain TEXT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
 
   let create_orders db  =
-    T.execute db ("CREATE TABLE orders (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
     id BIGINT NOT NULL,\n\
     amount DECIMAL(10,2) NOT NULL\n\
-)") T.no_params
+)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
 
   let create_events db  =
-    T.execute db ("CREATE TABLE events (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE events (\n\
   order_ref BIGINT NOT NULL,\n\
   amount BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_events" ~kind:Sqlgg_traits.Query.(Create "events")) T.no_params
 
   let create_named_owners db  =
-    T.execute db ("CREATE TABLE named_owners (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owners (\n\
     id BIGINT NOT NULL,\n\
   title TEXT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_named_owners" ~kind:Sqlgg_traits.Query.(Create "named_owners")) T.no_params
 
   let create_named_owned db  =
-    T.execute db ("CREATE TABLE named_owned (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owned (\n\
   id BIGINT NOT NULL,\n\
   note TEXT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_named_owned" ~kind:Sqlgg_traits.Query.(Create "named_owned")) T.no_params
 
   let create_other_domain db  =
-    T.execute db ("CREATE TABLE other_domain (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE other_domain (\n\
     id BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_other_domain" ~kind:Sqlgg_traits.Query.(Create "other_domain")) T.no_params
 
   let create_owners db  =
-    T.execute db ("CREATE TABLE owners (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owners (\n\
     id BIGINT NOT NULL PRIMARY KEY\n\
-)") T.no_params
+)") ~name:"create_owners" ~kind:Sqlgg_traits.Query.(Create "owners")) T.no_params
 
   let create_owned db  =
-    T.execute db ("CREATE TABLE owned (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owned (\n\
   owner_ref BIGINT NOT NULL,\n\
   loose BIGINT NOT NULL,\n\
   FOREIGN KEY (owner_ref) REFERENCES owners(id)\n\
-)") T.no_params
+)") ~name:"create_owned" ~kind:Sqlgg_traits.Query.(Create "owned")) T.no_params
 
   let create_unrelated db  =
-    T.execute db ("CREATE TABLE unrelated (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE unrelated (\n\
   owner_ref BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_unrelated" ~kind:Sqlgg_traits.Query.(Create "unrelated")) T.no_params
 
   let create_projects db  =
-    T.execute db ("CREATE TABLE projects (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE projects (\n\
   id BIGINT NOT NULL,\n\
     company_id BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_projects" ~kind:Sqlgg_traits.Query.(Create "projects")) T.no_params
 
   let create_alerts db  =
-    T.execute db ("CREATE TABLE alerts (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE alerts (\n\
   dashboard_id BIGINT NOT NULL,\n\
   company_id BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_alerts" ~kind:Sqlgg_traits.Query.(Create "alerts")) T.no_params
 
   let create_courses db  =
-    T.execute db ("CREATE TABLE courses (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE courses (\n\
     slug TEXT NOT NULL,\n\
     seconds BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_courses" ~kind:Sqlgg_traits.Query.(Create "courses")) T.no_params
 
   let create_left_rows db  =
-    T.execute db ("CREATE TABLE left_rows (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE left_rows (\n\
     id BIGINT NOT NULL\n\
-)") T.no_params
+)") ~name:"create_left_rows" ~kind:Sqlgg_traits.Query.(Create "left_rows")) T.no_params
 
   let create_right_rows db  =
-    T.execute db ("CREATE TABLE right_rows (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE right_rows (\n\
     id BIGINT NOT NULL,\n\
     status ENUM('draft','published','failed') NOT NULL\n\
-)") T.no_params
+)") ~name:"create_right_rows" ~kind:Sqlgg_traits.Query.(Create "right_rows")) T.no_params
 
   let create_codec_rows db  =
-    T.execute db ("CREATE TABLE codec_rows (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE codec_rows (\n\
   id INT NOT NULL,\n\
       status ENUM('new','paid','shipped') NOT NULL\n\
-)") T.no_params
+)") ~name:"create_codec_rows" ~kind:Sqlgg_traits.Query.(Create "codec_rows")) T.no_params
 
   let shared_by_equality db  callback =
     let invoke_callback stmt =
@@ -97,35 +97,35 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~order_ref:(Codecs.Order_id.get_column (T.get_column_int64 stmt 0))
         ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
     in
-    T.select db ("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let disjunction_withdraws_it db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(T.get_column_Int stmt 0)
     in
-    T.select db ("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let representation_mismatch db  callback =
     let invoke_callback stmt =
       callback
         ~amount:(T.get_column_Int stmt 0)
     in
-    T.select db ("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let towards_the_nullable_side db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db ("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let towards_the_preserved_side db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(T.get_column_Int stmt 0)
     in
-    T.select db ("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let no_join db  callback =
     let invoke_callback stmt =
@@ -133,21 +133,21 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
         ~loose:(T.get_column_Int stmt 1)
     in
-    T.select db ("SELECT owner_ref, loose FROM owned") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let outer_join_preserved_side db  callback =
     let invoke_callback stmt =
       callback
         ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let without_the_declaration db  callback =
     let invoke_callback stmt =
       callback
         ~owner_ref:(T.get_column_Int stmt 0)
     in
-    T.select db ("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let through_a_null_handling_call db ~a ~b callback =
     let invoke_callback stmt =
@@ -160,7 +160,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_string p (Codecs.Status.set_param b);
       T.finish_params p
     in
-    T.select db ("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let through_nested_coalesce db ~a ~b callback =
     let invoke_callback stmt =
@@ -173,7 +173,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_int64 p (Codecs.Cid.set_param b);
       T.finish_params p
     in
-    T.select db ("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let through_nullif db ~param callback =
     let invoke_callback stmt =
@@ -185,14 +185,14 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_string p (Codecs.Status.set_param param);
       T.finish_params p
     in
-    T.select db ("SELECT NULLIF(status, ?) AS s FROM accounts") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let greatest_over_a_literal db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT GREATEST(cid, 0) AS c FROM accounts") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let least_feeds_the_param db ~param callback =
     let invoke_callback stmt =
@@ -204,34 +204,34 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_int64 p (Codecs.Cid.set_param param);
       T.finish_params p
     in
-    T.select db ("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let untyped_sibling db  callback =
     let invoke_callback stmt =
       callback
         ~company_id:(Codecs.Company_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let literal_fallback db  callback =
     let invoke_callback stmt =
       callback
         ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
     in
-    T.select db ("SELECT COALESCE(slug, '') AS module_slug FROM courses") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let selecting_aggregate_keeps_it db  =
     let get_row stmt =
       (Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
     in
-    T.select_one db ("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") T.no_params get_row
+    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
 
   let computing_aggregate_keeps_it db  =
     let get_row stmt =
       (Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
     in
-    T.select_one db ("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") T.no_params get_row
+    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
 
   let transforming_function db ~param callback =
     let invoke_callback stmt =
@@ -243,7 +243,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
       T.set_param_Text p param;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM accounts WHERE LOWER(status) = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let arithmetic db ~param callback =
     let invoke_callback stmt =
@@ -255,21 +255,21 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
       T.set_param_Int p param;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM accounts WHERE cid = ? + 1") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let concatenation db  callback =
     let invoke_callback stmt =
       callback
         ~s:(T.get_column_Text stmt 0)
     in
-    T.select db ("SELECT CONCAT(status, plain) AS s FROM accounts") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let case_literal_fallback db  callback =
     let invoke_callback stmt =
       callback
         ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
     in
-    T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let param_branch db ~param callback =
     let invoke_callback stmt =
@@ -281,7 +281,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
       T.set_param_string p (Codecs.Status.set_param param);
       T.finish_params p
     in
-    T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let condition_is_not_a_branch db ~cond callback =
     let invoke_callback stmt =
@@ -293,7 +293,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
       T.set_param_string p (Codecs.Status.set_param cond);
       T.finish_params p
     in
-    T.select db ("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let fetch_merged db  callback =
     let invoke_callback stmt =
@@ -302,23 +302,23 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         ~right_id:(Codecs.Right_id.get_column_nullable (T.get_column_int64_nullable stmt 1))
         ~row_status:(Codecs.Row_status.get_column (T.get_column_string stmt 2))
     in
-    T.select db ("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") T.no_params invoke_callback
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let scalar_subquery db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db ("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let scalar_subquery_with_cte db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db ("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let one_typed_one_not db ~cid ~id callback =
     let invoke_callback stmt =
@@ -331,7 +331,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT plain FROM accounts WHERE cid = ? AND id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let param_list db ~cids callback =
     let invoke_callback stmt =
@@ -342,7 +342,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       let p = T.start_params stmt (0 + (match cids with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db ("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let assignment db ~cid ~id =
     let set_params stmt =
@@ -351,7 +351,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db ("UPDATE accounts SET cid = ? WHERE id = ?") set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE accounts SET cid = ? WHERE id = ?") ~name:"assignment" ~kind:Sqlgg_traits.Query.(Update (Some "accounts"))) set_params
 
   let insert_from_select db ~cid =
     let set_params stmt =
@@ -359,7 +359,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_int64 p (Codecs.Cid.set_param cid);
       T.finish_params p
     in
-    T.execute db ("INSERT INTO accounts (id, cid, status, plain) SELECT id, ?, status, plain FROM accounts") set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO accounts (id, cid, status, plain) SELECT id, ?, status, plain FROM accounts") ~name:"insert_from_select" ~kind:Sqlgg_traits.Query.(Insert "accounts")) set_params
 
   let get_status db ~id callback =
     let invoke_callback stmt =
@@ -371,7 +371,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT status FROM codec_rows WHERE id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let set_status db ~status ~id =
     let set_params stmt =
@@ -380,35 +380,35 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db ("UPDATE codec_rows SET status = ? WHERE id = ?") set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE codec_rows SET status = ? WHERE id = ?") ~name:"set_status" ~kind:Sqlgg_traits.Query.(Update (Some "codec_rows"))) set_params
 
   let spelled_with_on db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let spelled_with_using db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let spelled_naturally db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db ("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let outer_join_by_name_stays_silent db  callback =
     let invoke_callback stmt =
       callback
         ~id:(T.get_column_Int stmt 0)
     in
-    T.select db ("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   let param_meets_two_domains db ~needle callback =
     let invoke_callback stmt =
@@ -421,8 +421,8 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_int64 p (Codecs.Course_id.set_param needle);
       T.finish_params p
     in
-    T.select db ("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Single = struct
     let selecting_aggregate_keeps_it db  callback =
@@ -430,14 +430,14 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
         callback
           ~longest:(Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
       in
-      T.select_one db ("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") T.no_params invoke_callback
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
 
     let computing_aggregate_keeps_it db  callback =
       let invoke_callback stmt =
         callback
           ~total:(Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
       in
-      T.select_one db ("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") T.no_params invoke_callback
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
 
   end (* module Single *)
   
@@ -449,7 +449,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let disjunction_withdraws_it db  callback acc =
@@ -458,7 +458,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let representation_mismatch db  callback acc =
@@ -467,7 +467,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~amount:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let towards_the_nullable_side db  callback acc =
@@ -476,7 +476,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let towards_the_preserved_side db  callback acc =
@@ -485,7 +485,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let no_join db  callback acc =
@@ -495,7 +495,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~loose:(T.get_column_Int stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT owner_ref, loose FROM owned") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let outer_join_preserved_side db  callback acc =
@@ -504,7 +504,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let without_the_declaration db  callback acc =
@@ -513,7 +513,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~owner_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_a_null_handling_call db ~a ~b callback acc =
@@ -528,7 +528,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_nested_coalesce db ~a ~b callback acc =
@@ -543,7 +543,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_nullif db ~param callback acc =
@@ -557,7 +557,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT NULLIF(status, ?) AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let greatest_over_a_literal db  callback acc =
@@ -566,7 +566,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT GREATEST(cid, 0) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let least_feeds_the_param db ~param callback acc =
@@ -580,7 +580,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let untyped_sibling db  callback acc =
@@ -589,8 +589,8 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params invoke_callback
           ~company_id:(Codecs.Company_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let literal_fallback db  callback acc =
@@ -599,7 +599,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT COALESCE(slug, '') AS module_slug FROM courses") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let transforming_function db ~param callback acc =
@@ -613,7 +613,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE LOWER(status) = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let arithmetic db ~param callback acc =
@@ -627,7 +627,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE cid = ? + 1") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let concatenation db  callback acc =
@@ -636,7 +636,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~s:(T.get_column_Text stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT CONCAT(status, plain) AS s FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let case_literal_fallback db  callback acc =
@@ -645,7 +645,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_branch db ~param callback acc =
@@ -659,7 +659,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let condition_is_not_a_branch db ~cond callback acc =
@@ -673,7 +673,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let fetch_merged db  callback acc =
@@ -684,9 +684,9 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~row_status:(Codecs.Row_status.get_column (T.get_column_string stmt 2))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let scalar_subquery db  callback acc =
@@ -695,7 +695,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let scalar_subquery_with_cte db  callback acc =
@@ -704,7 +704,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let one_typed_one_not db ~cid ~id callback acc =
@@ -719,7 +719,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT plain FROM accounts WHERE cid = ? AND id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_list db ~cids callback acc =
@@ -732,7 +732,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let get_status db ~id callback acc =
@@ -746,7 +746,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT status FROM codec_rows WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_with_on db  callback acc =
@@ -755,7 +755,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_with_using db  callback acc =
@@ -764,7 +764,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_naturally db  callback acc =
@@ -773,7 +773,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let outer_join_by_name_stays_silent db  callback acc =
@@ -782,7 +782,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_meets_two_domains db ~needle callback acc =
@@ -797,8 +797,8 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -811,7 +811,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let disjunction_withdraws_it db  callback =
@@ -820,7 +820,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let representation_mismatch db  callback =
@@ -829,7 +829,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~amount:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let towards_the_nullable_side db  callback =
@@ -838,7 +838,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let towards_the_preserved_side db  callback =
@@ -847,7 +847,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let no_join db  callback =
@@ -857,7 +857,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~loose:(T.get_column_Int stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT owner_ref, loose FROM owned") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let outer_join_preserved_side db  callback =
@@ -866,7 +866,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let without_the_declaration db  callback =
@@ -875,7 +875,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~owner_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_a_null_handling_call db ~a ~b callback =
@@ -890,7 +890,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_nested_coalesce db ~a ~b callback =
@@ -905,7 +905,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_nullif db ~param callback =
@@ -919,7 +919,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT NULLIF(status, ?) AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let greatest_over_a_literal db  callback =
@@ -928,7 +928,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT GREATEST(cid, 0) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let least_feeds_the_param db ~param callback =
@@ -942,7 +942,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let untyped_sibling db  callback =
@@ -951,8 +951,8 @@ WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc :
           ~company_id:(Codecs.Company_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let literal_fallback db  callback =
@@ -961,7 +961,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT COALESCE(slug, '') AS module_slug FROM courses") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let transforming_function db ~param callback =
@@ -975,7 +975,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE LOWER(status) = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let arithmetic db ~param callback =
@@ -989,7 +989,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM accounts WHERE cid = ? + 1") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let concatenation db  callback =
@@ -998,7 +998,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~s:(T.get_column_Text stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT CONCAT(status, plain) AS s FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let case_literal_fallback db  callback =
@@ -1007,7 +1007,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_branch db ~param callback =
@@ -1021,7 +1021,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let condition_is_not_a_branch db ~cond callback =
@@ -1035,7 +1035,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let fetch_merged db  callback =
@@ -1046,9 +1046,9 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") T.no_param
           ~row_status:(Codecs.Row_status.get_column (T.get_column_string stmt 2))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let scalar_subquery db  callback =
@@ -1057,7 +1057,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let scalar_subquery_with_cte db  callback =
@@ -1066,7 +1066,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let one_typed_one_not db ~cid ~id callback =
@@ -1081,7 +1081,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT plain FROM accounts WHERE cid = ? AND id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_list db ~cids callback =
@@ -1094,7 +1094,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let get_status db ~id callback =
@@ -1108,7 +1108,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT status FROM codec_rows WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_with_on db  callback =
@@ -1117,7 +1117,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_with_using db  callback =
@@ -1126,7 +1126,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_naturally db  callback =
@@ -1135,7 +1135,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let outer_join_by_name_stays_silent db  callback =
@@ -1144,7 +1144,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_meets_two_domains db ~needle callback =
@@ -1159,8 +1159,8 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_migrations/closed-loop-5tables.t/run.t
+++ b/test/cram/test_migrations/closed-loop-5tables.t/run.t
@@ -17,10 +17,10 @@ Step 2 - day-to-day change: target.sql adds `posts.views`.
     module IO = T.IO
   
     let apply_20260101000000_alter_posts_add_col_views db  =
-      T.execute db ("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") ~name:"apply_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_posts_add_col_views db  =
-      T.execute db ("ALTER TABLE `posts` DROP COLUMN `views`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `views`") ~name:"revert_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("20260101000000_alter_posts_add_col_views", apply_20260101000000_alter_posts_add_col_views, revert_20260101000000_alter_posts_add_col_views);

--- a/test/cram/test_migrations/diff-add-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_col_age db  =
-    T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101000000_alter_users_add_col_age db  =
-    T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/diff-add-index.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-index.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db ("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") ~name:"apply_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db ("ALTER TABLE `users` DROP INDEX `email_idx`") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP INDEX `email_idx`") ~name:"revert_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_unique_email_idx", apply_20260101000000_alter_users_add_unique_email_idx, revert_20260101000000_alter_users_add_unique_email_idx);

--- a/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_pk db  =
-    T.execute db ("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") ~name:"apply_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101000000_alter_users_add_pk db  =
-    T.execute db ("ALTER TABLE `users` DROP PRIMARY KEY") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP PRIMARY KEY") ~name:"revert_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_pk", apply_20260101000000_alter_users_add_pk, revert_20260101000000_alter_users_add_pk);

--- a/test/cram/test_migrations/diff-change-type.t/migrations.ml
+++ b/test/cram/test_migrations/diff-change-type.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_change_col_id db  =
-    T.execute db ("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101000000_alter_users_change_col_id db  =
-    T.execute db ("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_change_col_id", apply_20260101000000_alter_users_change_col_id, revert_20260101000000_alter_users_change_col_id);

--- a/test/cram/test_migrations/diff-create-unique-index.t/run.t
+++ b/test/cram/test_migrations/diff-create-unique-index.t/run.t
@@ -14,11 +14,11 @@ the whole apply string, so it shows the result.)
     module IO = T.IO
   
     let apply_20260101000000_create_u db  =
-      T.execute db ("CREATE TABLE `u` (`id` INT, `email` VARCHAR(255), PRIMARY KEY (`id`));\n\
-  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE `u` (`id` INT, `email` VARCHAR(255), PRIMARY KEY (`id`));\n\
+  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") ~name:"apply_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_create_u db  =
-      T.execute db ("DROP TABLE `u`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TABLE `u`") ~name:"revert_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("20260101000000_create_u", apply_20260101000000_create_u, revert_20260101000000_create_u);

--- a/test/cram/test_migrations/diff-drop-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-drop-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_drop_col_age db  =
-    T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"apply_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101000000_alter_users_drop_col_age db  =
-    T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"revert_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_drop_col_age", apply_20260101000000_alter_users_drop_col_age, revert_20260101000000_alter_users_drop_col_age);

--- a/test/cram/test_migrations/diff-three-changes.t/migrations.ml
+++ b/test/cram/test_migrations/diff-three-changes.t/migrations.ml
@@ -3,22 +3,22 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101120000_alter_c_change_col_id db  =
-    T.execute db ("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101120000_alter_c_change_col_id db  =
-    T.execute db ("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let apply_20260101120000_alter_b_drop_col_old db  =
-    T.execute db ("ALTER TABLE `b` DROP COLUMN `old`") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` DROP COLUMN `old`") ~name:"apply_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101120000_alter_b_drop_col_old db  =
-    T.execute db ("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") ~name:"revert_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let apply_20260101120000_alter_a_add_col_x db  =
-    T.execute db ("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") ~name:"apply_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let revert_20260101120000_alter_a_add_col_x db  =
-    T.execute db ("ALTER TABLE `a` DROP COLUMN `x`") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` DROP COLUMN `x`") ~name:"revert_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other) T.no_params
 
   let migrations = [
     ("20260101120000_alter_c_change_col_id", apply_20260101120000_alter_c_change_col_id, revert_20260101120000_alter_c_change_col_id);

--- a/test/cram/test_migrations/diff-ttl.t/run.t
+++ b/test/cram/test_migrations/diff-ttl.t/run.t
@@ -57,10 +57,10 @@ The full -migrate cycle generates apply/revert code for the TTL change:
     module IO = T.IO
   
     let apply_20260101000000_alter_foo_set_ttl db  =
-      T.execute db ("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") ~name:"apply_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_foo_set_ttl db  =
-      T.execute db ("ALTER TABLE `foo` REMOVE TTL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` REMOVE TTL") ~name:"revert_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("20260101000000_alter_foo_set_ttl", apply_20260101000000_alter_foo_set_ttl, revert_20260101000000_alter_foo_set_ttl);

--- a/test/cram/test_migrations/dune-codegen.t/run.t
+++ b/test/cram/test_migrations/dune-codegen.t/run.t
@@ -35,16 +35,16 @@ current, so -migrate only regenerates and prints the human note to stderr:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users ADD COLUMN bio TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users DROP COLUMN bio") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-irreversible.t
+++ b/test/cram/test_migrations/migrate-irreversible.t
@@ -30,17 +30,17 @@ delta keeps a real one:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users DROP COLUMN legacy") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN legacy") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_0 db  =
       ignore db;
       IO.return { T.affected_rows = 0L; insert_id = None }
   
     let apply_20260101000000_alter_users_add_col_name db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `name` TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `name` TEXT") ~name:"apply_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_users_add_col_name db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `name`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `name`") ~name:"revert_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
+++ b/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
@@ -76,40 +76,40 @@ The generated code merges everything by id: manual (day-pinned) and generated
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `email` TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `email` TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `email`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `email`") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_alter_users_1 db  =
-      T.execute db ("ALTER TABLE users ADD COLUMN bio TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_1 db  =
-      T.execute db ("ALTER TABLE users DROP COLUMN bio") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_alter_posts_2 db  =
-      T.execute db ("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") ~name:"apply_alter_posts_2" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_posts_2 db  =
-      T.execute db ("ALTER TABLE `posts` DROP COLUMN `author_id`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `author_id`") ~name:"revert_alter_posts_2" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_alter_posts_3 db  =
-      T.execute db ("ALTER TABLE posts ADD COLUMN body TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts ADD COLUMN body TEXT") ~name:"apply_alter_posts_3" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_posts_3 db  =
-      T.execute db ("ALTER TABLE posts DROP COLUMN body") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts DROP COLUMN body") ~name:"revert_alter_posts_3" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_20260101000000_alter_posts_add_col_published db  =
-      T.execute db ("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") ~name:"apply_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_posts_add_col_published db  =
-      T.execute db ("ALTER TABLE `posts` DROP COLUMN `published`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `published`") ~name:"revert_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `created_at`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `created_at`") ~name:"revert_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-loop.t/run.t
+++ b/test/cram/test_migrations/migrate-loop.t/run.t
@@ -24,10 +24,10 @@ The code is regenerated from the migration SQL:
     module IO = T.IO
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/migrate-manual-mix.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-mix.t/run.t
@@ -34,16 +34,16 @@ The code merges both by id (manual day 20251231 first, generated 20260101000000_
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users ADD COLUMN bio TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users DROP COLUMN bio") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-manual-only.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-only.t/run.t
@@ -26,10 +26,10 @@ But the code is regenerated and contains the hand-written rename:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users RENAME COLUMN email TO email_address") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email TO email_address") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db ("ALTER TABLE users RENAME COLUMN email_address TO email") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email_address TO email") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-timestamp.t/run.t
+++ b/test/cram/test_migrations/migrate-timestamp.t/run.t
@@ -42,22 +42,22 @@ The code merges all three by id, so the manual `status` sits between `age` and
     module IO = T.IO
   
     let apply_20260101120000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260101120000_alter_users_add_col_age db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `age`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_alter_users_1 db  =
-      T.execute db ("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_alter_users_1 db  =
-      T.execute db ("ALTER TABLE users DROP COLUMN status") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN status") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let apply_20260102000000_alter_users_add_col_city db  =
-      T.execute db ("ALTER TABLE `users` ADD COLUMN `city` TEXT") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `city` TEXT") ~name:"apply_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let revert_20260102000000_alter_users_add_col_city db  =
-      T.execute db ("ALTER TABLE `users` DROP COLUMN `city`") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `city`") ~name:"revert_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other) T.no_params
   
     let migrations = [
       ("20260101120000_alter_users_add_col_age", apply_20260101120000_alter_users_add_col_age, revert_20260101120000_alter_users_add_col_age);

--- a/test/cram/test_query_meta/app.ml
+++ b/test/cram/test_query_meta/app.ml
@@ -1,0 +1,83 @@
+open Printf
+
+let kind_name (kind : Sqlgg_traits.Query.kind) =
+  match kind with
+  | Select Nat -> "select"
+  | Select One -> "select_one"
+  | Select Zero_one -> "select_zero_one"
+  | Insert table -> "insert " ^ table
+  | Update table -> "update " ^ Option.value table ~default:"?"
+  | Delete tables -> "delete " ^ String.concat "," tables
+  | Create table -> "create " ^ table
+  | CreateIndex index -> "create index " ^ index
+  | Alter tables -> "alter " ^ String.concat "," tables
+  | Drop table -> "drop " ^ table
+  | CreateRoutine name -> "create routine " ^ name
+  | CreateType name -> "create type " ^ name
+  | DropType name -> "drop type " ^ name
+  | Other -> "other"
+
+let current_request = ref "req-1"
+
+module Annotating_impl = struct
+
+  include Print_ocaml_impl
+
+  let annotate (q : Sqlgg_traits.Query.t) =
+    match q.kind with
+    | Create _ | Alter _ | Drop _ -> q
+    | _ ->
+      Sqlgg_traits.Query.Sqlcommenter.annotate [
+        "app", "users api";
+        "query", q.name;
+        "kind", kind_name q.kind;
+        "request_id", !current_request;
+      ] q
+
+  let select db q = Print_ocaml_impl.select db (annotate q)
+  let select_one db q = Print_ocaml_impl.select_one db (annotate q)
+  let select_one_maybe db q = Print_ocaml_impl.select_one_maybe db (annotate q)
+  let execute db q = Print_ocaml_impl.execute db (annotate q)
+
+end
+
+module Sql = Output.Sqlgg (Annotating_impl)
+
+let section name = printf "\n=== %s ===\n" name
+
+let () =
+  let db = () in
+
+  section "named select, parameters stay bound";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_select_response [
+    Print_ocaml_impl.make_mock_row [ Print_ocaml_impl.mock_int 1L; Print_ocaml_impl.mock_text "alice" ]
+  ];
+  Sql.find_user ~id:1L db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+
+  section "unnamed select gets a generated name";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_select_one_response
+    (Some (Print_ocaml_impl.make_mock_row [ Print_ocaml_impl.mock_int 7L ]));
+  printf "total: %Ld\n" (Sql.select_2 db);
+
+  section "runtime assembled sql, same name and kind";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_select_response [];
+  Sql.find_users ~ids:[ 1L; 2L; 3L ] db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+
+  section "batch insert";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_execute_response ~affected_rows:2L ~insert_id:(Some 10L) ();
+  ignore (Sql.add_users ~rows:[ (1L, "alice"); (2L, "bob") ] db);
+
+  section "per request attributes change, sql of the query does not";
+  current_request := "req-2";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_execute_response ~affected_rows:1L ();
+  ignore (Sql.rename_user ~name:"carol" ~id:1L db);
+
+  section "ddl is left alone by this implementation";
+  Print_ocaml_impl.clear_mock_responses ();
+  Print_ocaml_impl.setup_execute_response ~affected_rows:0L ();
+  ignore (Sql.create_users db)

--- a/test/cram/test_query_meta/cached_app.ml
+++ b/test/cram/test_query_meta/cached_app.ml
@@ -1,0 +1,65 @@
+open Printf
+
+let current_request = ref "req-1"
+let per_request_attrs = ref []
+
+module Cache = Sqlgg_stmt_cache.Make (struct
+  let max_cache_size = 16
+  let ttl_seconds = None
+end) (Print_impl)
+
+module Annotating_cache = struct
+
+  include Cache
+
+  let annotate q =
+    Sqlgg_traits.Query.Sqlcommenter.annotate
+      ([ "app", "users api"; "query", q.Sqlgg_traits.Query.name ] @ !per_request_attrs) q
+
+  let select db q = Cache.select db (annotate q)
+  let select_one db q = Cache.select_one db (annotate q)
+  let select_one_maybe db q = Cache.select_one_maybe db (annotate q)
+  let execute db q = Cache.execute db (annotate q)
+
+end
+
+module Sql = Output.Sqlgg (Annotating_cache)
+
+let section name = printf "\n=== %s ===\n" name
+
+let find_user id db =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_select_response [
+    Print_impl.make_mock_row [ Print_impl.mock_int id; Print_impl.mock_text "alice" ]
+  ];
+  Sql.find_user ~id db (fun ~id ~name -> printf "row: %Ld %s\n" id name)
+
+let () =
+  let db = Annotating_cache.create_cached_connection () in
+  Print_impl.reset_mock_stats ();
+
+  section "static attributes only: first call prepares";
+  find_user 1L db;
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "next request reuses that statement, the sql is the same";
+  current_request := "req-2";
+  find_user 2L db;
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "execute takes the same path";
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_execute_response ~affected_rows:1L ();
+  ignore (Sql.rename_user ~name:"carol" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "adding a per request attribute changes the sql on every call";
+  per_request_attrs := [ "request_id", !current_request ];
+  find_user 3L db;
+  printf "%s\n" (Cache.cache_stats db);
+  current_request := "req-3";
+  per_request_attrs := [ "request_id", !current_request ];
+  find_user 4L db;
+  printf "%s\n" (Cache.cache_stats db);
+
+  ignore (Print_impl.get_mock_stats ())

--- a/test/cram/test_query_meta/dune
+++ b/test/cram/test_query_meta/dune
@@ -1,0 +1,8 @@
+(cram
+ (deps
+  %{bin:sqlgg}
+  ../sqlgg_test.sh
+  ../print_ocaml_impl.ml
+  ../print_impl.ml
+  (glob_files *.sql)
+  (glob_files *.ml)))

--- a/test/cram/test_query_meta/queries.compare.ml
+++ b/test/cram/test_query_meta/queries.compare.ml
@@ -1,0 +1,132 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_users db  =
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+
+  let find_user db ~id callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~name:(T.get_column_Text stmt 1)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (1) in
+      T.set_param_Int p id;
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+
+  let select_2 db  =
+    let get_row stmt =
+      (T.get_column_Int stmt 0)
+    in
+    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+
+  let find_users db ~ids callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int stmt 0)
+        ~name:(T.get_column_Text stmt 1)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+
+  let add_users db ~rows =
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, name) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal name); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users")) T.no_params )
+
+  let rename_user db ~name ~id =
+    let set_params stmt =
+      let p = T.start_params stmt (2) in
+      T.set_param_Text p name;
+      T.set_param_Int p id;
+      T.finish_params p
+    in
+    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE users SET name = ? WHERE id = ?") ~name:"rename_user" ~kind:Sqlgg_traits.Query.(Update (Some "users"))) set_params
+
+  let delete_users_6 db ~id =
+    let set_params stmt =
+      let p = T.start_params stmt (1) in
+      T.set_param_Int p id;
+      T.finish_params p
+    in
+    T.execute db (Sqlgg_traits.Query.make ~sql:("DELETE FROM users WHERE id = ?") ~name:"delete_users_6" ~kind:Sqlgg_traits.Query.(Delete ["users"])) set_params
+
+  module Single = struct
+    let select_2 db  callback =
+      let invoke_callback stmt =
+        callback
+          ~total:(T.get_column_Int stmt 0)
+      in
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+
+  end (* module Single *)
+  
+  module Fold = struct
+    let find_user db ~id callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let find_users db ~ids callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let find_user db ~id callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        T.set_param_Int p id;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let find_users db ~ids callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int stmt 0)
+          ~name:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/test_query_meta/queries.sql
+++ b/test/cram/test_query_meta/queries.sql
@@ -1,0 +1,17 @@
+CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL);
+
+-- @find_user
+SELECT id, name FROM users WHERE id = @id;
+
+SELECT COUNT(*) AS total FROM users;
+
+-- @find_users
+SELECT id, name FROM users WHERE id IN @ids;
+
+-- @add_users
+INSERT INTO users (id, name) VALUES @rows;
+
+-- @rename_user
+UPDATE users SET name = @name WHERE id = @id;
+
+DELETE FROM users WHERE id = @id;

--- a/test/cram/test_query_meta/routing_app.ml
+++ b/test/cram/test_query_meta/routing_app.ml
@@ -1,0 +1,115 @@
+open Printf
+
+let current_request = ref "req-1"
+
+module Cache = Sqlgg_stmt_cache.Make (struct
+  let max_cache_size = 2
+  let ttl_seconds = None
+end) (Print_impl)
+
+let static_attrs q = [ "app", "users api"; "query", q.Sqlgg_traits.Query.name ]
+
+let annotate_static q = Sqlgg_traits.Query.Sqlcommenter.annotate (static_attrs q) q
+
+let annotate_per_request q =
+  Sqlgg_traits.Query.Sqlcommenter.annotate
+    (static_attrs q @ [ "request_id", !current_request ]) q
+
+let per_request q = q.Sqlgg_traits.Query.name = "find_user"
+
+module Routed_db = struct
+
+  include Cache
+
+  let select db q set_params cb =
+    if per_request q then Print_impl.select db.Cache.original (annotate_per_request q) set_params cb
+    else Cache.select db (annotate_static q) set_params cb
+
+  let select_one db q set_params conv =
+    if per_request q then Print_impl.select_one db.Cache.original (annotate_per_request q) set_params conv
+    else Cache.select_one db (annotate_static q) set_params conv
+
+  let select_one_maybe db q set_params conv =
+    if per_request q then Print_impl.select_one_maybe db.Cache.original (annotate_per_request q) set_params conv
+    else Cache.select_one_maybe db (annotate_static q) set_params conv
+
+  let execute db q set_params =
+    if per_request q then Print_impl.execute db.Cache.original (annotate_per_request q) set_params
+    else Cache.execute db (annotate_static q) set_params
+
+end
+
+module Naive_db = struct
+
+  include Cache
+
+  let select db q set_params cb = Cache.select db (annotate_per_request q) set_params cb
+  let select_one db q set_params conv = Cache.select_one db (annotate_per_request q) set_params conv
+  let select_one_maybe db q set_params conv = Cache.select_one_maybe db (annotate_per_request q) set_params conv
+  let execute db q set_params = Cache.execute db (annotate_per_request q) set_params
+
+end
+
+module Routed = Output.Sqlgg (Routed_db)
+module Naive = Output.Sqlgg (Naive_db)
+
+let section name = printf "\n=== %s ===\n" name
+
+let one_count () =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_select_one_response (Some (Print_impl.make_mock_row [ Print_impl.mock_int 7L ]))
+
+let one_user () =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_select_response
+    [ Print_impl.make_mock_row [ Print_impl.mock_int 1L; Print_impl.mock_text "alice" ] ]
+
+let one_update () =
+  Print_impl.clear_mock_responses ();
+  Print_impl.setup_execute_response ~affected_rows:1L ()
+
+let () =
+  let db = Cache.create_cached_connection () in
+  Print_impl.reset_mock_stats ();
+
+  section "static attributes fill the cache";
+  one_count (); ignore (Routed.select_2 db);
+  one_update (); ignore (Routed.rename_user ~name:"carol" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "both are reused, comments unchanged";
+  one_count (); ignore (Routed.select_2 db);
+  one_update (); ignore (Routed.rename_user ~name:"dave" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "per request query is routed past the cache, comment is fresh";
+  one_user (); Routed.find_user ~id:1L db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+  current_request := "req-2";
+  one_user (); Routed.find_user ~id:2L db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "the cached statements survived, still no new prepare for them";
+  one_count (); ignore (Routed.select_2 db);
+  one_update (); ignore (Routed.rename_user ~name:"erin" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+  printf "--- after routing ---\n";
+  ignore (Print_impl.get_mock_stats ());
+
+  section "same load through the cache instead: every call is a new statement";
+  let db = Cache.create_cached_connection () in
+  Print_impl.reset_mock_stats ();
+  one_count (); ignore (Naive.select_2 db);
+  one_update (); ignore (Naive.rename_user ~name:"carol" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+  current_request := "req-3";
+  one_user (); Naive.find_user ~id:1L db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+  current_request := "req-4";
+  one_user (); Naive.find_user ~id:2L db (fun ~id ~name -> printf "row: %Ld %s\n" id name);
+  printf "%s\n" (Cache.cache_stats db);
+
+  section "and the statements it evicted have to be prepared again";
+  one_count (); ignore (Naive.select_2 db);
+  one_update (); ignore (Naive.rename_user ~name:"dave" ~id:1L db);
+  printf "%s\n" (Cache.cache_stats db);
+  printf "--- after naive ---\n";
+  ignore (Print_impl.get_mock_stats ())

--- a/test/cram/test_query_meta/run.t
+++ b/test/cram/test_query_meta/run.t
@@ -1,0 +1,255 @@
+Generated code passes a query record to the traits instead of a bare sql string.
+[name] is the name from -- @name or a generated fallback, [kind] mirrors the
+statement kind, and [sql] is the only field that may be assembled at runtime
+(see the IN list and the batch insert in queries.compare.ml).
+
+  $ /bin/sh ../sqlgg_test.sh queries.sql queries.compare.ml
+  $ echo $?
+  0
+
+The implementation receives that record, so annotating is plain user code: it
+picks the attributes, sqlcommenter only serializes them into a comment. app.ml
+attaches the query name, the kind, and a per request id, and skips DDL.
+
+  $ cp ../print_ocaml_impl.ml ../print_impl.ml .
+  $ ocamlfind ocamlc -package sqlgg.traits -c output.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_ocaml_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c app.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -linkpkg -o app.exe output.cmo print_ocaml_impl.cmo app.cmo
+  $ ./app.exe
+  
+  === named select, parameters stay bound ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [SQL] SELECT id, name FROM users WHERE id = 1 /*app='users%20api',kind='select',query='find_user',request_id='req-1'*/
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  
+  === unnamed select gets a generated name ===
+  [MOCK SELECT_ONE] Connection type: [> `RO ]
+  [SQL] SELECT COUNT(*) AS total FROM users /*app='users%20api',kind='select_one',query='select_2',request_id='req-1'*/
+  [MOCK] Returning one row
+  [MOCK] get_column_Int[0] = 7
+  total: 7
+  
+  === runtime assembled sql, same name and kind ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [SQL] SELECT id, name FROM users WHERE id IN (1, 2, 3) /*app='users%20api',kind='select',query='find_users',request_id='req-1'*/
+  [MOCK] Returning 0 rows
+  
+  === batch insert ===
+  [MOCK EXECUTE] Connection type: [> `WR ]
+  [SQL] INSERT INTO users (id, name) VALUES (1, 'alice'), (2, 'bob') /*app='users%20api',kind='insert%20users',query='add_users',request_id='req-1'*/
+  [MOCK] Execute result: affected_rows=2, insert_id=10
+  
+  === per request attributes change, sql of the query does not ===
+  [MOCK EXECUTE] Connection type: [> `WR ]
+  [SQL] UPDATE users SET name = 'carol' WHERE id = 1 /*app='users%20api',kind='update%20users',query='rename_user',request_id='req-2'*/
+  [MOCK] Execute result: affected_rows=1, insert_id=None
+  
+  === ddl is left alone by this implementation ===
+  [MOCK EXECUTE] Connection type: [> `WR ]
+  [SQL] CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)
+  [MOCK] Execute result: affected_rows=0, insert_id=None
+
+With prepared statements the wiring goes above the statement cache, not into
+[prepare]: the cache keys on the [sql] it is handed, so annotating first keeps
+the key equal to the text that gets prepared. Static attributes leave that text
+alone and the statement is reused; a per request attribute rewrites it, and the
+cost of that shows up as a prepare per call rather than as a stale comment on a
+reused statement.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c cached_app.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -linkpkg -o cached_app.exe output.cmo print_impl.cmo cached_app.cmo
+  $ ./cached_app.exe
+  
+  === static attributes only: first call prepares ===
+  [MOCK] PREPARE[1]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user'*/
+  [MOCK] SELECT_WITH_STMT[1]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  Cache: 1/16 items, 1 ops since start
+  
+  === next request reuses that statement, the sql is the same ===
+  [MOCK] SELECT_WITH_STMT[1]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=2 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 2
+  row: 2 alice
+  Cache: 1/16 items, 2 ops since start
+  
+  === execute takes the same path ===
+  [MOCK] PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user'*/
+  [MOCK] EXECUTE_WITH_STMT[2]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/16 items, 3 ops since start
+  
+  === adding a per request attribute changes the sql on every call ===
+  [MOCK] PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-2'*/
+  [MOCK] SELECT_WITH_STMT[3]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=3 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 3
+  row: 3 alice
+  Cache: 3/16 items, 4 ops since start
+  [MOCK] PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+  [MOCK] SELECT_WITH_STMT[4]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=4 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 4
+  row: 4 alice
+  Cache: 4/16 items, 5 ops since start
+  
+  --- MOCK STATS ---
+  Prepared: 4, Closed: 0, Open: 4
+  Operations:
+    1. PREPARE[1]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user'*/
+    2. SELECT_WITH_STMT[1]
+    3. SELECT_WITH_STMT[1]
+    4. PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user'*/
+    5. EXECUTE_WITH_STMT[2]
+    6. PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-2'*/
+    7. SELECT_WITH_STMT[3]
+    8. PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+    9. SELECT_WITH_STMT[4]
+  ---
+
+Which queries carry a per request attribute is a routing decision, and [name] is
+what it is made on: those go the non prepared route, everything else keeps using
+the cache. routing_app.ml runs the same load both ways over a cache of two, so
+the cost of not routing is visible as evictions and re prepares.
+
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c routing_app.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -linkpkg -o routing_app.exe output.cmo print_impl.cmo routing_app.cmo
+  $ ./routing_app.exe
+  
+  === static attributes fill the cache ===
+  [MOCK] PREPARE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2'*/
+  [MOCK] SELECT_ONE_WITH_STMT[1]
+  [MOCK] select_one_with_stmt returning one row
+  [MOCK] get_column_Int[0] = 7
+  [MOCK] PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user'*/
+  [MOCK] EXECUTE_WITH_STMT[2]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/2 items, 2 ops since start
+  
+  === both are reused, comments unchanged ===
+  [MOCK] SELECT_ONE_WITH_STMT[1]
+  [MOCK] select_one_with_stmt returning one row
+  [MOCK] get_column_Int[0] = 7
+  [MOCK] EXECUTE_WITH_STMT[2]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/2 items, 4 ops since start
+  
+  === per request query is routed past the cache, comment is fresh ===
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-1'*/
+  [SQL] SELECT id, name FROM users WHERE id = 1 /*app='users%20api',query='find_user',request_id='req-1'*/
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-2'*/
+  [SQL] SELECT id, name FROM users WHERE id = 2 /*app='users%20api',query='find_user',request_id='req-2'*/
+  [MOCK] Returning 1 rows
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  Cache: 2/2 items, 4 ops since start
+  
+  === the cached statements survived, still no new prepare for them ===
+  [MOCK] SELECT_ONE_WITH_STMT[1]
+  [MOCK] select_one_with_stmt returning one row
+  [MOCK] get_column_Int[0] = 7
+  [MOCK] EXECUTE_WITH_STMT[2]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/2 items, 6 ops since start
+  --- after routing ---
+  
+  --- MOCK STATS ---
+  Prepared: 4, Closed: 0, Open: 4
+  Operations:
+    1. PREPARE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2'*/
+    2. SELECT_ONE_WITH_STMT[1]
+    3. PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user'*/
+    4. EXECUTE_WITH_STMT[2]
+    5. SELECT_ONE_WITH_STMT[1]
+    6. EXECUTE_WITH_STMT[2]
+    7. PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-1'*/
+    8. PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-2'*/
+    9. SELECT_ONE_WITH_STMT[1]
+    10. EXECUTE_WITH_STMT[2]
+  ---
+  
+  === same load through the cache instead: every call is a new statement ===
+  [MOCK] PREPARE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-2'*/
+  [MOCK] SELECT_ONE_WITH_STMT[1]
+  [MOCK] select_one_with_stmt returning one row
+  [MOCK] get_column_Int[0] = 7
+  [MOCK] PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-2'*/
+  [MOCK] EXECUTE_WITH_STMT[2]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/2 items, 2 ops since start
+  [MOCK] PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+  [MOCK] CLOSE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-2'*/
+  [MOCK] SELECT_WITH_STMT[3]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  [MOCK] PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-4'*/
+  [MOCK] CLOSE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-2'*/
+  [MOCK] SELECT_WITH_STMT[4]
+  [MOCK] Processing 1 rows in select_with_stmt
+    Row 0: col0=1 col1=alice 
+  [MOCK] get_column_Text[1] = "alice"
+  [MOCK] get_column_Int[0] = 1
+  row: 1 alice
+  Cache: 2/2 items, 4 ops since start
+  
+  === and the statements it evicted have to be prepared again ===
+  [MOCK] PREPARE[5]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-4'*/
+  [MOCK] CLOSE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+  [MOCK] SELECT_ONE_WITH_STMT[5]
+  [MOCK] select_one_with_stmt returning one row
+  [MOCK] get_column_Int[0] = 7
+  [MOCK] PREPARE[6]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-4'*/
+  [MOCK] CLOSE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-4'*/
+  [MOCK] EXECUTE_WITH_STMT[6]
+  [MOCK] execute_with_stmt result: affected_rows=1, insert_id=None
+  Cache: 2/2 items, 6 ops since start
+  --- after naive ---
+  
+  --- MOCK STATS ---
+  Prepared: 6, Closed: 4, Open: 2
+  Operations:
+    1. PREPARE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-2'*/
+    2. SELECT_ONE_WITH_STMT[1]
+    3. PREPARE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-2'*/
+    4. EXECUTE_WITH_STMT[2]
+    5. PREPARE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+    6. CLOSE[1]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-2'*/
+    7. SELECT_WITH_STMT[3]
+    8. PREPARE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-4'*/
+    9. CLOSE[2]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-2'*/
+    10. SELECT_WITH_STMT[4]
+    11. PREPARE[5]: SELECT COUNT(*) AS total FROM users /*app='users%20api',query='select_2',request_id='req-4'*/
+    12. CLOSE[3]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-3'*/
+    13. SELECT_ONE_WITH_STMT[5]
+    14. PREPARE[6]: UPDATE users SET name = ? WHERE id = ? /*app='users%20api',query='rename_user',request_id='req-4'*/
+    15. CLOSE[4]: SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-4'*/
+    16. EXECUTE_WITH_STMT[6]
+  ---

--- a/test/cram/test_scoped_select/scope.expected.ml
+++ b/test/cram/test_scoped_select/scope.expected.ml
@@ -54,7 +54,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select_one_maybe db
-      ("SELECT " ^ col.column ^ " FROM products WHERE id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ?") ~name:"scope_q1" ~kind:Sqlgg_traits.Query.(Select Zero_one))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
 
   end
@@ -103,7 +103,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM products WHERE stock > ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -117,7 +117,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM products WHERE stock > ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -134,7 +134,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM products WHERE stock > ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -144,13 +144,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_products db  =
-    T.execute db ("CREATE TABLE products (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
     id INT PRIMARY KEY,\n\
     name TEXT,\n\
     price DECIMAL(10,2),\n\
     category TEXT,\n\
     stock INT\n\
-)") T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
 
   module Single = struct
   end (* module Single *)

--- a/test/cram/test_shared_choice/shared.compare.ml
+++ b/test/cram/test_shared_choice/shared.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_t db  =
-    T.execute db ("CREATE TABLE t (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT NOT NULL,\n\
     name TEXT,\n\
     status INT\n\
-)") T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
 
   let shared_const db ~x callback =
     let invoke_callback stmt =
@@ -18,9 +18,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match x with `Small -> 0 | `Big -> 0) + (match x with `Small -> 0 | `Big -> 0)) in
       T.finish_params p
     in
-    T.select db ("SELECT id FROM t\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params invoke_callback
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let shared_param_same_name db ~x callback =
     let invoke_callback stmt =
@@ -41,9 +41,9 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
       end;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM t\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params invoke_callback
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let shared_params_diff_names db ~f callback =
     let invoke_callback stmt =
@@ -64,9 +64,9 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
       end;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM t\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params invoke_callback
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let shared_cte db ~f callback =
     let invoke_callback stmt =
@@ -87,10 +87,10 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
       end;
       T.finish_params p
     in
-    T.select db ("WITH recent AS (\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params invoke_callback
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let shared_mixed db ~ids ~nm ~f ~sort callback =
     let invoke_callback stmt =
@@ -116,12 +116,12 @@ SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> 
       end;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM t\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params invoke_callback
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let shared_const db ~x callback acc =
@@ -134,9 +134,9 @@ ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_param_same_name db ~x callback acc =
@@ -159,9 +159,9 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_params_diff_names db ~f callback acc =
@@ -184,9 +184,9 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_cte db ~f callback acc =
@@ -209,10 +209,10 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("WITH recent AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_mixed db ~ids ~nm ~f ~sort callback acc =
@@ -240,12 +240,12 @@ SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> 
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -261,9 +261,9 @@ ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_param_same_name db ~x callback =
@@ -286,9 +286,9 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_params_diff_names db ~f callback =
@@ -311,9 +311,9 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_cte db ~f callback =
@@ -336,10 +336,10 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("WITH recent AS (\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_mixed db ~ids ~nm ~f ~sort callback =
@@ -367,12 +367,12 @@ SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> 
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM t\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")") ^ "\n\
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/both.t/both.compare.ml
+++ b/test/cram/test_static_flags/both.t/both.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -90,7 +90,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT id, name FROM users WHERE id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -105,7 +105,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -123,7 +123,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
+++ b/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_static_flags/global.t/global.compare.ml
+++ b/test/cram/test_static_flags/global.t/global.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -109,7 +109,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +122,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +138,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -148,7 +148,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -161,7 +161,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT id, name FROM users WHERE id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let list_users_static db  callback =
     let invoke_callback stmt =
@@ -169,7 +169,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~id:(T.get_column_Int stmt 0)
         ~name:(T.get_column_Text_nullable stmt 1)
     in
-    T.select db ("SELECT id, name FROM users") T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let list_users_static db  callback acc =
@@ -194,7 +194,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text_nullable stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -212,7 +212,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let list_users_static db  callback =
@@ -222,7 +222,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text_nullable stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/je_static.t/je_static.compare.ml
+++ b/test/cram/test_static_flags/je_static.t/je_static.compare.ml
@@ -45,9 +45,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ "\n\
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?")
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -61,9 +61,9 @@ WHERE i.id > ?")
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?")
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -80,9 +80,9 @@ WHERE i.id > ?")
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ "\n\
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?")
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -92,10 +92,10 @@ WHERE i.id > ?")
 
 
   let create_items db  =
-    T.execute db ("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
 
   let create_stats db  =
-    T.execute db ("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") ~name:"create_stats" ~kind:Sqlgg_traits.Query.(Create "stats")) T.no_params
 
   let wide_static db ~min_id callback =
     let invoke_callback stmt =
@@ -109,10 +109,10 @@ WHERE i.id > ?")
       T.set_param_Int p min_id;
       T.finish_params p
     in
-    T.select db ("SELECT i.id, i.name, s.sold\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") set_params invoke_callback
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let wide_static db ~min_id callback acc =
@@ -128,10 +128,10 @@ WHERE i.id > ?") set_params invoke_callback
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT i.id, i.name, s.sold\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -150,10 +150,10 @@ WHERE i.id > ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT i.id, i.name, s.sold\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/override.t/override.compare.ml
+++ b/test/cram/test_static_flags/override.t/override.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        ("SELECT " ^ col.column ^ " FROM users WHERE id = ?")
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db ("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -90,7 +90,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT id, name FROM users WHERE id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let get_user_classic db ~id callback =
     let invoke_callback stmt =
@@ -103,7 +103,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db ("SELECT id, name FROM users WHERE id = ?") set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -118,7 +118,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let get_user_classic db ~id callback acc =
@@ -133,7 +133,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -151,7 +151,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let get_user_classic db ~id callback =
@@ -166,7 +166,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id, name FROM users WHERE id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_mappings.compare.ml
+++ b/test/cram/type_mappings.compare.ml
@@ -3,16 +3,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_table_37 db  =
-    T.execute db ("CREATE TABLE table_37 (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_37 (\n\
                 col_1 INT PRIMARY KEY,\n\
                         col_2 INT NOT NULL\n\
-      )") T.no_params
+      )") ~name:"create_table_37" ~kind:Sqlgg_traits.Query.(Create "table_37")) T.no_params
 
   let create_table_38 db  =
-    T.execute db ("CREATE TABLE table_38 (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_38 (\n\
                 col_3 INT PRIMARY KEY,\n\
         col_4 TEXT NOT NULL\n\
-      )") T.no_params
+      )") ~name:"create_table_38" ~kind:Sqlgg_traits.Query.(Create "table_38")) T.no_params
 
   let select_2 db  callback =
     let invoke_callback stmt =
@@ -22,7 +22,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~col_3:(FooBar.get_column_nullable (T.get_column_int64_nullable stmt 2))
         ~col_4:(T.get_column_Text_nullable stmt 3)
     in
-    T.select db ("SELECT \n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
   (\n\
     SELECT MAX(x.col_val)\n\
     FROM (\n\
@@ -41,7 +41,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") T.no_params invoke_callback
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
 
   module Fold = struct
     let select_2 db  callback acc =
@@ -53,7 +53,7 @@ LEFT JOIN table_38\n\
           ~col_4:(T.get_column_Text_nullable stmt 3)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
   (\n\
     SELECT MAX(x.col_val)\n\
     FROM (\n\
@@ -72,7 +72,7 @@ LEFT JOIN table_38\n\
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -87,7 +87,7 @@ LEFT JOIN table_38\n\
           ~col_4:(T.get_column_Text_nullable stmt 3)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \n\
   (\n\
     SELECT MAX(x.col_val)\n\
     FROM (\n\
@@ -106,7 +106,7 @@ LEFT JOIN table_38\n\
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_mappings_params.compare.ml
+++ b/test/cram/type_mappings_params.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_example db  =
-    T.execute db ("CREATE TABLE example (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example (\n\
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL,\n\
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP\n\
-)") T.no_params
+)") ~name:"create_example" ~kind:Sqlgg_traits.Query.(Create "example")) T.no_params
 
   let select_1 db ~x callback =
     let invoke_callback stmt =
@@ -18,13 +18,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match x with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let create_example2 db  =
-    T.execute db ("CREATE TABLE example2 (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example2 (\n\
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name_2 VARCHAR(255) NOT NULL\n\
-)") T.no_params
+)") ~name:"create_example2" ~kind:Sqlgg_traits.Query.(Create "example2")) T.no_params
 
   let select_3 db ~name ~name_2 ~id callback =
     let invoke_callback stmt =
@@ -37,10 +37,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_int64 p (ExampleId.set_param id);
       T.finish_params p
     in
-    T.select db ("SELECT example2.id, name_2 \n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params invoke_callback
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let select_1 db ~x callback acc =
@@ -53,7 +53,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let select_3 db ~name ~name_2 ~id callback acc =
@@ -68,10 +68,10 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT example2.id, name_2 \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -87,7 +87,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let select_3 db ~name ~name_2 ~id callback =
@@ -102,10 +102,10 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT example2.id, name_2 \n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_unreserved.t
+++ b/test/cram/type_unreserved.t
@@ -129,14 +129,14 @@ produce a bare `type` keyword clash):
     module IO = Sqlgg_io.Blocking
   
     let create_kw db  =
-      T.execute db ("CREATE TABLE kw (type INT NOT NULL)") T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw (type INT NOT NULL)") ~name:"create_kw" ~kind:Sqlgg_traits.Query.(Create "kw")) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~type_:(T.get_column_Int stmt 0)
       in
-      T.select db ("SELECT type FROM kw") T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -145,7 +145,7 @@ produce a bare `type` keyword clash):
             ~type_:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db ("SELECT type FROM kw") T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -157,7 +157,7 @@ produce a bare `type` keyword clash):
             ~type_:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db ("SELECT type FROM kw") T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)

--- a/test/cram/where_in_composable.compare.ml
+++ b/test/cram/where_in_composable.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_random_table_1 db  =
-    T.execute db ("CREATE TABLE IF NOT EXISTS random_table_1 (\n\
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS random_table_1 (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `id2` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_random_table_1" ~kind:Sqlgg_traits.Query.(Create "random_table_1")) T.no_params
 
   let select_1 db ~id ~ids2 callback =
     let invoke_callback stmt =
@@ -24,10 +24,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       end;
       T.finish_params p
     in
-    T.select db ("SELECT id FROM random_table_1\n\
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params invoke_callback
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   let select_2 db ~ids2 callback =
     let invoke_callback stmt =
@@ -38,8 +38,8 @@ WHERE \n\
       let p = T.start_params stmt (0 + (match ids2 with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db ("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
 
   module Fold = struct
     let select_1 db ~id ~ids2 callback acc =
@@ -58,10 +58,10 @@ WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let select_2 db ~ids2 callback acc =
@@ -74,8 +74,8 @@ WHERE \n\
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -97,10 +97,10 @@ WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let select_2 db ~ids2 callback =
@@ -113,8 +113,8 @@ WHERE \n\
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db ("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)


### PR DESCRIPTION
### Description

This PR adds the support of Sqlcommenter and passes meta info about a query

Passing information about the query to the `Trait`s about the query name and query type so it can be processed for example for `otel` or something else depending on the user. The second and main thing is support for the https://google.github.io/sqlcommenter/spec/ It is expected that the first part is useful for this. So the user can take the query name and add it as a comment.
They can also pass some additional information as a key value list which in the commenter spec format will be added as a comment to the query.
We could just generate the query and for example insert the comment based on a flag but then there would be no support for the additional key value metadata dictionary

And I want to say right away that dynamic comments basically break prepared `cached statements`.


#### What is generated

```sql
-- @find_user
SELECT id, name FROM users WHERE id = @id;
SELECT COUNT(*) AS total FROM users;
-- @add_users
INSERT INTO users (id, name) VALUES @rows;
```

```ocaml
T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, name) VALUES " ^ (* runtime assembled rows *)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users")) T.no_params
```

#### Adding a comment


```ocaml
module Db = struct
  include Sqlgg_sqlite3
  let annotate (q : Sqlgg_traits.Query.t) =
    match q.kind with
    | Create _ | Alter _ | Drop _ -> q
    | _ ->
      Sqlgg_traits.Query.Sqlcommenter.annotate [
        "app", "users api";
        "query", q.name;
        "request_id", Context.request_id ();
      ] q
  let select db q = Sqlgg_sqlite3.select db (annotate q)
  let select_one db q = Sqlgg_sqlite3.select_one db (annotate q)
  let select_one_maybe db q = Sqlgg_sqlite3.select_one_maybe db (annotate q)
  let execute db q = Sqlgg_sqlite3.execute db (annotate q)
end

module Sql = Queries.Sqlgg (Db)
```

Those are the only things that can be done with `q`, because the type is private:

```ocaml
type t = private {
  sql : string;
  name : string;
  kind : kind;
}
```

Reading `sql`, `name`, `kind` and matching on the kind is allowed, building a query or rewriting the sql behind the metadata is not, so the user cannot alter a query in any way and the only path to a modified one is a helper such as `Sqlgg_traits.Query.Sqlcommenter.annotate`:

```ocaml
let evil (q : Sqlgg_traits.Query.t) = { q with Sqlgg_traits.Query.sql = "DROP TABLE users" }
(* Error: Cannot create values of the private type Sqlgg_traits.Query.t *)
```

What reaches the database:

```sql
SELECT id, name FROM users WHERE id = ? /*app='users%20api',query='find_user',request_id='req-1'*/
INSERT INTO users (id, name) VALUES (1, 'alice'), (2, 'bob') /*app='users%20api',query='add_users',request_id='req-1'*/
```
