### PR TITLE
Add Kleene nullability narrowing

### DIFF
--- a/lib/narrowing.ml
+++ b/lib/narrowing.ml
@@ -1,0 +1,145 @@
+open ExtLib
+open Sql
+
+module Qualified_attr = struct
+  module T = struct
+    type t = { sources : table_name list; name : string } [@@deriving eq, ord]
+  end
+  include T
+
+  let of_attr (a : table_name Schema.Source.Attr.t) = { sources = a.sources; name = a.attr.name }
+  let named = function { name = ""; _ } -> None | key -> Some key
+
+  module Map = Map.Make(T)
+  module Set = Set.Make(T)
+end
+
+module Attr_refinement = struct
+  type t = { not_null : Qualified_attr.Set.t; meta : Meta.t Qualified_attr.Map.t }
+
+  let empty = { not_null = Qualified_attr.Set.empty; meta = Qualified_attr.Map.empty }
+
+  let add a b = {
+    not_null = Qualified_attr.Set.union a.not_null b.not_null;
+    meta = Qualified_attr.Map.union (fun _ x y -> Some (Meta.merge_right x y)) a.meta b.meta }
+
+  let keep_all = List.fold_left add empty
+
+  let keep_shared = function
+    | [] -> empty
+    | x :: l ->
+      List.fold_left (fun a b -> {
+        not_null = Qualified_attr.Set.inter a.not_null b.not_null;
+        meta = Qualified_attr.Map.merge (fun _ x y ->
+          match x, y with Some x, Some y -> Meta.declared (Meta.inter x y) | _ -> None) a.meta b.meta }) x l
+
+  let not_null attr = { empty with not_null = Qualified_attr.Set.singleton attr }
+  let restrict_not_null keep t = { t with not_null = Qualified_attr.Set.filter keep t.not_null }
+
+  let inherit_meta ~constrains (col : table_name Schema.Source.Attr.t)
+      ~(referenced : table_name Schema.Source.Attr.t) =
+    let inherited = Meta.of_domain referenced.attr.meta in
+    let carries =
+      match col.attr.domain.t, referenced.attr.domain.t with
+      | Union a, Union b -> Type.Enum_kind.Ctors.subset a.ctors b.ctors
+      | a, b -> constrains col && Type.equal_kind a b
+    in
+    if carries && not (Meta.is_empty inherited)
+    then { empty with meta = Qualified_attr.Map.singleton (Qualified_attr.of_attr col) inherited }
+    else empty
+
+  let refine_nullability t a =
+    if Qualified_attr.Set.mem (Qualified_attr.of_attr a) t.not_null
+    then Schema.Source.Attr.map_attr (fun attr -> { attr with domain = Type.make_strict attr.domain }) a
+    else a
+
+  let apply t a =
+    let inherited = Option.default (Meta.empty ()) (Qualified_attr.Map.find_opt (Qualified_attr.of_attr a) t.meta) in
+    refine_nullability t
+      (Schema.Source.Attr.map_attr (fun attr -> { attr with meta = Meta.merge_right inherited attr.meta }) a)
+end
+
+let narrow_columns ~resolve ~constrains e =
+  let open Attr_refinement in
+  let strict col =
+    match resolve col with
+    | Some a when constrains a -> not_null (Qualified_attr.of_attr a)
+    | Some _ | None -> empty
+  in
+  let borrow_meta = function
+    | Sql.Fun { kind = Comparison (Comp_equal | Not_distinct_op); parameters = [Column a; Column b]; _ } ->
+      begin match resolve a.collated, resolve b.collated with
+      | Some a, Some b ->
+        let borrow = inherit_meta ~constrains in
+        add (borrow a ~referenced:b) (borrow b ~referenced:a)
+      | None, _ | _, None -> empty
+      end
+    | _ -> empty
+  in
+  let rec narrow (e : Sql.expr) known =
+    let same e = narrow e known in
+    let has_value e = narrow e `Has_value in
+    let every_path { Sql.case; branches; else_ } =
+      let condition when_ =
+        match case with
+        | Some x -> add (has_value x) (has_value when_)
+        | None -> narrow when_ `Holds
+      in
+      let per_branch = List.map (fun { Sql.when_; then_ } -> add (condition when_) (same then_)) branches in
+      let no_branch = Option.map_default (fun e -> [ same e ]) [] else_ in
+      keep_shared (per_branch @ no_branch)
+    in
+    match known with
+    | `Has_value ->
+      begin match e with
+      | Column col -> strict col.collated
+      | Fun { kind = Null_handling (Coalesce _ | If_null); parameters; _ } -> keep_shared (List.map same parameters)
+      | Fun { kind; parameters; _ } ->
+        let strict_args =
+          match kind, parameters with
+          | (Comparison (Comp_equal | Comp_num_cmp | Comp_text_cmp | Comp_num_eq)
+            | Negation | Arith _ | Like | Like_escape), _ -> parameters
+          | Membership, _ :: (SelectExpr _ | Inparam _) :: _ -> []
+          | (Membership | Range), _ -> List.take 1 parameters
+          | (Comparison (Not_distinct_op | Is_null | Is_not_null)
+            | Quantified_comparison _
+            | Agg _ | Null_handling _ | Logical _ | Ret _ | F _ | Col_assign _ | Multi _), _ -> []
+        in
+        keep_all (List.map same strict_args)
+      | Case c -> every_path c
+      | Value _ | Param _ | Inparam _ | Choices _ | InChoice _ | InTupleList _
+      | SelectExpr _ | OptionActions _ | Of_values _ -> empty
+      end
+    | (`Holds | `Fails) as known ->
+      let required =
+        match e with
+        | Fun { kind = Logical ((And | Or) as op); parameters; _ } ->
+          let combine = match op, known with And, `Holds | Or, `Fails -> keep_all | _ -> keep_shared in
+          combine (List.map same parameters)
+        | Fun { kind = Logical Xor; parameters; _ } ->
+          keep_all (List.map (fun e -> keep_shared [narrow e `Holds; narrow e `Fails]) parameters)
+        | Fun { kind = Negation; parameters = [e]; _ } ->
+          let opposite = match known with `Holds -> `Fails | `Fails -> `Holds in
+          narrow e opposite
+        | Fun { kind = Comparison Is_not_null; parameters = [e]; _ }
+        | Fun { kind = Quantified_comparison
+                  { op = Comp_equal | Comp_num_cmp | Comp_text_cmp | Comp_num_eq; quantifier = `Any };
+                parameters = e :: _; _ } ->
+          begin match known with `Holds -> has_value e | `Fails -> empty end
+        | Fun { kind = Comparison Is_null; parameters = [e]; _ } ->
+          begin match known with `Holds -> empty | `Fails -> has_value e end
+        | Fun { kind = Quantified_comparison _; _ } -> empty
+        | Case c -> every_path c
+        | Choices (_, alternatives) ->
+          keep_shared (List.map (fun (_, e) -> Option.map_default same empty e) alternatives)
+        | InChoice (_, `In, Fun { kind = Membership; parameters = x :: _; _ }) ->
+          begin match known with `Holds -> has_value x | `Fails -> empty end
+        | InTupleList { value = { exprs; kind_in_tuple_list = `In; _ }; _ } ->
+          begin match known with `Holds -> keep_all (List.map has_value exprs) | `Fails -> empty end
+        | InChoice _ | OptionActions _ -> empty
+        | e -> has_value e
+      in
+      let from_equality = match known with `Holds -> borrow_meta e | `Fails -> empty in
+      add from_equality required
+  in
+  narrow e `Holds

--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -715,8 +715,14 @@ and 't func =
   | Agg of agg_fun (* 'a -> 'a | 'a -> t *)
   | Null_handling of null_handling_fn_kind
   | Comparison of comparison_op
+  | Quantified_comparison of { op: comparison_op; quantifier: [ `Any | `All ] } 
   | Logical of logical_op
   | Negation
+  | Arith of 't  (* 'a -> 'a -> t *)
+  | Membership (* 'a -> { 'a }+ -> bool *)
+  | Range  (* 'a -> 'a -> 'a -> bool *)
+  | Like (* text -> text -> bool *)
+  | Like_escape (* bool -> text -> bool *)
   | Ret of 't (* _ -> t *) (* TODO eliminate *)
   | F of Type.tyvar * Type.tyvar list
   | Col_assign of { ret_t: Type.tyvar; col_t: Type.tyvar; arg_t: Type.tyvar; }
@@ -733,7 +739,8 @@ and 't func =
      Valid calls: f(a,b,c) or f(a,b,c,d,e) or f(a,b,c,d,e,f,g) etc. *)
   [@@deriving show]
 and 'expr choices = (param_id * 'expr option) list
-and 't fun_ = { fn_name: string; kind: 't func; parameters: expr list; is_over_clause: bool; } [@@deriving show]
+and 't fun_ = { fn_name: string; kind: 't func; parameters: expr list; over: over option } [@@deriving show]
+and over = { frame_has_a_row: bool } [@@deriving show]
 and case_branch = { when_: expr; then_: expr }
 and case = {  
   case: expr option;
@@ -765,6 +772,10 @@ and column_kind =
 
 type columns = column list [@@deriving show]
 
+let fn ?over fn_name kind parameters = Fun { fn_name; kind; parameters; over }
+
+let column ?collation collated = Column (make_collated ?collation ~collated ())
+
 let comparison_signature op =
   let open Type in
   match op with
@@ -794,13 +805,16 @@ let signature kind arity =
   let sign =
     match kind with
     | F (ret, args) -> Some (ret, args)
-    | Comparison op -> Some (comparison_signature op)
+    | Comparison op | Quantified_comparison { op; _ } -> Some (comparison_signature op)
     | Null_handling nulls -> Some (null_handling_signature nulls arity)
     | Agg Self -> Some agg_same_type
     | Col_assign { ret_t; col_t; arg_t } -> Some (ret_t, [col_t; arg_t])
     | Multi { ret; fixed_args; repeating_pattern } ->
       Option.map (fun args -> ret, args) (multi_args ~fixed_args ~repeating_pattern arity)
-    | Agg _ | Logical _ | Negation | Ret _ -> None
+    | Membership | Range -> Some Type.(Typ (depends Bool), List.make arity (Var 0))
+    | Like -> Some Type.(Typ (depends Bool), [Typ (depends Text); Typ (depends Text)])
+    | Like_escape -> Some Type.(Typ (depends Bool), [Typ (depends Bool); Typ (depends Text)])
+    | Agg _ | Logical _ | Negation | Ret _ | Arith _ -> None
   in
   match sign with
   | Some (_, args) when not (Int.equal (List.length args) arity) -> None
@@ -808,9 +822,11 @@ let signature kind arity =
 
 let source_fun_kind_to_infer = function
   | Ret t -> Ret (Source_type.to_infer_type t)
+  | Arith t -> Arith (Source_type.to_infer_type t)
   | Agg (Self | Count | Avg | With_order _) 
-  | Null_handling _ | Comparison _
+  | Null_handling _ | Comparison _ | Quantified_comparison _
   | Logical _ | Negation | F _ 
+  | Membership | Range | Like | Like_escape
   | Col_assign _ | Multi _ as fn -> fn
 
 let expr_to_string = show_expr
@@ -818,8 +834,9 @@ let expr_to_string = show_expr
 let map_kind_exprs f = function
   | Agg (With_order ({ order; _ } as wo)) ->
     Agg (With_order { wo with order = List.map (fun (e, dir) -> f e, dir) order })
-  | Agg (Self | Count | Avg) | Null_handling _ | Comparison _
-  | Logical _ | Negation | Ret _ | F _ | Col_assign _ | Multi _ as kind -> kind
+  | Agg (Self | Count | Avg) | Null_handling _ | Comparison _ | Quantified_comparison _
+  | Logical _ | Negation | Ret _ | F _ | Col_assign _ | Multi _
+  | Arith _ | Membership | Range | Like | Like_escape as kind -> kind
 
 let sub_exprs = function
   | Value _ | Param _ | Inparam _ | Column _ | Of_values _ | SelectExpr _ -> []
@@ -1089,11 +1106,21 @@ let pp_func pp f =
   | Agg (With_order { with_order_kind = Group_concat; _ }) -> fprintf pp "|'a| -> text"
   | Agg (With_order { with_order_kind = Json_arrayagg; _ }) -> fprintf pp "|'a| -> json"
   | Ret ret -> fprintf pp "_ -> %s" (Type.show ret)
+  | Arith ret -> fprintf pp "'a -> 'a -> %s" (Type.show ret)
+  | Membership -> fprintf pp "'a -> { 'a }+ -> %s" (Type.show_kind Bool)
+  | Range -> fprintf pp "'a -> 'a -> 'a -> %s" (Type.show_kind Bool)
+  | Like -> fprintf pp "%s -> %s -> %s" (Type.show_kind Text) (Type.show_kind Text) (Type.show_kind Bool)
+  | Like_escape -> fprintf pp "%s -> %s -> %s" (Type.show_kind Bool) (Type.show_kind Text) (Type.show_kind Bool)
   | F (ret, args) -> fprintf pp "%s -> %s" (String.concat " -> " @@ List.map Type.string_of_tyvar args) (Type.string_of_tyvar ret)
   | Col_assign { ret_t=ret; col_t; arg_t } -> aux (F (ret, [col_t; arg_t]))
   | Null_handling (Coalesce (ret, each_arg)) -> fprintf pp "{ %s }+ -> %s" (Type.string_of_tyvar each_arg) (Type.string_of_tyvar ret)
   | Null_handling nulls -> let ret, args = null_handling_signature nulls 2 in aux (F (ret, args))
   | Comparison op -> let ret, args = comparison_signature op in aux (F (ret, args))
+  | Quantified_comparison { op; quantifier } ->
+    let ret, _ = comparison_signature op in
+    fprintf pp "'a -> %s { 'a } -> %s"
+      (match quantifier with `Any -> "any" | `All -> "all")
+      (Type.string_of_tyvar ret)
   | Logical _ -> fprintf pp "'a -> 'a -> %s" (Type.show_kind Bool)
   | Negation -> fprintf pp "'a -> %s" (Type.show_kind Bool)
   | Multi { ret; fixed_args; repeating_pattern } ->
@@ -1110,7 +1137,8 @@ let string_of_func = Format.asprintf "%a" pp_func
 
 let is_grouping = function
   | Agg _ -> true
-  | Col_assign _ | Ret _ | F _ | Multi _ | Null_handling _  | Comparison _ | Negation | Logical _ -> false
+  | Col_assign _ | Ret _ | F _ | Multi _ | Null_handling _  | Comparison _ | Negation | Logical _
+  | Quantified_comparison _ | Arith _ | Membership | Range | Like | Like_escape -> false
 
 module Function : sig
 

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -18,7 +18,9 @@
     in
     List.filter_map param l, List.mem (`Limit,`Const 1) l
 
-  let poly name ret parameters = Fun { fn_name = name; kind = (F (Typ ret, List.map (fun _ -> Var 0) parameters)); parameters; is_over_clause = false }
+  let call name parameters = fn name (Function.lookup name (List.length parameters)) parameters
+
+  let arith name ret e1 e2 = fn name (Arith (Source_type.depends ret)) [e1; e2]
 %}
 
 %token <int> INTEGER
@@ -483,7 +485,8 @@ set_column_expr:
   | LCURLY e=expr RCURLY TWO_QSTN { (WithDefaultParam (e, (($startofs, $endofs), ($startofs + 1, $endofs - 3)))) }
   | DEFAULT { AssignDefault }
 
-anyall: ANY | ALL | SOME { }
+anyall: ANY | SOME { `Any }
+      | ALL { `All }
 
 mnot(X): NOT x = X | x = X { x }
 
@@ -492,42 +495,45 @@ attr_name: cname=ident { { cname; tname=None} }
 
 distinct_from: DISTINCT FROM { }
 
-like_expr: e1=expr mnot(like) e2=expr %prec LIKE { Fun { fn_name = "like"; kind = (fixed Bool [Text; Text]); parameters = [e1;e2]; is_over_clause = false } }
+like_expr: e1=expr mnot(like) e2=expr %prec LIKE { fn "like" Like [e1;e2] }
 
 expr:
-      e1=expr numeric_bin_op e2=expr %prec PLUS { Fun { fn_name = "numeric_bin_op"; kind = (Ret (Source_type.depends Any)); parameters = [e1;e2]; is_over_clause = false } } (* TODO default Int *)
-    | MOD LPAREN e1=expr COMMA e2=expr RPAREN { Fun { fn_name = "mod"; kind = (Ret (Source_type.depends Any)); parameters = [e1;e2]; is_over_clause = false } } (* mysql special *)
-    | e1=expr NUM_DIV_OP e2=expr %prec PLUS { Fun { fn_name = "num_div"; kind = (Ret (Source_type.depends Float)); parameters = [e1;e2]; is_over_clause = false } }
-    | e1=expr TEXT_DIST_OP e2=expr { Fun { fn_name = "text_dist"; kind = (Ret (Source_type.depends Float)); parameters = [e1;e2]; is_over_clause = false } }
-    | e1=expr DIV e2=expr %prec PLUS { Fun { fn_name = "div"; kind = (Ret (Source_type.depends Int)); parameters = [e1;e2]; is_over_clause = false } }
-    | e1=expr bool_op=boolean_bin_op e2=expr %prec AND { Fun { fn_name = "boolean_bin_op"; kind = (Logical bool_op); parameters = [e1;e2]; is_over_clause = false } }
-    | e1=expr comp_op=comparison_op anyall? e2=expr %prec EQUAL { Fun { fn_name = "comparison"; kind = Comparison comp_op; parameters = [e1; e2]; is_over_clause = false } }
-    | e1=expr CONCAT_OP e2=expr { Fun { fn_name = "concat"; kind = (fixed Text [Text;Text]); parameters = [e1;e2]; is_over_clause = false } }
-    | e1=expr JSON_EXTRACT_OP e2=expr { Fun { fn_name = "json_extract"; kind = (Function.lookup "json_extract" 2); parameters = [e1; e2]; is_over_clause = false } }
-    | e1=expr JSON_UNQUOTE_EXTRACT_OP e2=expr { 
-        let extracted = Fun { fn_name = "json_extract"; kind = (Function.lookup "json_extract" 2); parameters = [e1; e2]; is_over_clause = false } in 
-        Fun { fn_name = "json_unquote"; kind = (Function.lookup "json_unquote" 1); parameters = [extracted]; is_over_clause = false } 
-      }
+      e1=expr numeric_bin_op e2=expr %prec PLUS { arith "numeric_bin_op" Any e1 e2 } (* TODO default Int *)
+    | MOD LPAREN e1=expr COMMA e2=expr RPAREN { arith "mod" Any e1 e2 } (* mysql special *)
+    | e1=expr NUM_DIV_OP e2=expr %prec PLUS { arith "num_div" Float e1 e2 }
+    | e1=expr TEXT_DIST_OP e2=expr { arith "text_dist" Float e1 e2 }
+    | e1=expr DIV e2=expr %prec PLUS { arith "div" Int e1 e2 }
+    | e1=expr op=and_op e2=expr %prec AND { fn "boolean_bin_op" (Logical op) [e1;e2] }
+    | e1=expr XOR e2=expr { fn "boolean_bin_op" (Logical Xor) [e1;e2] }
+    | e1=expr OR e2=expr { fn "boolean_bin_op" (Logical Or) [e1;e2] }
+    | e1=expr op=comparison_op q=anyall? e2=expr %prec EQUAL
+      { let kind = Option.map_default (fun quantifier -> Quantified_comparison { op; quantifier }) (Comparison op) q in
+        fn "comparison" kind [e1;e2] }
+    | e1=expr CONCAT_OP e2=expr { fn "concat" (fixed Text [Text;Text]) [e1;e2] }
+    | e1=expr JSON_EXTRACT_OP e2=expr { call "json_extract" [e1;e2] }
+    | e1=expr JSON_UNQUOTE_EXTRACT_OP e2=expr { call "json_unquote" [call "json_extract" [e1;e2]] }
     | e=like_expr esc=escape?
-      {
-        match esc with
-        | None -> e
-        | Some esc -> Fun { fn_name = "like_escape"; kind = (fixed Bool [Bool; Text]); parameters = [e;esc]; is_over_clause = false }
-      }
-    | f=unary_op e=expr { f e }
+      { Option.map_default (fun esc -> fn "like_escape" Like_escape [e;esc]) e esc }
+    | EXCL e=expr %prec EXCL
+      (* Some SQLs use ! as negation, some don't. play it safe and negate it,
+         since negation is currently only used to verify cardinality constraints *)
+      { fn "excl" Negation [e] }
+    | TILDE e=expr %prec TILDE { e }
+    | NOT e=expr %prec NOT { fn "not" Negation [e] }
     | MINUS e=expr %prec UNARY_MINUS { e }
-    | INTERVAL e=expr interval_unit { Fun { fn_name = "interval"; kind = (fixed Datetime [Int]); parameters = [e]; is_over_clause = false } }
+    | INTERVAL e=expr interval_unit { fn "interval" (fixed Datetime [Int]) [e] }
     | LPAREN e=expr RPAREN { e }
-    | a=attr_name c=collate? { Column (make_collated ?collation:c ~collated:a ()) }
+    | a=attr_name c=collate? { column ?collation:c a }
     | VALUES LPAREN n=ident RPAREN { Of_values n }
     | v=literal_value | v=datetime_value { v }
     | INTERVAL_UNIT { Value (make_collated ~collated:(strict Datetime) ()) }
-    | e1=expr mnot(IN) l=sequence(expr) { poly "in" (depends Bool) (e1::l) }
-    | e1=expr mnot(IN) LPAREN select=select_stmt RPAREN { poly "in_select" (depends Bool) [e1; SelectExpr (select, `AsValue)] }
+    | e1=expr mnot(IN) l=sequence(expr) { fn "in" Membership (e1::l) }
+    | e1=expr mnot(IN) LPAREN select=select_stmt RPAREN { fn "in_select" Membership [e1; SelectExpr (select, `AsValue)] }
     | e1=expr IN table=table_name { Tables.check table; e1 }
     | e1=expr k=in_or_not_in p=param
       {
-        let e = poly "in_param" (depends Bool) [ e1; Inparam (make_param ~id:p ~typ:(Source_type.depends Any), Meta.empty()) ] in
+        let arg = Inparam (make_param ~id:p ~typ:(Source_type.depends Any), Meta.empty()) in
+        let e = fn "in_param" Membership [e1; arg] in
         InChoice (make_located ~value:p.value ~pos:($startofs, $endofs), k, e )
       }
     | LPAREN exprs=commas(expr) RPAREN k=in_or_not_in p=param
@@ -539,33 +545,27 @@ expr:
     | LCURLY e=expr RCURLY QSTN { OptionActions ({ choice=e; pos=(($startofs, $endofs), ($startofs + 1, $endofs - 2)); kind = BoolChoices}) }
     | p=param parser_state_ident LCURLY l=choices c2=RCURLY { let { value; pos=(p1,_p2) } = p in Choices ({ value; pos = (p1,c2+1)},l) }
     | SUBSTRING LPAREN s=expr FROM p=expr FOR n=expr RPAREN
-    | SUBSTRING LPAREN s=expr COMMA p=expr COMMA n=expr RPAREN { Fun { fn_name = "substring"; kind = (Function.lookup "substring" 3); parameters = [s;p;n]; is_over_clause = false } }
-    | SUBSTRING LPAREN s=expr either(FROM,COMMA) p=expr RPAREN { Fun { fn_name = "substring"; kind = (Function.lookup "substring" 2); parameters = [s;p]; is_over_clause = false } }
-    | REPLACE LPAREN s=expr COMMA from=expr COMMA to_=expr RPAREN { Fun { fn_name = "replace"; kind = (Function.lookup "replace" 3); parameters = [s;from;to_]; is_over_clause = false } }
-    | DATE LPAREN e=expr RPAREN { Fun { fn_name = "date"; kind = (Function.lookup "date" 1); parameters = [e]; is_over_clause = false } }
-    | TIME LPAREN e=expr RPAREN { Fun { fn_name = "time"; kind = (Function.lookup "time" 1); parameters = [e]; is_over_clause = false } }
-    | f=INTERVAL_UNIT LPAREN e=expr RPAREN { Fun { fn_name = f; kind = Function.lookup f 1; parameters = [e]; is_over_clause = false } }
-    | EXTRACT LPAREN interval_unit FROM e=expr RPAREN { Fun { fn_name = "extract"; kind = Function.lookup "extract" 1; parameters = [e]; is_over_clause = false } }
-    | DEFAULT LPAREN a=attr_name RPAREN { Fun { fn_name = "default"; kind = fun_identity; parameters = [Column (make_collated ~collated:a ())]; is_over_clause = false } }
+    | SUBSTRING LPAREN s=expr COMMA p=expr COMMA n=expr RPAREN { call "substring" [s;p;n] }
+    | SUBSTRING LPAREN s=expr either(FROM,COMMA) p=expr RPAREN { call "substring" [s;p] }
+    | REPLACE LPAREN s=expr COMMA from=expr COMMA to_=expr RPAREN { call "replace" [s;from;to_] }
+    | DATE LPAREN e=expr RPAREN { call "date" [e] }
+    | TIME LPAREN e=expr RPAREN { call "time" [e] }
+    | f=INTERVAL_UNIT LPAREN e=expr RPAREN { call f [e] }
+    | EXTRACT LPAREN interval_unit FROM e=expr RPAREN { call "extract" [e] }
+    | DEFAULT LPAREN a=attr_name RPAREN { fn "default" fun_identity [Column (make_collated ~collated:a ())] }
     | CONVERT LPAREN e=expr USING IDENT RPAREN { e }
     | CONVERT LPAREN e=expr COMMA f=cast_as RPAREN { f e }
     | GROUP_CONCAT LPAREN p=func_params order=loption(order) preceded(SEPARATOR, TEXT)? RPAREN
-      {
-        Fun { fn_name = "group_concat"; kind = Agg ( With_order({ with_order_kind = Group_concat; order })); parameters = p; is_over_clause = false } 
-      }
+      { fn "group_concat" (Agg (With_order { with_order_kind = Group_concat; order })) p }
     | JSON_ARRAYAGG LPAREN p=func_params order=loption(order) limit_t? RPAREN
-      {
-        Fun { fn_name = "json_arrayagg"; kind = Agg ( With_order({ with_order_kind = Json_arrayagg; order })); parameters = p; is_over_clause = false } 
-      }
+      { fn "json_arrayagg" (Agg (With_order { with_order_kind = Json_arrayagg; order })) p }
     | CAST LPAREN e=expr AS f=cast_as RPAREN { f e }
-    | f=table_name LPAREN p=func_params RPAREN { 
-        Fun { fn_name = f.tn; kind = (Function.lookup f.tn (List.length p)); parameters = p; is_over_clause = false } 
-      }
-    | e=expr IS NOT NULL { Fun { fn_name = "is_not_null"; kind = Comparison Is_not_null; parameters = [e]; is_over_clause = false } }
-    | e=expr IS NULL { Fun { fn_name = "is_null"; kind = Comparison Is_null; parameters = [e]; is_over_clause = false } }
-    | e1=expr IS NOT? distinct_from? e2=expr { Fun { fn_name = "is_distinct"; kind = Comparison Not_distinct_op; parameters = [e1; e2]; is_over_clause = false } }
-    | e=expr mnot(BETWEEN) a=expr AND b=expr { poly "between" (depends Bool) [e;a;b] }
-    | mnot(EXISTS) LPAREN select=select_stmt RPAREN { Fun { fn_name = "exists"; kind = (F (Typ (strict Bool), [Typ (depends Any)])); parameters = [SelectExpr (select,`Exists)]; is_over_clause = false } }
+    | f=table_name LPAREN p=func_params RPAREN { call f.tn p }
+    | e=expr IS NOT NULL { fn "is_not_null" (Comparison Is_not_null) [e] }
+    | e=expr IS NULL { fn "is_null" (Comparison Is_null) [e] }
+    | e1=expr IS NOT? distinct_from? e2=expr { fn "is_distinct" (Comparison Not_distinct_op) [e1;e2] }
+    | e=expr mnot(BETWEEN) a=expr AND b=expr { fn "between" Range [e;a;b] }
+    | mnot(EXISTS) LPAREN select=select_stmt RPAREN { fn "exists" (F (Typ (strict Bool), [Typ (depends Any)])) [SelectExpr (select,`Exists)] }
     | CASE initial_expr=expr? branches_list=nonempty_list(case_branch) else_expr=preceded(ELSE,expr)? END
       {
         let case_record = {
@@ -575,10 +575,10 @@ expr:
         } in
         Sql.Case case_record
       }
-    | IF LPAREN e1=expr COMMA e2=expr COMMA e3=expr RPAREN { Fun { fn_name = "if"; kind = (F (Var 0, [Typ (depends Bool);Var 0;Var 0])); parameters = [e1;e2;e3]; is_over_clause = false } }
-    | e=window_function OVER window_spec { e }
-    | f=table_name LPAREN p=func_params RPAREN OVER window_spec 
-        { Fun { fn_name = f.tn; kind = (Function.lookup_agg f.tn (List.length p)); parameters = p; is_over_clause = true } }
+    | IF LPAREN e1=expr COMMA e2=expr COMMA e3=expr RPAREN { fn "if" (F (Var 0, [Typ (depends Bool); Var 0; Var 0])) [e1;e2;e3] }
+    | w=window_function OVER spec=window_spec { w spec }
+    | f=table_name LPAREN p=func_params RPAREN OVER w=window_spec
+        { fn ~over:w f.tn (Function.lookup_agg f.tn (List.length p)) p }
 
 values_stmt1: 
   | VALUES expr_list=commas(preceded(ROW, delimited(LPAREN, expr_list, RPAREN))) { RowExprList expr_list }
@@ -589,24 +589,41 @@ values_stmt:
   
 
 (* https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html *)
+lag_or_lead: LAG { "lag" } | LEAD { "lead" }
+
 window_function:
-  | either(FIRST_VALUE,LAST_VALUE) LPAREN e=expr RPAREN { e }
-  | NTH_VALUE LPAREN e=expr COMMA INTEGER RPAREN { e }
-  | either(LAG,LEAD) LPAREN e=expr pair(COMMA, pair(MINUS?,INTEGER))? RPAREN { e }
+  | FIRST_VALUE LPAREN e=expr RPAREN { fun over -> fn ~over "first_value" (Agg Self) [e] }
+  | LAST_VALUE LPAREN e=expr RPAREN { fun over -> fn ~over "last_value" (Agg Self) [e] }
+  | NTH_VALUE LPAREN e=expr COMMA INTEGER RPAREN
+    { fun _ -> fn ~over:{ frame_has_a_row = false } "nth_value" (Agg Self) [e] }
+  | f=lag_or_lead LPAREN e=expr offset=pair(COMMA, pair(MINUS?,INTEGER))? RPAREN
+    {
+      match offset with
+      | Some (_, (_, 0)) -> (fun _ -> e)
+      | None | Some _ -> (fun _ -> fn ~over:{ frame_has_a_row = false } f (Agg Self) [e])
+    }
 
-window_spec: LPAREN e=partition? o=order? frame? RPAREN (* TODO order parameters? *) { (Option.may (fun o -> make_partition_by (List.map fst o )) o); e }
-partition: PARTITION BY e=expr_list { make_partition_by e} (* TODO check no params *)
-
-frame: either(ROWS,RANGE) either(frame_border, frame_between) { }
-
-frame_between: BETWEEN frame_border AND frame_border { }
+frame:
+  | either(ROWS,RANGE) start=frame_border { start, `Current }
+  | either(ROWS,RANGE) BETWEEN start=frame_border AND stop=frame_border { start, stop }
 
 frame_border:
-  | CURRENT ROW
-  | UNBOUNDED PRECEDING
-  | UNBOUNDED FOLLOWING
-  | expr PRECEDING
-  | expr FOLLOWING { }
+  | CURRENT ROW { `Current }
+  | UNBOUNDED PRECEDING { `Before }
+  | UNBOUNDED FOLLOWING { `After }
+  | expr PRECEDING { `Before }
+  | expr FOLLOWING { `After }
+
+window_spec: LPAREN partition? o=order? f=frame? RPAREN (* TODO order parameters? *)
+  {
+    Option.may (fun o -> make_partition_by (List.map fst o)) o;
+    { frame_has_a_row = match f with
+      | None -> true
+      | Some (`After, _) | Some (_, `Before) -> false
+      | Some ((`Before | `Current), (`Current | `After)) -> true }
+  }
+
+partition: PARTITION BY e=expr_list { make_partition_by e} (* TODO check no params *)
 
 in_or_not_in: IN { `In } | NOT IN { `NotIn }
 case_branch: WHEN w=expr THEN t=expr
@@ -654,17 +671,7 @@ comparison_op:
       Comp_num_eq 
     }
 
-boolean_bin_op: 
-    | AND { And }
-    | OR { Or }
-    | XOR { Xor }
-
-unary_op: EXCL { 
-          (* Some SQLs use ! as negation, some don't. play it safe and negate it,
-             since negation is currently only used to verify cardinality constraints *)
-          (fun e -> Fun { fn_name = "excl"; kind = Negation; parameters = [e]; is_over_clause = false }) } 
-        | TILDE { (fun e -> e) }
-        | NOT { (fun e -> Fun { fn_name = "not"; kind = Negation; parameters = [e]; is_over_clause = false }) }
+and_op: AND { And }
 
 interval_unit: INTERVAL_UNIT
              | SECOND_MICROSECOND | MINUTE_MICROSECOND | MINUTE_SECOND
@@ -726,9 +733,9 @@ binary: BINARY | BINARY VARYING { }
 text: CHARACTER { }
 
 cast_as:
-    | t=cast_sql_type { (fun e -> Fun { fn_name = "cast"; kind = (Ret (Source_type.depends t)); parameters = [e]; is_over_clause = false }) }
-    | UNSIGNED { (fun e -> Fun { fn_name = "cast_unsigned"; kind = (Ret (Source_type.depends UInt64)); parameters = [e]; is_over_clause = false }) }
-    | SIGNED { (fun e -> Fun { fn_name = "cast_signed"; kind = (Ret (Source_type.depends Int)); parameters = [e]; is_over_clause = false }) }
+    | t=cast_sql_type { (fun e -> fn "cast" (Ret (Source_type.depends t)) [e]) }
+    | UNSIGNED { (fun e -> fn "cast_unsigned" (Ret (Source_type.depends UInt64)) [e]) }
+    | SIGNED { (fun e -> fn "cast_signed" (Ret (Source_type.depends Int)) [e]) }
 
 %inline either(X,Y): X | Y { }
 %inline commas(X): l=separated_nonempty_list(COMMA,X) { l }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -5,6 +5,7 @@ open Printf
 open ExtLib
 open Prelude
 open Sql
+open Narrowing
 
 module Config = struct 
   let debug = ref false
@@ -18,68 +19,6 @@ type query_scope =
   | Subquery
   | From_passthrough
 
-module Qualified_attr = struct
-  module T = struct
-    type t = { sources : table_name list; name : string } [@@deriving eq, ord]
-  end
-  include T
-
-  let of_attr (a : table_name Schema.Source.Attr.t) = { sources = a.sources; name = a.attr.name }
-
-  let named = function { name = ""; _ } -> None | key -> Some key
-
-  module Map = Map.Make(T)
-  module Set = Set.Make(T)
-end
-
-module Attr_refinement = struct
-  type t = {
-    not_null : Qualified_attr.Set.t;
-    meta : Meta.t Qualified_attr.Map.t;
-  }
-
-  let empty = { not_null = Qualified_attr.Set.empty; meta = Qualified_attr.Map.empty }
-
-  let add a b = {
-    not_null = Qualified_attr.Set.union a.not_null b.not_null;
-    meta = Qualified_attr.Map.union (fun _ x y -> Some (Meta.merge_right x y)) a.meta b.meta;
-  }
-
-  let keep_all = List.fold_left add empty
-
-  let keep_shared = function
-    | [] -> empty
-    | x :: l ->
-      List.fold_left (fun a b -> {
-        not_null = Qualified_attr.Set.inter a.not_null b.not_null;
-        meta = Qualified_attr.Map.merge (fun _ x y ->
-          match x, y with
-          | Some x, Some y -> Meta.declared (Meta.inter x y)
-          | Some _, None | None, Some _ | None, None -> None) a.meta b.meta;
-      }) x l
-
-  let not_null attr = { empty with not_null = Qualified_attr.Set.singleton attr }
-
-  let inherit_meta ~constrains (col : table_name Schema.Source.Attr.t) ~(referenced : table_name Schema.Source.Attr.t) =
-    let inherited = Meta.of_domain referenced.attr.meta in
-    let carries =
-      match col.attr.domain.t, referenced.attr.domain.t with
-      | Union a, Union b -> Type.Enum_kind.Ctors.subset a.ctors b.ctors
-      | a, b -> constrains col && Type.equal_kind a b
-    in
-    match Meta.is_empty inherited, carries with
-    | false, true -> { empty with meta = Qualified_attr.Map.singleton (Qualified_attr.of_attr col) inherited }
-    | _ -> empty
-
-  let apply t a =
-    let key = Qualified_attr.of_attr a in
-    let from_query = Option.default (Meta.empty ()) (Qualified_attr.Map.find_opt key t.meta) in
-    let not_null = Qualified_attr.Set.mem key t.not_null in
-    Schema.Source.Attr.map_attr (fun attr ->
-      { attr with
-        meta = Meta.merge_right from_query attr.meta;
-        domain = if not_null then Type.make_strict attr.domain else attr.domain }) a
-end
 
 type env = {
   tables : Tables.table list;
@@ -128,7 +67,7 @@ type res_expr =
 
 and case_branch = { when_: res_expr; then_: res_expr; } [@@deriving show]
 
-and res_fun = { kind: Type.t func [@printer pp_func] ; parameters: res_expr list; is_over_clause: bool; } [@@deriving show]
+and res_fun = { kind: Type.t func [@printer pp_func] ; parameters: res_expr list; over: Sql.over option } [@@deriving show]
 
 and res_in_tuple_list =
   ResTyped of (Type.t * Meta.t) list | Res of (res_expr * Meta.t) list [@@deriving show]
@@ -191,7 +130,7 @@ let rec is_grouping = function
 | e -> List.exists is_grouping (sub_exprs e)
 
 let is_windowing =
-  expr_exists (function Sql.Fun { is_over_clause; _ } -> is_over_clause | _ -> false)
+  expr_exists (function Sql.Fun { over; _ } -> Option.is_some over | _ -> false)
 
 let exists_grouping columns =
   List.exists (function
@@ -245,12 +184,16 @@ let resolve_column_opt ~env col =
   | attr -> Some attr
   | exception (Schema.Error _ | Failure _) -> None
 
+let as_column ~env = function
+  | Sql.Column col -> resolve_column_opt ~env col.collated
+  | _ -> None
+
 let _print_env env =
   eprintfn "env: ";
   Schema.print @@ Schema.Source.to_schema env.schema;
   Tables.print stderr env.tables
 
-let update_schema_with_aliases all_schema final_schema = 
+let update_schema_with_aliases all_schema final_schema =
   let applied = all_schema |> List.filter (fun s1 -> List.for_all Schema.Source.Attr.(fun s2 -> s2.attr.name <> s1.attr.name) final_schema) in  
   applied @ final_schema
 
@@ -400,12 +343,8 @@ let matches_at_most_one_row ~env table expr =
   let independent_of_table e =
     not (Table_refs.may_refer table (Table_refs.of_expr ~env e))
   in
-  let as_column = function
-    | Sql.Column c -> resolve_column_opt ~env c.collated
-    | _ -> None
-  in
   let bound1 a b =
-    match as_column a with
+    match as_column ~env a with
     | Some attr when belongs attr && independent_of_table b ->
       Some attr.Schema.Source.Attr.attr.name
     | _ -> None
@@ -629,35 +568,6 @@ let propagate_meta ~meta_of =
 
 let push_meta ~meta_of ctx e = snd (propagate_meta ~meta_of e) ctx
 
-let narrow_columns ~env ~constrains e =
-  let not_null col =
-    match resolve_column_opt ~env col with
-    | Some a when constrains a -> Attr_refinement.not_null (Qualified_attr.of_attr a)
-    | Some _ | None -> Attr_refinement.empty
-  in
-  let rec narrow satisfied = function
-    | Sql.Fun { kind = Comparison (Is_null | Is_not_null as op); parameters = [Column c]; _ }
-      when Bool.equal satisfied (equal_comparison_op op Is_not_null) -> not_null c.collated
-    | Fun { kind = Comparison (Comp_equal | Not_distinct_op); parameters = [Column a; Column b]; _ } when satisfied ->
-      begin match resolve_column_opt ~env a.collated, resolve_column_opt ~env b.collated with
-      | Some a, Some b ->
-        let inherit_meta = Attr_refinement.inherit_meta ~constrains in
-        Attr_refinement.add (inherit_meta a ~referenced:b) (inherit_meta b ~referenced:a)
-      | None, _ | _, None -> Attr_refinement.empty
-      end
-    | Fun { kind = Negation; parameters = [e]; _ } -> narrow (not satisfied) e
-    | Fun { kind = Logical (And | Or as op); parameters; _ } ->
-      let keep = if Bool.equal satisfied (equal_logical_op op And) then Attr_refinement.keep_all else Attr_refinement.keep_shared in
-      keep (List.map (narrow satisfied) parameters)
-    | InChoice (_, _, e) | OptionActions { choice = e; _ } -> narrow satisfied e
-    | Choices (_, l) -> Attr_refinement.keep_shared (List.map (fun (_, e) -> Option.map_default (narrow satisfied) Attr_refinement.empty e) l)
-    | Case { branches; else_ = Some e; _ } ->
-      Attr_refinement.keep_shared (narrow satisfied e :: List.map (fun (b : Sql.case_branch) -> narrow satisfied b.then_) branches)
-    | Value _ | Param _ | Inparam _ | Column _ | Of_values _ | SelectExpr _
-    | InTupleList _ | Case { else_ = None; _ } | Fun _ -> Attr_refinement.empty
-  in
-  narrow true e
-
 (** resolve each name reference (Column, Inserted, etc) into ResValue or ResFun of corresponding type *)
 let rec resolve_columns env expr =
   if !Config.debug then
@@ -671,7 +581,7 @@ let rec resolve_columns env expr =
     match e with
     | Value x -> ResValue x.collated
     | Column col ->
-      let attr = (resolve_column ~env col.collated).attr in
+      let attr = (Attr_refinement.refine_nullability env.attr_refinement (resolve_column ~env col.collated)).attr in
       let json_null_kind = Meta.find_opt attr.meta "json_null_kind" in
       let text_as_json = Meta.find_opt attr.meta "text_as_json" in
       let domain = match json_null_kind, text_as_json, attr.domain with
@@ -746,8 +656,8 @@ let rec resolve_columns env expr =
     | Inparam (x, m) -> ResInparam (make_param ~id:x.id ~typ:(Source_type.to_infer_type x.typ), m)
     | InChoice (n, k, x) -> ResInChoice (n, k, each x)
     | Choices (n, l) -> ResChoices (n, List.map (fun (n, e) -> n, Option.map each e) l)
-    | Fun { kind; parameters; is_over_clause; _ } ->
-      ResFun { kind = source_fun_kind_to_infer kind; parameters = List.map each parameters; is_over_clause }
+    | Fun { kind; parameters; over; _ } ->
+      ResFun { kind = source_fun_kind_to_infer kind; parameters = List.map each parameters; over }
     | Case { case; branches; else_ } ->
       let case = Option.map each case in
       let branches = List.map (fun { Sql.when_; then_ } -> { when_ = each when_; then_ = each then_ }) branches in
@@ -775,16 +685,16 @@ let rec resolve_columns env expr =
               let then_exprs = List.map (fun b -> b.Sql.then_) branches in
               let all_results_exprs = then_exprs @ (option_list else_) in
               List.find_map with_count all_results_exprs
-            | Fun { kind = Agg Count; is_over_clause = false; _ }
+            | Fun { kind = Agg Count; over = None; _ }
             | SelectExpr (_, _) -> Some domain
-            | Fun { parameters; is_over_clause = false; _ } -> List.find_map with_count parameters
+            | Fun { parameters; over = None; _ } -> List.find_map with_count parameters
             | Choices (_, chs) ->
               List.fold_left (fun acc (_, e) -> match acc with
                 | None -> None
                 | Some _ -> Stdlib.Option.bind e with_count
               ) (Some domain) chs
             | OptionActions { choice; _ } -> with_count choice  
-            | Fun { is_over_clause = true; _ }
+            | Fun { over = Some _; _ }
             | Value _| Param _| Inparam _ | InChoice _
             | Column _| InTupleList _ | Of_values _ -> None
         in
@@ -880,7 +790,7 @@ and assign_types env expr =
       let case = Option.map (assign_params whens_t) case_e in
       let branches = List.map2 (fun when_ then_ -> { when_; then_ }) whens_e thens_e in
       ResCase { case = case; branches; else_ = else_ }, `Ok thens_t
-    | ResFun { kind; parameters; is_over_clause}  ->
+    | ResFun { kind; parameters; over }  ->
         let open Type in
         let (params,types) = parameters |> List.map typeof |> List.split in
         let types = List.map get_or_failwith types in
@@ -929,7 +839,9 @@ and assign_types env expr =
 
         (* With GROUP BY, the query returns no rows if no groups exist. With OVER clause, the query returns no rows if the outer query filter eliminates all rows.
            In both cases, if we're in a context that expects a value (like a subquery), the result should be nullable. *)
-        let consider_agg_nullability typ = if (env.query_has_grouping || is_over_clause) && is_strict typ then typ else make_nullable typ in
+        let aggregates_a_row =
+          env.query_has_grouping || Option.map_default (fun o -> o.frame_has_a_row) false over in
+        let consider_agg_nullability typ = if aggregates_a_row && is_strict typ then typ else make_nullable typ in
 
         let first_strict ret args = 
           let has_one_strict = List.exists (fun arg -> equal_nullability arg.nullability Strict) types in
@@ -978,6 +890,12 @@ and assign_types env expr =
         | F (ret, args), _ ->
           let args, ret = convert (ret, args) in
           undepend ret (common_nullability args), args
+        | Arith t, _ -> infer_fn (Ret t) types
+        | (Membership | Range | Like | Like_escape) as func, _ ->
+          begin match Sql.signature func (List.length types) with
+          | Some (ret, args) -> infer_fn (F (ret, args)) types
+          | None -> fail "wrong number of arguments : %s" (show_func ())
+          end
         | Ret t, _ when Type.is_any t -> (* lame *)
           begin match common_supertype types with
           | Some t -> t, List.map (const t) types
@@ -986,6 +904,7 @@ and assign_types env expr =
         | Ret ret, _ ->
           let nullability = common_nullability @@ ret :: types in (* remove this when subqueries are taken out separately *)
           { ret with nullability }, types (* ignoring arguments FIXME *)
+        | Quantified_comparison { op; _ }, _ -> infer_fn (Comparison op) types
         | Comparison op, _ ->
           let args, ret = convert (Sql.comparison_signature op) in
           begin match op with
@@ -1023,7 +942,7 @@ and assign_types env expr =
         | Col_assign _, _ -> fail "SET operation requires two arguments"
         in
         let (ret,inferred_params) = infer_fn kind types in
-        ResFun { kind; parameters = (List.map2 assign_params inferred_params params); is_over_clause }, `Ok ret
+        ResFun { kind; parameters = (List.map2 assign_params inferred_params params); over }, `Ok ret
   and typeof expr =
     let r = typeof_ expr in
     if !Config.debug then eprintfn "%s is typeof %s" (Type.show @@ get_or_failwith @@ snd r) (show_res_expr @@ fst r);
@@ -1079,7 +998,7 @@ and resolve_column_assignments ~env l =
     let assign e =
       let e = push_meta ~meta_of:(meta_of ~env) attr.meta e in
       Fun { fn_name = "col_assign"; kind = Col_assign { ret_t = Var 0; col_t = Var 0; arg_t = Var 0 };
-            parameters = [Value typ; e]; is_over_clause = false }
+            parameters = [Value typ; e]; over = None }
     in
     match expr with
     (* FIXME hack, should propagate properly *)
@@ -1161,30 +1080,41 @@ and get_params_l env l = flat_map (get_params env) l
 
 and do_join (env,params) { From.src; kind; cond; _ } =
   let joined = Qualified_attr.Set.of_list (List.map Qualified_attr.of_attr src.rsrc_schema) in
-  let constrains col =
-    let from_joined_source = Qualified_attr.Set.mem (Qualified_attr.of_attr col) joined in
+  let is_joined key = Qualified_attr.Set.mem key joined in
+  let is_accumulated key = not (is_joined key) in
+  let both = const true in
+  let neither = const false in
+  let filtered, survives_padding =
     match kind with
-    | Inner | Straight -> true
-    | Left -> from_joined_source
-    | Right -> not from_joined_source
-    | Full -> false
+    | Inner | Straight -> both, both
+    | Left -> is_joined, is_accumulated
+    | Right -> is_accumulated, is_joined
+    | Full -> neither, neither
   in
+  let constrains col = filtered (Qualified_attr.of_attr col) in
+  let survives_padding = Attr_refinement.restrict_not_null survives_padding in
   let common_columns = match cond with
     | Natural | Using _ -> Schema.Join.common_columns cond env.schema src.rsrc_schema
     | On _ | Default -> []
   in
   let schema = Schema.Join.join kind cond env.schema src.rsrc_schema in
+  let equated a =
+    if constrains a then Attr_refinement.not_null (Qualified_attr.of_attr a) else Attr_refinement.empty in
   let inherited =
-    List.map (fun (col, referenced) -> Attr_refinement.inherit_meta ~constrains col ~referenced) common_columns
+    List.concat_map (fun (col, referenced) ->
+      [ Attr_refinement.inherit_meta ~constrains col ~referenced; equated col; equated referenced ])
+      common_columns
   in
-  let attr_refinement = Attr_refinement.keep_all (env.attr_refinement :: inherited) in
-  let env = { env with schema; attr_refinement } in
+  let env = { env with schema;
+    attr_refinement = survives_padding (Attr_refinement.keep_all (env.attr_refinement :: inherited)) } in
+  let params = params @ src.rsrc_params in
   match cond with
-  | Default | Natural | Using _ -> env, params @ src.rsrc_params
+  | Default | Natural | Using _ -> env, params
   | On e ->
-    let env = { env with attr_refinement = Attr_refinement.add env.attr_refinement (narrow_columns ~env ~constrains e) } in
+    let env = { env with attr_refinement = Attr_refinement.add env.attr_refinement
+      (survives_padding (narrow_columns ~resolve:(resolve_column_opt ~env) ~constrains e)) } in
     (* TODO should use final schema (same as tables)? *)
-    env, params @ src.rsrc_params @ get_params { env with set_tyvar_strict = true } e
+    env, params @ get_params { env with set_tyvar_strict = true } e
 
 and join env { From.base; joins } =
   assert (env.schema = []);
@@ -1251,8 +1181,8 @@ and ensure_res_expr = function
   | InChoice (p,_,_) -> failed ~at:p.pos "ensure_res_expr InChoice TBD"
   | Column _ | Of_values _ -> failwith "Not a simple expression"
   | Fun { kind; _ } when Sql.is_grouping kind -> failwith "Grouping function not allowed in simple expression"
-  | Fun { kind; parameters; is_over_clause; _ } ->
-     ResFun { kind = source_fun_kind_to_infer kind; parameters = List.map ensure_res_expr parameters; is_over_clause } (* FIXME *)
+  | Fun { kind; parameters; over; _ } ->
+     ResFun { kind = source_fun_kind_to_infer kind; parameters = List.map ensure_res_expr parameters; over } (* FIXME *)
   | SelectExpr _ -> failwith "not implemented : ensure_res_expr for SELECT"
   | OptionActions _ -> failwith  "BoolChoice is used in WHERE expr only"
 
@@ -1284,8 +1214,14 @@ and eval_select ~order env { columns; from; where; group; having; } =
   let from_env, p2, resolved_from = eval_nested { env with scope = child_scope } from in
   let env = { from_env with scope = env.scope } in
   let env = { env with query_has_grouping = List.length group > 0 } in
-  let env = { env with attr_refinement = Attr_refinement.keep_all (env.attr_refinement ::
-    List.map (Option.map_default (narrow_columns ~env ~constrains:(const true)) Attr_refinement.empty) [ where; having ]) } in
+  let narrow = Option.map_default (narrow_columns ~resolve:(resolve_column_opt ~env) ~constrains:(const true)) Attr_refinement.empty in
+  let grouping_keys = Qualified_attr.Set.of_list @@
+    List.filter_map (fun e -> Option.map Qualified_attr.of_attr (as_column ~env e)) group
+  in
+  let narrow_having having =
+    Attr_refinement.restrict_not_null (fun k -> Qualified_attr.Set.mem k grouping_keys) (narrow having) in
+  let env = { env with attr_refinement =
+    Attr_refinement.keep_all [ env.attr_refinement; narrow where; narrow_having having ] } in
   let projection = make_dynamic_select ~env columns in
   let final_schema = infer_schema env projection in
   let final_schema =
@@ -1299,14 +1235,15 @@ and eval_select ~order env { columns; from; where; group; having; } =
   ) final_schema in
   (* use schema without aliases here *)
   let p1 = get_params_of_columns env projection in
-  let env, p3 = if Dialect.Semantic.is_where_aliases_dialect () then 
-    let env = { env with schema = make_unique (Schema.Join.cross env.schema final_schema') } in
-    env, get_params_opt { env with set_tyvar_strict = true; } where
-  else
-    let p3 = get_params_opt { env with set_tyvar_strict = true; 
-       (* Some dialects support aliasing *)
-      schema = List.filter (fun i -> i.Schema.Source.Attr.sources <> []) env.schema; } where in
-    env, p3
+  let env, p3 =
+    let where_params env = get_params_opt { env with set_tyvar_strict = true } where in
+    (* Some dialects support aliasing *)
+    if Dialect.Semantic.is_where_aliases_dialect () then
+      let env = { env with schema = make_unique (Schema.Join.cross env.schema final_schema') } in
+      env, where_params env
+    else
+      let sourced = { env with schema = List.filter (fun i -> i.Schema.Source.Attr.sources <> []) env.schema } in
+      env, where_params sourced
   in
   (* ORDER BY, HAVING, GROUP BY allow have column without explicit referring to source if it's specified in SELECT *)
   let env = { env with schema = update_schema_with_aliases env.schema final_schema' } in
@@ -1513,7 +1450,7 @@ let annotate_select select attrs =
       | { value = Expr (loc, name); pos = col_pos } :: cols, a :: attrs ->
         let e = push_meta ~meta_of:(const None) a.meta loc.value in
         let t = a.domain in
-        loop ({ value = Expr ({ loc with value = Fun { fn_name = "insert_select"; kind = (F (Typ t, [Typ t])); parameters = [e]; is_over_clause = false} }, name); pos = col_pos } :: acc) cols attrs
+        loop ({ value = Expr ({ loc with value = Fun { fn_name = "insert_select"; kind = (F (Typ t, [Typ t])); parameters = [e]; over = None} }, name); pos = col_pos } :: acc) cols attrs
       | _, [] | [], _ -> failwith "Select cardinality doesn't match Insert"
     in
     loop [] cols attrs

--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -24,7 +24,7 @@ depends: [
   "base-unix"
   "odoc" {with-doc}
   "ounit"
-  "qcheck-ounit" {>= "0.25"}
+  "qcheck-core" {with-test & >= "0.25"}
 ]
 depopts: [
   "mariadb"

--- a/src/test.ml
+++ b/src/test.ml
@@ -106,16 +106,16 @@ let test = Type.[
      [attr' ~nullability:Nullable "str" Text]
      [param Int];
   tt "SELECT x,y+? AS z FROM (SELECT id AS y,CONCAT(str,name) AS x FROM test WHERE id=@id*2) ORDER BY x,x+z LIMIT @lim"
-     [attr' ~nullability:Nullable "x" Text; attr' ~nullability:Nullable "z" Int]
-     [param_nullable Int; named "id" Int; named "lim" Int; ];
+     [attr' ~nullability:Nullable "x" Text; attr' "z" Int]
+     [param Int; named "id" Int; named "lim" Int; ];
   tt "select test.name,other.name as other_name from test, test as other where test.id=other.id + @delta"
      [  attr' ~nullability:Nullable "name" Text;
         attr' ~nullability:Nullable "other_name" Text
      ]
-     [named_nullable "delta" Int];
+     [named "delta" Int];
   tt "select test.name from test where test.id + @x = ? or test.id - @x = ?"
      [attr' ~nullability:Nullable "name" Text;]
-     [named_nullable "x" Int; param Int; named_nullable "x" Int; param Int;];
+     [named "x" Int; param Int; named "x" Int; param Int;];
   tt "SELECT name FROM test WHERE name IS NOT NULL"
      [attr' "name" Text]  (* Strict, not Nullable *)
      [];
@@ -259,9 +259,8 @@ let test = Type.[
      [attr' "name" Text;
       attr' "str" ~nullability:Nullable Text]
      [];
-  (* CASE missing ELSE - should NOT refine (else branch might be NULL) *)
   tt "SELECT name FROM test WHERE CASE WHEN id > 10 THEN name IS NOT NULL END"
-     [attr' "name" ~nullability:Nullable Text]
+     [attr' "name" Text]
      [];
   (* CASE with one branch missing check - should NOT refine *)
   tt "SELECT name FROM test WHERE CASE WHEN id > 10 THEN name IS NOT NULL WHEN id < 10 THEN id > 0 ELSE name IS NOT NULL END"
@@ -269,6 +268,20 @@ let test = Type.[
      [];
   (* CASE with different columns in branches - should NOT refine either *)
   tt "SELECT name, str FROM test WHERE CASE WHEN id > 10 THEN name IS NOT NULL ELSE str IS NOT NULL END"
+     [attr' "name" ~nullability:Nullable Text;
+      attr' "str" ~nullability:Nullable Text]
+     [];
+  tt "SELECT name FROM test WHERE name > ALL (SELECT str FROM test)"
+     [attr' "name" ~nullability:Nullable Text]
+     [];
+  tt "SELECT name FROM test WHERE name > ANY (SELECT str FROM test)"
+     [attr' "name" Text]
+     [];
+  tt "SELECT name, str FROM test WHERE NOT (name IS NULL) AND NOT (str IS NULL)"
+     [attr' "name" Text;
+      attr' "str" Text]
+     [];
+  tt "SELECT name, str FROM test WHERE NOT (name IS NULL AND str IS NULL)"
      [attr' "name" ~nullability:Nullable Text;
       attr' "str" ~nullability:Nullable Text]
      [];
@@ -291,7 +304,7 @@ let test = Type.[
   (* check precedence of boolean and arithmetic operators *)
   tt "select str from test where id>=@id and id-@x<@id"
     [attr' ~nullability:Nullable "str" Text;]
-    [named "id" Int; named_nullable "x" Int; named "id" Int];
+    [named "id" Int; named "x" Int; named "id" Int];
   tt "select 3/5"
     [attr' ~nullability:Strict "" Float;]
     [];
@@ -336,8 +349,8 @@ let test4 =
     [attr' ~nullability:Strict  "" Int; attr' ~nullability:Strict "" Text] [] ~kind:(Select `Nat);
   tt "select greatest(10,x) from test4" [attr' ~nullability:Nullable "" Int] [] ~kind:(Select `Nat);
   tt "select 1+2 from test4 where x=y"  [attr' ~nullability:Strict "" Int] [] ~kind:(Select `Nat);
-  tt "select max(x) as q from test4 where y = x + @n" [attr' ~nullability:Nullable "q" Int] [named_nullable "n" Int] ~kind:(Select `One);
-  tt "select coalesce(max(x),0) as q from test4 where y = x + @n" [attr' ~nullability:Strict "q" Int] [named_nullable "n" Int] ~kind:(Select `One); 
+  tt "select max(x) as q from test4 where y = x + @n" [attr' ~nullability:Nullable "q" Int] [named "n" Int] ~kind:(Select `One);
+  tt "select coalesce(max(x),0) as q from test4 where y = x + @n" [attr' ~nullability:Strict "q" Int] [named "n" Int] ~kind:(Select `One); 
 ]
 
 let test_parsing = [
@@ -353,27 +366,29 @@ let test_join_result_cols () =
   Tables.reset ();
   let ints = List.map (fun name ->
     if Stdlib.String.ends_with name ~suffix:"?" then
-      Sql.{ name = String.slice ~last:(-1) name; domain = Type.(nullable Int); extra = Constraints.empty; meta = Meta.empty();}
+      attr' ~nullability:Type.Nullable (String.slice ~last:(-1) name) Type.Int
     else
-      attr name Int)
+      attr' name Type.Int)
   in
   do_test "CREATE TABLE t1 (i INT, j INT)" [] [];
   do_test "CREATE TABLE t2 (k INT, j INT)" [] [];
-  do_test "SELECT * FROM t1 JOIN t2 ON t1.j=t2.j" (ints ["i";"j";"k";"j"]) [];
-  do_test "SELECT * FROM t1 LEFT JOIN t2 ON t1.j=t2.j" (ints ["i";"j";"k?";"j?"]) [];
-  do_test "SELECT * FROM t1 RIGHT JOIN t2 ON t1.j=t2.j" (ints ["i?";"j?";"k";"j"]) [];
+  do_test "SELECT * FROM t1 JOIN t2 ON t1.j=t2.j" (ints ["i?";"j";"k?";"j"]) [];
+  do_test "SELECT * FROM t1 LEFT JOIN t2 ON t1.j=t2.j" (ints ["i?";"j?";"k?";"j?"]) [];
+  do_test "SELECT * FROM t1 RIGHT JOIN t2 ON t1.j=t2.j" (ints ["i?";"j?";"k?";"j?"]) [];
   do_test "SELECT * FROM t1 FULL JOIN t2 ON t1.j=t2.j" (ints ["i?";"j?";"k?";"j?"]) [];
-  do_test "SELECT * FROM t1 NATURAL JOIN t2" (ints ["j";"i";"k"]) [];
-  do_test "SELECT * FROM t1 JOIN t2 USING (j)" (ints ["j";"i";"k"]) [];
+  do_test "SELECT * FROM t1 NATURAL JOIN t2" (ints ["j";"i?";"k?"]) [];
+  do_test "SELECT * FROM t1 JOIN t2 USING (j)" (ints ["j";"i?";"k?"]) [];
+  do_test "SELECT * FROM t1 NATURAL LEFT JOIN t2" (ints ["j?";"i?";"k?"]) [];
+  do_test "SELECT * FROM t1 LEFT JOIN t2 USING (j)" (ints ["j?";"i?";"k?"]) [];
 (*   NATURAL JOIN with common column in WHERE *)
   do_test
     "SELECT * FROM t1 NATURAL JOIN t2 WHERE j > @x"
-    (ints ["j";"i";"k"])
+    (ints ["j";"i?";"k?"])
     [named"x" Int];
 (*   NATURAL JOIN with common column qualified in WHERE *)
   do_test
     "SELECT * FROM t1 NATURAL JOIN t2 WHERE t2.j > @x"
-    (ints ["j";"i";"k"])
+    (ints ["j";"i?";"k?"])
     [named "x" Int];
   ()
 
@@ -385,10 +400,10 @@ let test_enum = [
 
 let test_manual_param = [
   tt "CREATE TABLE test7 (x INT NULL DEFAULT 0) ENGINE=MyISAM DEFAULT CHARSET=utf8" [] [];
-  tt "SELECT * FROM test7 WHERE x = @x_arg" [attr "x" Int ~extra:[Null; WithDefault];] [
+  tt "SELECT * FROM test7 WHERE x = @x_arg" [attr' "x" Int ~extra:[Null; WithDefault];] [
     named "x_arg" Int
   ];
-  tt "SELECT * FROM test7 WHERE x = @x_arg::Int" [attr "x" Int ~extra:[Null; WithDefault];] [
+  tt "SELECT * FROM test7 WHERE x = @x_arg::Int" [attr' "x" Int ~extra:[Null; WithDefault];] [
     named "x_arg" Int
   ];
   tt "INSERT INTO test7 VALUES (@x_arg)" [] [
@@ -461,10 +476,10 @@ let test_param_not_null_by_default = [
     AND a + @x = 10
     AND c = @c AND a < (@a2 :: Int Null)
     AND (SELECT d FROM test16 LIMIT 1) = @d
-  |} [attr "a" Int ~extra:[];] [
+  |} [attr' "a" Int ~extra:[];] [
     named "a" Int;
     named "ab" Int;
-    named_nullable "x" Int;
+    named "x" Int;
     named "c" Text;
     named_nullable "a2" Int;
     named "d" Int;
@@ -487,7 +502,7 @@ let test_in_clause_with_tuple_sets () =
     SELECT a FROM test17 
     WHERE (a, b, c) IN @abc
   |} in
-  assert_equal ~msg:"schema" ~printer:Sql.Schema.to_string [attr' ~nullability:Nullable "a" Int] (schema_to_attrs stmt.schema);
+  assert_equal ~msg:"schema" ~printer:Sql.Schema.to_string [attr' "a" Int] (schema_to_attrs stmt.schema);
   ()
 
 let test_agg_nullable = [
@@ -612,7 +627,7 @@ let cte_possible_rec_non_shared_select_only = [
     )
     SELECT num
     FROM cte
-  |} [ attr' ~nullability:Nullable "num" Int;][];
+  |} [ attr' ~nullability:Strict "num" Int;][];
   tt {|
     CREATE TABLE test22 (
       col_id INT PRIMARY KEY,
@@ -648,7 +663,7 @@ let cte_possible_rec_non_shared_select_only = [
     WHERE dt.avg_value
   |} [
     attr' ~nullability:Nullable "col_group" Text;
-    attr' ~nullability:Nullable "avg_value" Float;
+    attr' ~nullability:Strict "avg_value" Float;
   ] [];
   tt {|
     INSERT INTO test22 (col_id, col_value, col_group)
@@ -710,26 +725,26 @@ let test_ambiguous = [
      while it doesn't do that for WHERE.
   *)
   tt "select test23.id from test23 join test24 on test23.id = test24.id order by id" [
-    attr' ~nullability:Nullable "id" Int;
+    attr' ~nullability:Strict "id" Int;
   ] [];
   (* Wrong parses and asserts fail *)
   wrong "select test23.id from test23 join test24 on test23.id = test24.id where id > 2 order by id";
   tt "select test23.id from test23 join test24 on test23.id = test24.id group by id" [
-    attr' ~nullability:Nullable "id" Int;
+    attr' ~nullability:Strict "id" Int;
   ] [];
   tt "select test23.id as test from test23 join test24 on test23.id = test24.id group by column_a" [
-    attr' ~nullability:Nullable "test" Int;
+    attr' ~nullability:Strict "test" Int;
   ][];
   tt "select test23.id, test24.id from test23 join test24 on test23.id = test24.id" [
-    attr' ~nullability:Nullable "id" Int;
-    attr' ~nullability:Nullable "id" Int;
+    attr' ~nullability:Strict "id" Int;
+    attr' ~nullability:Strict "id" Int;
   ] [];
   (* Wrong parses and asserts fail *)
   wrong "select id, id from test23 join test24 on test23.id = test24.id group by id";
   wrong "select id as id1, id as id2 from test23 join test24 on test23.id = test24.id group by id";
   wrong "select test23.id, test24.id from test23 join test24 on test23.id = test24.id group by id";
   tt "select test23.id from test23 join test24 on test23.id = test24.id group by id, column_a" [
-    attr' ~nullability:Nullable "id" Int;
+    attr' ~nullability:Strict "id" Int;
   ] [];
   tt "SELECT COUNT(column_a) as column_a FROM test23 WHERE column_a = @column_a" [
     (* COUNT(column_a :: Text) :: Int *)
@@ -742,19 +757,19 @@ let test_ambiguous = [
   tt "CREATE TABLE test26 (id INT)" [] [];
   wrong "select * from foo join bar on foo.id";
   tt "SELECT test23.id AS id1, test24.id AS id2 FROM test23 JOIN test24 ON test23.id = test24.id" [
-    attr' ~nullability:Nullable "id1" Int;
-    attr' ~nullability:Nullable "id2" Int;
+    attr' ~nullability:Strict "id1" Int;
+    attr' ~nullability:Strict "id2" Int;
   ] [];
   tt "SELECT test23.id, test24.id FROM test23 JOIN test24 ON test23.id = test24.id GROUP BY test23.id" [
-    attr' ~nullability:Nullable "id" Int;
-    attr' ~nullability:Nullable "id" Int;
+    attr' ~nullability:Strict "id" Int;
+    attr' ~nullability:Strict "id" Int;
   ][];
   wrong "SELECT COUNT(id) FROM test23 JOIN test24 ON test23.id = test24.id";
   wrong "SELECT COUNT(id) as id FROM test23 JOIN test24 ON test23.id = test24.id";
   wrong "SELECT id FROM test23 JOIN test24 ON test23.id = test24.id WHERE id > 2";
   tt "SELECT test23.id AS test_id, test24.id AS other_id FROM test23 JOIN test24 ON test23.id = test24.id" [
-    attr' ~nullability:Nullable "test_id" Int;
-    attr' ~nullability:Nullable "other_id" Int;
+    attr' ~nullability:Strict "test_id" Int;
+    attr' ~nullability:Strict "other_id" Int;
   ] [];
   tt "SELECT COUNT(test23.id) AS count_id FROM test23 JOIN test24 ON test23.id = test24.id" [
     attr' "count_id" Int;
@@ -768,7 +783,7 @@ let test_ambiguous = [
     JOIN test28 t2 ON t1.id = t2.id
     JOIN test29 t3 ON t1.id = t3.id
   |}[
-    attr' ~nullability:Nullable "id_from_test27" Int;
+    attr' ~nullability:Strict "id_from_test27" Int;
     attr' ~nullability:Nullable "value_from_test28" Int;
     attr' ~nullability:Nullable "value_from_test29" Int;
   ][];
@@ -1101,6 +1116,21 @@ let test_add_with_window_function = [
   tt {| SELECT MIN(1) OVER() WHERE FALSE |} [attr' "" Int;] [];
   tt {| SELECT MAX(1) OVER() WHERE FALSE |} [attr' "" Int;] [];
   tt {| SELECT MAX(NULL) OVER() |} [attr' ~nullability:Nullable "" Any;] [];
+
+  (* A frame that never reaches the current row is empty on the rows at that edge *)
+  tt "CREATE TABLE win_frame (a INT, b INT)" [] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' "w" Int] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b ROWS UNBOUNDED PRECEDING) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' "w" Int] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' "w" Int] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' ~nullability:Nullable "w" Int] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' ~nullability:Nullable "w" Int] [];
+  tt {| SELECT SUM(a) OVER (ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS w FROM win_frame WHERE a IS NOT NULL |}
+     [attr' ~nullability:Nullable "w" Int] [];
 
   (* Same but with PARTITION BY and ORDER BY *)
   tt {| SELECT SUM(1) OVER(PARTITION BY COALESCE(NULL, 'a')) |} [attr' "" Int;] [];
@@ -2636,6 +2666,7 @@ let test_cardinality =
   let z = [attr' ~nullability:Nullable "z" ~extra:[Constraint.make_composite_unique ["z"; "a"]] Int] in
   let a = [attr' ~nullability:Nullable "a" ~extra:[Constraint.make_composite_unique ["z"; "a"]] Int] in
   let b = [attr' ~nullability:Nullable "b" Int] in
+  let refined = List.map (fun a -> Sql.{ a with domain = Type.make_strict a.domain }) in
   [
   tt "CREATE TABLE test_cardinality (x INT PRIMARY KEY, y INT, z INT, a INT, b INT, UNIQUE(y), UNIQUE(z, a))" [] [];
   tt "select x from test_cardinality where true" x [] ~kind:(Select `Nat);
@@ -2663,49 +2694,49 @@ let test_cardinality =
   tt "select x from test_cardinality where x = 1 and x = 2 and x = 3" x [] ~kind:(Select `Zero_one);
   tt "select x from test_cardinality where x = 1 and x = 2 and x = 3 and x = 4" x [] ~kind:(Select `Zero_one);
   tt "select x from test_cardinality where x = 1 and x = 2 and x = 3 and x = 4 and x = 5" x [] ~kind:(Select `Zero_one);
-  tt "select y from test_cardinality where y = 1" y [] ~kind:(Select `Zero_one);
-  tt "select y from test_cardinality where y != 1" y [] ~kind:(Select `Nat);
-  tt "select z from test_cardinality where z = 1" z [] ~kind:(Select `Nat);
-  tt "select z from test_cardinality where z != 1" z [] ~kind:(Select `Nat);
+  tt "select y from test_cardinality where y = 1" (refined y) [] ~kind:(Select `Zero_one);
+  tt "select y from test_cardinality where y != 1" (refined y) [] ~kind:(Select `Nat);
+  tt "select z from test_cardinality where z = 1" (refined z) [] ~kind:(Select `Nat);
+  tt "select z from test_cardinality where z != 1" (refined z) [] ~kind:(Select `Nat);
   tt "select x from test_cardinality where x = 1 limit 1" x [] ~kind:(Select `Zero_one);
-  tt "select y from test_cardinality where y = 1 limit 1" y [] ~kind:(Select `Zero_one);
-  tt "select z from test_cardinality where z = 1 limit 1" z [] ~kind:(Select `Zero_one);
+  tt "select y from test_cardinality where y = 1 limit 1" (refined y) [] ~kind:(Select `Zero_one);
+  tt "select z from test_cardinality where z = 1 limit 1" (refined z) [] ~kind:(Select `Zero_one);
   tt "select x from test_cardinality where x = 1 limit 2" x [] ~kind:(Select `Zero_one);
-  tt "select y from test_cardinality where y = 1 limit 2" y [] ~kind:(Select `Zero_one);
-  tt "select z from test_cardinality where z = 1 limit 2" z [] ~kind:(Select `Nat);
+  tt "select y from test_cardinality where y = 1 limit 2" (refined y) [] ~kind:(Select `Zero_one);
+  tt "select z from test_cardinality where z = 1 limit 2" (refined z) [] ~kind:(Select `Nat);
   tt "select x,y from test_cardinality where x = 1" (x @ y) [] ~kind:(Select `Zero_one);
   tt "select x,y from test_cardinality where x = 1 limit 1" (x @ y) [] ~kind:(Select `Zero_one);
   tt "select x,y from test_cardinality where x = 1 limit 2" (x @ y) [] ~kind:(Select `Zero_one);
   tt "select x,z from test_cardinality where x = 1" (x @ z) [] ~kind:(Select `Zero_one);
   tt "select x,z from test_cardinality where x = 1 limit 1" (x @ z) [] ~kind:(Select `Zero_one);
   tt "select x,z from test_cardinality where x = 1 limit 2" (x @ z) [] ~kind:(Select `Zero_one);
-  tt "select x,z from test_cardinality where z = 1" (x @ z) [] ~kind:(Select `Nat);
-  tt "select x,z from test_cardinality where z = 1 limit 1" (x @ z) [] ~kind:(Select `Zero_one);
-  tt "select x,z from test_cardinality where z = 1 limit 2" (x @ z) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where z = 1 and a = 1" (z @ a) [] ~kind:(Select `Zero_one);
-  tt "select z,a from test_cardinality where z = 1 and not (a = 1)" (z @ a) [] ~kind:(Select `Nat);
+  tt "select x,z from test_cardinality where z = 1" (x @ refined z) [] ~kind:(Select `Nat);
+  tt "select x,z from test_cardinality where z = 1 limit 1" (x @ refined z) [] ~kind:(Select `Zero_one);
+  tt "select x,z from test_cardinality where z = 1 limit 2" (x @ refined z) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where z = 1 and a = 1" (refined z @ refined a) [] ~kind:(Select `Zero_one);
+  tt "select z,a from test_cardinality where z = 1 and not (a = 1)" (refined z @ refined a) [] ~kind:(Select `Nat);
   tt "select z,a from test_cardinality where not (z = 1 and a = 1)" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where not (z = 1) and a = 1" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where not not (a = 1)" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where z = 1 and a != 1" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where z != 1 and a = 1" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where (z = 1) and (a = 1)" (z @ a) [] ~kind:(Select `Zero_one);
-  tt "select z,a from test_cardinality where z = 1 and a = 1 limit 1" (z @ a) [] ~kind:(Select `Zero_one);
-  tt "select z,a from test_cardinality where z = 1 and a = 1 limit 2" (z @ a) [] ~kind:(Select `Zero_one);
-  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1" (z @ a @ b) [] ~kind:(Select `Zero_one);
-  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1 limit 1" (z @ a @ b) [] ~kind:(Select `Zero_one);
-  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1 limit 2" (z @ a @ b) [] ~kind:(Select `Zero_one);
-  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and not b = 1" (z @ a @ b) [] ~kind:(Select `Zero_one);
-  tt "select z,a from test_cardinality where z = 1" (z @ a) [] ~kind:(Select `Nat);
-  tt "select z,a from test_cardinality where z = 1 limit 1" (z @ a) [] ~kind:(Select `Zero_one);
-  tt "select z,a from test_cardinality where z = 1 limit 2" (z @ a) [] ~kind:(Select `Nat);
-  tt "select a,b from test_cardinality where a = 1 and b = 1" (a @ b) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where not (z = 1) and a = 1" (refined z @ refined a) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where not not (a = 1)" (z @ refined a) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where z = 1 and a != 1" (refined z @ refined a) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where z != 1 and a = 1" (refined z @ refined a) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where (z = 1) and (a = 1)" (refined z @ refined a) [] ~kind:(Select `Zero_one);
+  tt "select z,a from test_cardinality where z = 1 and a = 1 limit 1" (refined z @ refined a) [] ~kind:(Select `Zero_one);
+  tt "select z,a from test_cardinality where z = 1 and a = 1 limit 2" (refined z @ refined a) [] ~kind:(Select `Zero_one);
+  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1" (refined z @ refined a @ refined b) [] ~kind:(Select `Zero_one);
+  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1 limit 1" (refined z @ refined a @ refined b) [] ~kind:(Select `Zero_one);
+  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and b = 1 limit 2" (refined z @ refined a @ refined b) [] ~kind:(Select `Zero_one);
+  tt "select z,a,b from test_cardinality where z = 1 and a = 1 and not b = 1" (refined z @ refined a @ refined b) [] ~kind:(Select `Zero_one);
+  tt "select z,a from test_cardinality where z = 1" (refined z @ a) [] ~kind:(Select `Nat);
+  tt "select z,a from test_cardinality where z = 1 limit 1" (refined z @ a) [] ~kind:(Select `Zero_one);
+  tt "select z,a from test_cardinality where z = 1 limit 2" (refined z @ a) [] ~kind:(Select `Nat);
+  tt "select a,b from test_cardinality where a = 1 and b = 1" (refined a @ refined b) [] ~kind:(Select `Nat);
 ]
 
 let test_cardinality_optimization_validity = 
   let x = [attr' ~nullability:Strict "x" ~extra:[PrimaryKey] Int] in
   let id = [attr' ~nullability:Nullable "id" Int] in
-  let one_x = [attr' ~nullability:Nullable "one_x" Int] in
+  let one_x = [attr' ~nullability:Strict "one_x" Int] in
   [
   tt "CREATE TABLE tc2_1 (x INT PRIMARY KEY)" [] [];
   tt "CREATE TABLE tc2_2 (id INT, one_x INT, FOREIGN KEY (one_x) REFERENCES tc2_1(x))" [] [];
@@ -2715,6 +2746,71 @@ let test_cardinality_optimization_validity =
   tt "select * from tc2_2 join tc2_1 on tc2_2.one_x = tc2_1.x where tc2_1.x = 1" (id @ one_x @ x) [] ~kind:(Select `Nat);
   (* below should return multiple rows -- tc2_1.x is a primary key, but joining on it allows multiple rows with it to be returned *)
   tt "select * from tc2_1 join tc2_2 on tc2_1.x = tc2_2.one_x where tc2_1.x = 1" (x @ id @ one_x) [] ~kind:(Select `Nat);
+]
+
+let test_nullability_narrowing =
+  let n name = attr' ~nullability:Nullable name Int in
+  let s name = attr' ~nullability:Strict name Int in
+  [
+  tt "CREATE TABLE narrow1 (a INT, b INT, c TEXT)" [] [];
+  tt "CREATE TABLE narrow2 (d INT, e INT)" [] [];
+
+  tt "SELECT a FROM narrow1 WHERE a = 5" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a > 5" [s "a"] [];
+  tt "SELECT a, b FROM narrow1 WHERE a > b" [s "a"; s "b"] [];
+  tt "SELECT a FROM narrow1 WHERE a <> 5" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE NOT (a = 5)" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE NOT NOT (a = 5)" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a = a" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a" [s "a"] [];
+
+  tt "SELECT a + 1 AS r FROM narrow1 WHERE a IS NOT NULL" [s "r"] [];
+  tt "SELECT a + b AS r FROM narrow1 WHERE a > 0 AND b > 0" [s "r"] [];
+  tt "SELECT a FROM narrow1 WHERE a + 1 = 5" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE (a + 1) IS NOT NULL" [s "a"] [];
+
+  tt "SELECT a FROM narrow1 WHERE CAST(a AS DECIMAL) = 1" [n "a"] [];
+  tt "SELECT c FROM narrow1 WHERE CONCAT(c, c) = 'x'" [attr' ~nullability:Nullable "c" Text] [];
+  tt "SELECT c FROM narrow1 WHERE CONCAT_WS(',', c, c) = 'x'" [attr' ~nullability:Nullable "c" Text] [];
+  tt "SELECT a, b FROM narrow1 WHERE IF(a = 1, b = 2, b = 2)" [n "a"; n "b"] [];
+
+  tt "SELECT a, b FROM narrow1 WHERE a = 1 AND b = 2" [s "a"; s "b"] [];
+  tt "SELECT a, b FROM narrow1 WHERE a = 1 OR b = 2" [n "a"; n "b"] [];
+  tt "SELECT a FROM narrow1 WHERE a = 1 OR a = 2" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a IS NULL OR a > 3" [n "a"] [];
+  tt "SELECT a, b FROM narrow1 WHERE NOT (a = 1 AND b = 2)" [n "a"; n "b"] [];
+
+  tt "SELECT a FROM narrow1 WHERE a <=> 5" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE COALESCE(a, 0) = 1" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE COALESCE(a, a) = 1" [s "a"] [];
+
+  tt "SELECT a FROM narrow1 WHERE a IN (1, 2)" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a NOT IN (1, 2)" [s "a"] [];
+  (* an empty subquery makes IN false and NOT IN true even for a NULL left operand, and the
+     grammar drops the NOT, so membership in a subquery must not narrow at all *)
+  tt "SELECT a FROM narrow1 WHERE a IN (SELECT d FROM narrow2)" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a NOT IN (SELECT d FROM narrow2)" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE NOT (a IN (SELECT d FROM narrow2))" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a = ANY (SELECT d FROM narrow2)" [s "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a > ANY (SELECT d FROM narrow2)" [s "a"] [];
+  (* <=> is null-safe, so it narrows nothing even under ANY *)
+  tt "SELECT a FROM narrow1 WHERE a <=> ANY (SELECT d FROM narrow2)" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a = ALL (SELECT d FROM narrow2)" [n "a"] [];
+  tt "SELECT a FROM narrow1 WHERE a BETWEEN 1 AND 2" [s "a"] [];
+  tt "SELECT a, b FROM narrow1 WHERE a IN (b, 1)" [s "a"; n "b"] [];
+  tt "SELECT a, b FROM narrow1 WHERE a BETWEEN b AND 1" [s "a"; n "b"] [];
+
+  tt "SELECT a, b FROM narrow1 WHERE CASE WHEN a = 1 THEN b = 2 END" [s "a"; s "b"] [];
+  tt "SELECT a, b FROM narrow1 WHERE CASE WHEN a = 1 THEN b = 2 ELSE b = 3 END" [n "a"; s "b"] [];
+  tt "SELECT a, b FROM narrow1 WHERE CASE WHEN a = 1 THEN b = 2 ELSE a = 3 END" [s "a"; n "b"] [];
+
+  tt "SELECT a, d FROM narrow1 JOIN narrow2 ON a = d" [s "a"; s "d"] [];
+  tt "SELECT a, d FROM narrow1 LEFT JOIN narrow2 ON a = d" [n "a"; n "d"] [];
+  tt "SELECT a, d FROM narrow1 RIGHT JOIN narrow2 ON a = d" [n "a"; n "d"] [];
+  tt "SELECT a FROM narrow1 JOIN narrow2 ON a = d RIGHT JOIN narrow2 x2 ON a = x2.e" [n "a"] [];
+
+  tt "SELECT a, b FROM narrow1 GROUP BY a HAVING a > 1" [s "a"; n "b"] [];
+  tt "SELECT a, b FROM narrow1 GROUP BY a HAVING b > 1" [n "a"; n "b"] [];
 ]
 
 let test_nullability_rules = [
@@ -2762,7 +2858,7 @@ let test_fn_group_by_arg = [
     GROUP BY t1.table_no
     ORDER BY dates_from_t1; 
   |} [
-    attr' ~nullability:Nullable "table_no" Int;
+    attr' ~nullability:Strict "table_no" Int;
     attr' ~nullability:Nullable "dates_from_t1" Text;
     attr' ~nullability:Strict "dates_from_t1_strict" Text;
     attr' ~nullability:Nullable "dates_from_t2" Text;
@@ -2784,7 +2880,7 @@ let test_fn_group_by_arg = [
   GROUP BY t1.table_no
   ORDER BY dates_from_t1;
   |} [
-    attr' ~nullability:Nullable "table_no" Int;
+    attr' ~nullability:Strict "table_no" Int;
     attr' ~nullability:Nullable "dates_from_t1" Text;
     attr' ~nullability:Nullable "dates_from_t2" Text;
   ] [];
@@ -2810,7 +2906,7 @@ let test_fn_group_by_arg = [
     WHERE t1.table_no > @delta
     GROUP BY t1.table_no
   |} [
-    attr' ~nullability:Nullable "table_no" Int;
+    attr' ~nullability:Strict "table_no" Int;
     attr' ~nullability:Nullable "dates_from_t1" Text;
   ] [
     named "delta" Int;
@@ -2955,6 +3051,7 @@ let run () =
     "test_cardinality" >::: test_cardinality;
     "test_cardinality_optimization_validity" >::: test_cardinality_optimization_validity;
     "test_nullability_rules" >::: test_nullability_rules;
+    "test_nullability_narrowing" >::: test_nullability_narrowing;
     "test_fn_group_by_arg" >::: test_fn_group_by_arg;
     "test_join_hole_whitespace" >::: test_join_hole_whitespace;
     "migration name" >::: test_migration_name;
@@ -2963,3 +3060,4 @@ let run () =
 let test_suite = "main" >::: tests in
   let results = run_test_tt test_suite in
   exit @@ if List.exists (function RFailure _ | RError _ -> true | _ -> false) results then 1 else 0
+

--- a/test/cram/dynamic_subquery.t
+++ b/test/cram/dynamic_subquery.t
@@ -40,7 +40,7 @@ Full generated code:
         let price : _ t =
           {
             set = (fun _p -> ());
-            read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+            read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
             column = ("price");
             count = 0;
             deps = [];

--- a/test/cram/not_null_refine.compare.ml
+++ b/test/cram/not_null_refine.compare.ml
@@ -148,7 +148,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (\n\
   id INT NOT NULL,\n\
   name TEXT NULL,\n\
-  descr TEXT NULL\n\
+  descr TEXT NULL,\n\
+  num INT NULL,\n\
+  num2 INT NULL\n\
 )") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
 
   let static_not_null db  callback =
@@ -158,6 +160,112 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
+  let optional_guard_stays_nullable db ~name callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text_nullable stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match name with Some _ -> 1 | None -> 0)) in
+      begin match name with
+      | None -> ()
+      | Some name ->
+        T.set_param_Text p name;
+      end;
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match name with Some _ -> " ( " ^ "name = " ^ "?" ^ " ) " | None -> " TRUE ")) ~name:"optional_guard_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let in_param_is_strict db ~names callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"in_param_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let not_in_param_stays_nullable db ~names callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text_nullable stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "TRUE" | _ :: _ -> "name NOT IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"not_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let negated_in_param_stays_nullable db ~names callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text_nullable stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE NOT (" ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")") ^ ")") ~name:"negated_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let in_tuple_list_is_strict db ~pairs callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text stmt 0)
+        ~descr:(T.get_column_Text stmt 1)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "FALSE" | _ :: _ -> "(name, descr) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"in_tuple_list_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let not_in_tuple_list_stays_nullable db ~pairs callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text_nullable stmt 0)
+        ~descr:(T.get_column_Text_nullable stmt 1)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "TRUE" | _ :: _ -> "(name, descr) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"not_in_tuple_list_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let in_subquery_stays_nullable db  callback =
+    let invoke_callback stmt =
+      callback
+        ~name:(T.get_column_Text_nullable stmt 0)
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IN (SELECT descr FROM items)") ~name:"in_subquery_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
+
+  let between_params_are_strict db ~lo ~hi callback =
+    let invoke_callback stmt =
+      callback
+        ~num:(T.get_column_Int stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (2) in
+      T.set_param_Int p lo;
+      T.set_param_Int p hi;
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num FROM items WHERE num BETWEEN ? AND ?") ~name:"between_params_are_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let between_bound_columns_stay_nullable db ~hi callback =
+    let invoke_callback stmt =
+      callback
+        ~num:(T.get_column_Int stmt 0)
+        ~num2:(T.get_column_Int_nullable stmt 1)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (1) in
+      begin match hi with None -> T.set_param_null p | Some v -> T.set_param_Int p v end;
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num, num2 FROM items WHERE num BETWEEN num2 AND ?") ~name:"between_bound_columns_stay_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
   module Fold = struct
     let static_not_null db  callback acc =
       let invoke_callback stmt =
@@ -166,6 +274,130 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       in
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let optional_guard_stays_nullable db ~name callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match name with Some _ -> 1 | None -> 0)) in
+        begin match name with
+        | None -> ()
+        | Some name ->
+          T.set_param_Text p name;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match name with Some _ -> " ( " ^ "name = " ^ "?" ^ " ) " | None -> " TRUE ")) ~name:"optional_guard_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let in_param_is_strict db ~names callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"in_param_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let not_in_param_stays_nullable db ~names callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "TRUE" | _ :: _ -> "name NOT IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"not_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let negated_in_param_stays_nullable db ~names callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE NOT (" ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")") ^ ")") ~name:"negated_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let in_tuple_list_is_strict db ~pairs callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text stmt 0)
+          ~descr:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "FALSE" | _ :: _ -> "(name, descr) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"in_tuple_list_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let not_in_tuple_list_stays_nullable db ~pairs callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+          ~descr:(T.get_column_Text_nullable stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "TRUE" | _ :: _ -> "(name, descr) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"not_in_tuple_list_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let in_subquery_stays_nullable db  callback acc =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IN (SELECT descr FROM items)") ~name:"in_subquery_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let between_params_are_strict db ~lo ~hi callback acc =
+      let invoke_callback stmt =
+        callback
+          ~num:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_Int p lo;
+        T.set_param_Int p hi;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num FROM items WHERE num BETWEEN ? AND ?") ~name:"between_params_are_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let between_bound_columns_stay_nullable db ~hi callback acc =
+      let invoke_callback stmt =
+        callback
+          ~num:(T.get_column_Int stmt 0)
+          ~num2:(T.get_column_Int_nullable stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        begin match hi with None -> T.set_param_null p | Some v -> T.set_param_Int p v end;
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num, num2 FROM items WHERE num BETWEEN num2 AND ?") ~name:"between_bound_columns_stay_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -178,6 +410,130 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       in
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let optional_guard_stays_nullable db ~name callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match name with Some _ -> 1 | None -> 0)) in
+        begin match name with
+        | None -> ()
+        | Some name ->
+          T.set_param_Text p name;
+        end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match name with Some _ -> " ( " ^ "name = " ^ "?" ^ " ) " | None -> " TRUE ")) ~name:"optional_guard_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let in_param_is_strict db ~names callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"in_param_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let not_in_param_stays_nullable db ~names callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE " ^ (match names with [] -> "TRUE" | _ :: _ -> "name NOT IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"not_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let negated_in_param_stays_nullable db ~names callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE NOT (" ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")") ^ ")") ~name:"negated_in_param_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let in_tuple_list_is_strict db ~pairs callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text stmt 0)
+          ~descr:(T.get_column_Text stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "FALSE" | _ :: _ -> "(name, descr) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"in_tuple_list_is_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let not_in_tuple_list_stays_nullable db ~pairs callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+          ~descr:(T.get_column_Text_nullable stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name, descr FROM items WHERE " ^ (match pairs with [] -> "TRUE" | _ :: _ -> "(name, descr) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ~name:"not_in_tuple_list_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let in_subquery_stays_nullable db  callback =
+      let invoke_callback stmt =
+        callback
+          ~name:(T.get_column_Text_nullable stmt 0)
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IN (SELECT descr FROM items)") ~name:"in_subquery_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let between_params_are_strict db ~lo ~hi callback =
+      let invoke_callback stmt =
+        callback
+          ~num:(T.get_column_Int stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (2) in
+        T.set_param_Int p lo;
+        T.set_param_Int p hi;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num FROM items WHERE num BETWEEN ? AND ?") ~name:"between_params_are_strict" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let between_bound_columns_stay_nullable db ~hi callback =
+      let invoke_callback stmt =
+        callback
+          ~num:(T.get_column_Int stmt 0)
+          ~num2:(T.get_column_Int_nullable stmt 1)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (1) in
+        begin match hi with None -> T.set_param_null p | Some v -> T.set_param_Int p v end;
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT num, num2 FROM items WHERE num BETWEEN num2 AND ?") ~name:"between_bound_columns_stay_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/not_null_refine.sql
+++ b/test/cram/not_null_refine.sql
@@ -1,7 +1,9 @@
 CREATE TABLE items (
   id INT NOT NULL,
   name TEXT NULL,
-  descr TEXT NULL
+  descr TEXT NULL,
+  num INT NULL,
+  num2 INT NULL
 );
 
 -- @static_not_null
@@ -14,3 +16,30 @@ SELECT name, descr FROM items WHERE name IS NOT NULL AND descr IS NOT NULL;
 -- [sqlgg] dynamic_select=true
 -- @dynamic_or_stays_nullable
 SELECT name, descr FROM items WHERE name IS NOT NULL OR descr IS NOT NULL;
+
+-- @optional_guard_stays_nullable
+SELECT name FROM items WHERE {name = @name}?;
+
+-- @in_param_is_strict
+SELECT name FROM items WHERE name IN @names;
+
+-- @not_in_param_stays_nullable
+SELECT name FROM items WHERE name NOT IN @names;
+
+-- @negated_in_param_stays_nullable
+SELECT name FROM items WHERE NOT (name IN @names);
+
+-- @in_tuple_list_is_strict
+SELECT name, descr FROM items WHERE (name, descr) IN @pairs;
+
+-- @not_in_tuple_list_stays_nullable
+SELECT name, descr FROM items WHERE (name, descr) NOT IN @pairs;
+
+-- @in_subquery_stays_nullable
+SELECT name FROM items WHERE name IN (SELECT descr FROM items);
+
+-- @between_params_are_strict
+SELECT num FROM items WHERE num BETWEEN @lo AND @hi;
+
+-- @between_bound_columns_stay_nullable
+SELECT num, num2 FROM items WHERE num BETWEEN num2 AND @hi;

--- a/test/cram/reusable_queries_as_ctes.compare.ml
+++ b/test/cram/reusable_queries_as_ctes.compare.ml
@@ -72,7 +72,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invo
       callback
         ~id:(T.get_column_Int stmt 0)
         ~name:(T.get_column_Text stmt 1)
-        ~category_id:(T.get_column_Int_nullable stmt 2)
+        ~category_id:(T.get_column_Int stmt 2)
         ~category_name:(T.get_column_Text stmt 3)
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("WITH inner_cte AS (\n\
@@ -89,7 +89,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
       callback
         ~id:(T.get_column_Int stmt 0)
         ~name:(T.get_column_Text stmt 1)
-        ~category_id:(T.get_column_Int_nullable stmt 2)
+        ~category_id:(T.get_column_Int stmt 2)
         ~category_name:(T.get_column_Text stmt 3)
     in
     let set_params stmt =
@@ -166,7 +166,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun
         callback
           ~id:(T.get_column_Int stmt 0)
           ~name:(T.get_column_Text stmt 1)
-          ~category_id:(T.get_column_Int_nullable stmt 2)
+          ~category_id:(T.get_column_Int stmt 2)
           ~category_name:(T.get_column_Text stmt 3)
       in
       let r_acc = ref acc in
@@ -185,7 +185,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
         callback
           ~id:(T.get_column_Int stmt 0)
           ~name:(T.get_column_Text stmt 1)
-          ~category_id:(T.get_column_Int_nullable stmt 2)
+          ~category_id:(T.get_column_Int stmt 2)
           ~category_name:(T.get_column_Text stmt 3)
       in
       let set_params stmt =
@@ -266,7 +266,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun
         callback
           ~id:(T.get_column_Int stmt 0)
           ~name:(T.get_column_Text stmt 1)
-          ~category_id:(T.get_column_Int_nullable stmt 2)
+          ~category_id:(T.get_column_Int stmt 2)
           ~category_name:(T.get_column_Text stmt 3)
       in
       let r_acc = ref [] in
@@ -285,7 +285,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
         callback
           ~id:(T.get_column_Int stmt 0)
           ~name:(T.get_column_Text stmt 1)
-          ~category_id:(T.get_column_Int_nullable stmt 2)
+          ~category_id:(T.get_column_Int stmt 2)
           ~category_name:(T.get_column_Text stmt 3)
       in
       let set_params stmt =

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -1483,7 +1483,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
     let select_2 db ~order_kind ~par callback =
       let invoke_callback stmt =
         callback
-          ~table_no:(T.get_column_Int_nullable stmt 0)
+          ~table_no:(T.get_column_Int stmt 0)
           ~dates_from_t1:(T.get_column_Text_nullable stmt 1)
           ~dates_from_t2:(T.get_column_Text_nullable stmt 2)
           ~dates_from_t2_2:(T.get_column_Text_nullable stmt 3)
@@ -1516,7 +1516,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
       let select_2 db ~order_kind ~par callback acc =
         let invoke_callback stmt =
           callback
-            ~table_no:(T.get_column_Int_nullable stmt 0)
+            ~table_no:(T.get_column_Int stmt 0)
             ~dates_from_t1:(T.get_column_Text_nullable stmt 1)
             ~dates_from_t2:(T.get_column_Text_nullable stmt 2)
             ~dates_from_t2_2:(T.get_column_Text_nullable stmt 3)
@@ -1553,7 +1553,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
       let select_2 db ~order_kind ~par callback =
         let invoke_callback stmt =
           callback
-            ~table_no:(T.get_column_Int_nullable stmt 0)
+            ~table_no:(T.get_column_Int stmt 0)
             ~dates_from_t1:(T.get_column_Text_nullable stmt 1)
             ~dates_from_t2:(T.get_column_Text_nullable stmt 2)
             ~dates_from_t2_2:(T.get_column_Text_nullable stmt 3)
@@ -2457,7 +2457,7 @@ Test decimal to float - allowed:
   > SELECT * FROM items WHERE price_float = price;
   > EOF
   Failed : SELECT * FROM items WHERE price_float = price
-  Fatal error: exception Failure("types Float? and Decimal(10,2)? for 'a do not match in 'a -> 'a -> Bool?? applied to (Float?, Decimal(10,2)?)")
+  Fatal error: exception Failure("types Float and Decimal(10,2) for 'a do not match in 'a -> 'a -> Bool?? applied to (Float, Decimal(10,2))")
   [2]
 
 Test decimal to float - allowed:
@@ -2476,7 +2476,7 @@ Test decimal to float - allowed:
       let invoke_callback stmt =
         callback
           ~price:(T.get_column_Decimal_nullable stmt 0)
-          ~price_float:(T.get_column_Float_nullable stmt 1)
+          ~price_float:(T.get_column_Float stmt 1)
       in
       T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
@@ -2485,7 +2485,7 @@ Test decimal to float - allowed:
         let invoke_callback stmt =
           callback
             ~price:(T.get_column_Decimal_nullable stmt 0)
-            ~price_float:(T.get_column_Float_nullable stmt 1)
+            ~price_float:(T.get_column_Float stmt 1)
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
@@ -2498,7 +2498,7 @@ Test decimal to float - allowed:
         let invoke_callback stmt =
           callback
             ~price:(T.get_column_Decimal_nullable stmt 0)
-            ~price_float:(T.get_column_Float_nullable stmt 1)
+            ~price_float:(T.get_column_Float stmt 1)
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))

--- a/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
@@ -173,7 +173,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let bio : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("p.bio");
           count = 0;
           deps = [];

--- a/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
@@ -290,7 +290,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let label : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("b.label");
           count = 0;
           deps = [];

--- a/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
@@ -238,7 +238,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let bio : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("p.bio");
           count = 0;
           deps = [];
@@ -321,7 +321,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let bio : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("p.bio");
           count = 0;
           deps = [];
@@ -396,7 +396,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("u.id");
           count = 0;
           deps = [];

--- a/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
@@ -374,7 +374,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let bio : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("p.bio");
           count = 0;
           deps = [];

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -2189,7 +2189,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
         let id : _ t =
           {
             set = (fun _p -> ());
-            read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+            read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
             column = ("id");
             count = 0;
             deps = [];
@@ -2388,7 +2388,7 @@ Virtual select: mixed columns and params without spaces after commas:
         let id : _ t =
           {
             set = (fun _p -> ());
-            read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+            read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
             column = ("id");
             count = 0;
             deps = [];
@@ -2787,7 +2787,7 @@ Virtual select: arithmetic with param at expression start:
         let id : _ t =
           {
             set = (fun _p -> ());
-            read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+            read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
             column = ("id");
             count = 0;
             deps = [];

--- a/test/cram/test_dynamic_select/test_run.ml
+++ b/test/cram/test_dynamic_select/test_run.ml
@@ -527,7 +527,7 @@ module M (T: Sqlgg_traits.M with
       ));
       let combined =
         let+ i = id
-        and+ p = pairs [ (1L, Some 10L) ] in
+        and+ p = pairs [ (1L, 10L) ] in
         (i, p)
       in
       let _ = select connection combined ~id:1L in
@@ -599,7 +599,7 @@ module M (T: Sqlgg_traits.M with
           Print_ocaml_impl.mock_int 42L
         ]
       ));
-      let col = monster 2L 1L "then_v" "else_v" (Some 10.0) ["a"; "b"] [(1L, Some 10L)] in
+      let col = monster 2L 1L "then_v" "else_v" (Some 10.0) ["a"; "b"] [(1L, 10L)] in
       let _ = select connection col ~id:1L in
       printf "[TEST 17.1] Completed\n\n"
 
@@ -614,7 +614,7 @@ module M (T: Sqlgg_traits.M with
       ));
       let combined =
         let+ i = id
-        and+ m = monster 2L 1L "then_v" "else_v" (Some 10.0) ["a"; "b"] [(1L, Some 10L)] in
+        and+ m = monster 2L 1L "then_v" "else_v" (Some 10.0) ["a"; "b"] [(1L, 10L)] in
         (i, m)
       in
       let _ = select connection combined ~id:1L in
@@ -693,7 +693,7 @@ module M (T: Sqlgg_traits.M with
         and+ il = with_in_list [1L; 2L]
         and+ wo = with_optional (Some 5L)
         and+ wc = with_case 1L ["foo"]
-        and+ wt = with_tuple_list [(1L, Some 10L)]
+        and+ wt = with_tuple_list [(1L, 10L)]
         and+ fc = full_combo (Some 5L) ["x"] 100.0 in
         (i, p, il, wo, wc, wt, fc)
       in

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -8,7 +8,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("id");
           count = 0;
           deps = [];
@@ -16,7 +16,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let name : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("name");
           count = 0;
           deps = [];
@@ -82,6 +82,77 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let id : _ t =
         {
           set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
+          column = ("id");
+          count = 0;
+          deps = [];
+        }
+      let name : _ t =
+        {
+          set = (fun _p -> ());
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
+          column = ("name");
+          count = 0;
+          deps = [];
+        }
+    end
+    include Cols
+    let cols = object
+      method id = Cols.id
+      method name = Cols.name
+    end
+
+    let select db (col : _ t) ~pairs callback =
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+        col.set p;
+        T.finish_params p
+      in
+      T.select db
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+      set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col)
+
+    module Fold = struct
+      let select db (col : _ t) ~pairs callback acc =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref acc in
+        IO.(>>=) (T.select db
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
+          __sqlgg_r_col !r_acc)))
+        (fun () -> IO.return !r_acc)
+
+    end (* module Fold *)
+
+    module List = struct
+      let select db (col : _ t) ~pairs =
+        let set_params stmt =
+          let p = T.start_params stmt (0 + (match pairs with [] -> 0 | _ :: _ -> 0) + col.count) in
+          col.set p;
+          T.finish_params p
+        in
+        let r_acc = ref [] in
+        IO.(>>=) (T.select db
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+        set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
+        (fun () -> IO.return (List.rev !r_acc))
+
+    end (* module List *)
+
+  end
+
+  module Tuple_list_not_in = struct
+    type brand
+    include Sqlgg_scope.Make (struct type nonrec brand = brand type row = T.row type params = T.params end)
+    module Cols = struct
+      let id : _ t =
+        {
+          set = (fun _p -> ());
           read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
           column = ("id");
           count = 0;
@@ -109,7 +180,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "TRUE" | _ :: _ -> "(id, name) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list_not_in" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +193,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "TRUE" | _ :: _ -> "(id, name) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list_not_in" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +209,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "TRUE" | _ :: _ -> "(id, name) NOT IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list_not_in" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -574,7 +645,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("id");
           count = 0;
           deps = [];
@@ -582,7 +653,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
       let name : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("name");
           count = 0;
           deps = [];
@@ -618,7 +689,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
-  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
@@ -652,7 +723,7 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"k
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
-  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
@@ -689,7 +760,7 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"k
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ "\n\
-  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
+  AND " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")")) ^ "\n\
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\

--- a/test/cram/test_dynamic_select_compose/compose.sql
+++ b/test/cram/test_dynamic_select_compose/compose.sql
@@ -12,6 +12,10 @@ SELECT id, name FROM t WHERE id IN @ids AND name = @nm;
 SELECT id, name FROM t WHERE (id, name) IN @pairs;
 
 -- [sqlgg] dynamic_select=true
+-- @tuple_list_not_in
+SELECT id, name FROM t WHERE (id, name) NOT IN @pairs;
+
+-- [sqlgg] dynamic_select=true
 -- @opt_filter
 SELECT id, name FROM t WHERE { id = @v }?;
 

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -8,7 +8,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("id");
           count = 0;
           deps = [];
@@ -88,7 +88,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:S
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("id");
           count = 0;
           deps = [];
@@ -96,7 +96,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:S
       let name : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("name");
           count = 0;
           deps = [];
@@ -257,7 +257,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
       let id : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("id");
           count = 0;
           deps = [];
@@ -265,7 +265,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
       let name : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Text_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Text row idx, idx + 1));
           column = ("name");
           count = 0;
           deps = [];
@@ -290,7 +290,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -309,7 +309,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -331,7 +331,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal pairs_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal pairs_1n); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -465,12 +465,12 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         }
       let is_new cutoff : _ t =
         let _set_is_new p =
-          begin match cutoff with None -> T.set_param_null p | Some v -> T.set_param_Int p v end;
+          T.set_param_Int p cutoff;
           ()
         in
         {
           set = _set_is_new;
-          read = (fun row idx -> (T.get_column_Bool_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Bool row idx, idx + 1));
           column = ("(status >= " ^ "?" ^ ")");
           count = 1;
           deps = [];

--- a/test/cram/test_dynamic_select_compose/run.ml
+++ b/test/cram/test_dynamic_select_compose/run.ml
@@ -20,8 +20,14 @@ let () =
 
   go "tuple_list: empty pairs" (fun () ->
     C.Tuple_list.select db C.Tuple_list.id ~pairs:[] (fun _ -> ()));
-  go "tuple_list: two pairs with null" (fun () ->
-    C.Tuple_list.select db C.Tuple_list.id ~pairs:[(Some 1L, Some "a"); (None, Some "b")] (fun _ -> ()));
+  go "tuple_list: two pairs" (fun () ->
+    C.Tuple_list.select db C.Tuple_list.id ~pairs:[(1L, "a"); (2L, "b")] (fun _ -> ()));
+
+  go "tuple_list_not_in: empty pairs" (fun () ->
+    C.Tuple_list_not_in.select db C.Tuple_list_not_in.id ~pairs:[] (fun _ -> ()));
+  go "tuple_list_not_in: two pairs with null" (fun () ->
+    C.Tuple_list_not_in.select db C.Tuple_list_not_in.id
+      ~pairs:[(Some 1L, Some "a"); (None, Some "b")] (fun _ -> ()));
 
   go "opt_filter: none" (fun () ->
     C.Opt_filter.select db C.Opt_filter.name ~v:None (fun _ -> ()));
@@ -48,7 +54,7 @@ let () =
 
   go "kitchen_sink: everything on" (fun () ->
     C.Kitchen_sink.select db C.Kitchen_sink.name
-      ~ids:[1L; 2L] ~pairs:[(Some 1L, Some "a")] ~nm:(Some "x") ~f:(`ById 5L) ~sort:`N
+      ~ids:[1L; 2L] ~pairs:[(1L, "a")] ~nm:(Some "x") ~f:(`ById 5L) ~sort:`N
       (fun _ -> ()));
   go "kitchen_sink: everything off" (fun () ->
     C.Kitchen_sink.select db C.Kitchen_sink.name
@@ -71,7 +77,7 @@ let () =
   go "cte_opt_filter: none, empty pairs" (fun () ->
     W.Cte_opt_filter.select db ~st:None W.Cte_opt_filter.name ~pairs:[] (fun _ -> ()));
   go "cte_opt_filter: some, pairs" (fun () ->
-    W.Cte_opt_filter.select db ~st:(Some 1L) W.Cte_opt_filter.name ~pairs:[(Some 1L, Some "a")] (fun _ -> ()));
+    W.Cte_opt_filter.select db ~st:(Some 1L) W.Cte_opt_filter.name ~pairs:[(1L, "a")] (fun _ -> ()));
 
   go "cte_shared_choice: all" (fun () ->
     W.Cte_shared_choice.select db W.Cte_shared_choice.name ~f:`All (fun _ -> ()));
@@ -81,7 +87,7 @@ let () =
   go "cte_param_col: plain column" (fun () ->
     W.Cte_param_col.select db ~st:1L W.Cte_param_col.id (fun _ -> ()));
   go "cte_param_col: param inside picked column binds after cte param" (fun () ->
-    W.Cte_param_col.select db ~st:1L (W.Cte_param_col.is_new (Some 100L)) (fun _ -> ()));
+    W.Cte_param_col.select db ~st:1L (W.Cte_param_col.is_new 100L) (fun _ -> ()));
 
   go "where_subquery: empty names" (fun () ->
     W.Where_subquery.select db W.Where_subquery.name ~st:1L ~names:[] (fun _ -> ()));

--- a/test/cram/test_dynamic_select_compose/run.t
+++ b/test/cram/test_dynamic_select_compose/run.t
@@ -26,8 +26,14 @@ Run the generated code against the printing mock and check the final SQL strings
   -- tuple_list: empty pairs
   [SQL] SELECT id FROM t WHERE FALSE
   
-  -- tuple_list: two pairs with null
-  [SQL] SELECT id FROM t WHERE (id, name) IN ((1, 'a'), (NULL, 'b'))
+  -- tuple_list: two pairs
+  [SQL] SELECT id FROM t WHERE (id, name) IN ((1, 'a'), (2, 'b'))
+  
+  -- tuple_list_not_in: empty pairs
+  [SQL] SELECT id FROM t WHERE TRUE
+  
+  -- tuple_list_not_in: two pairs with null
+  [SQL] SELECT id FROM t WHERE (id, name) NOT IN ((1, 'a'), (NULL, 'b'))
   
   -- opt_filter: none
   [SQL] SELECT name FROM t WHERE  TRUE 

--- a/test/cram/test_scoped_select/scope.expected.ml
+++ b/test/cram/test_scoped_select/scope.expected.ml
@@ -66,7 +66,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let stock : _ t =
         {
           set = (fun _p -> ());
-          read = (fun row idx -> (T.get_column_Int_nullable row idx, idx + 1));
+          read = (fun row idx -> (T.get_column_Int row idx, idx + 1));
           column = ("stock");
           count = 0;
           deps = [];

--- a/test/out/cte.xml
+++ b/test/out/cte.xml
@@ -18,16 +18,16 @@
    <value name="some_value" type="Float"/>
   </in>
   <out>
-   <value name="col4" type="Int" nullable="true"/>
+   <value name="col4" type="Int"/>
    <value name="col5" type="Text" nullable="true"/>
-   <value name="col6" type="Float" nullable="true"/>
+   <value name="col6" type="Float"/>
   </out>
  </stmt>
  <stmt name="select_4" sql="SELECT *&#x0A;FROM (&#x0A;    WITH&#x0A;    cte_grouped AS (&#x0A;        SELECT col_group, AVG(col_value) AS avg_value&#x0A;        FROM test22&#x0A;        GROUP BY col_group&#x0A;    ),&#x0A;    cte_counts AS (&#x0A;        SELECT col_group, COUNT(*) AS group_count&#x0A;        FROM test22&#x0A;        GROUP BY col_group&#x0A;    ),&#x0A;    cte_max_values AS (&#x0A;        SELECT col_group, MAX(col_value) AS max_value&#x0A;        FROM test22&#x0A;        GROUP BY col_group&#x0A;    ),&#x0A;    cte_combined AS (&#x0A;        SELECT &#x0A;            g.col_group, &#x0A;            g.avg_value, &#x0A;            c.group_count, &#x0A;            m.max_value&#x0A;        FROM cte_grouped g&#x0A;        JOIN cte_counts c ON g.col_group = c.col_group&#x0A;        JOIN cte_max_values m ON g.col_group = m.col_group&#x0A;    )&#x0A;    SELECT col_group, avg_value, group_count, max_value&#x0A;    FROM cte_combined&#x0A;) AS dt&#x0A;WHERE dt.group_count &gt; 1 AND dt.avg_value &gt; 50.00" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="col_group" type="Text" nullable="true"/>
-   <value name="avg_value" type="Float" nullable="true"/>
+   <value name="col_group" type="Text"/>
+   <value name="avg_value" type="Float"/>
    <value name="group_count" type="Int"/>
    <value name="max_value" type="Decimal" nullable="true"/>
   </out>

--- a/test/out/interval.xml
+++ b/test/out/interval.xml
@@ -9,7 +9,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -17,7 +17,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -25,7 +25,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -33,7 +33,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -41,7 +41,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -49,7 +49,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -57,7 +57,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -65,7 +65,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -73,7 +73,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -81,7 +81,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -89,7 +89,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -97,7 +97,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -105,7 +105,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -113,7 +113,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -121,7 +121,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -129,7 +129,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -137,7 +137,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -145,7 +145,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -153,7 +153,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>
@@ -161,7 +161,7 @@
   <in/>
   <out>
    <value name="id" type="Int"/>
-   <value name="stamp" type="Datetime" nullable="true"/>
+   <value name="stamp" type="Datetime"/>
    <value name="interval" type="Int" nullable="true"/>
   </out>
  </stmt>

--- a/test/out/multidel.xml
+++ b/test/out/multidel.xml
@@ -15,7 +15,7 @@
   </in>
   <out>
    <value name="id" type="Int"/>
-   <value name="foo" type="Text" nullable="true"/>
+   <value name="foo" type="Text"/>
   </out>
  </stmt>
  <stmt name="delete_foo0" sql="DELETE foo FROM foo" category="DML" kind="delete" target="foo" cardinality="0">

--- a/test/out/reusable.xml
+++ b/test/out/reusable.xml
@@ -25,7 +25,7 @@
   <out>
    <value name="id" type="Int"/>
    <value name="name" type="Text"/>
-   <value name="category_id" type="Int" nullable="true"/>
+   <value name="category_id" type="Int"/>
    <value name="category_name" type="Text"/>
   </out>
  </stmt>
@@ -34,7 +34,7 @@
   <out>
    <value name="id" type="Int"/>
    <value name="name" type="Text"/>
-   <value name="category_id" type="Int" nullable="true"/>
+   <value name="category_id" type="Int"/>
    <value name="category_name" type="Text"/>
   </out>
  </stmt>

--- a/test/out/shared_choice.xml
+++ b/test/out/shared_choice.xml
@@ -8,8 +8,8 @@
  <stmt name="select_1" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
   <in/>
   <out>
-   <value name="a" type="Int" nullable="true"/>
-   <value name="b" type="Int" nullable="true"/>
+   <value name="a" type="Int"/>
+   <value name="b" type="Int"/>
   </out>
  </stmt>
  <stmt name="select_2" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
@@ -17,8 +17,8 @@
    <value name="v" type="Int"/>
   </in>
   <out>
-   <value name="a" type="Int" nullable="true"/>
-   <value name="b" type="Int" nullable="true"/>
+   <value name="a" type="Int"/>
+   <value name="b" type="Int"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT * FROM test&#x0A;WHERE a = {TODO dynamic choice}&#x0A;  AND b = {TODO dynamic choice}" category="DQL" kind="select" cardinality="n">
@@ -27,8 +27,8 @@
    <value name="q" type="Int"/>
   </in>
   <out>
-   <value name="a" type="Int" nullable="true"/>
-   <value name="b" type="Int" nullable="true"/>
+   <value name="a" type="Int"/>
+   <value name="b" type="Int"/>
   </out>
  </stmt>
  <table name="test">

--- a/test/out/where_in_in_subquery.xml
+++ b/test/out/where_in_in_subquery.xml
@@ -15,7 +15,7 @@
  </stmt>
  <stmt name="update_3" sql="UPDATE test30 t30&#x0A;SET&#x0A;    t30.column_a = 'the value',&#x0A;    t30.column_b = false&#x0A;WHERE&#x0A;    t30.column_c_31 IN (&#x0A;        SELECT t31.id&#x0A;        FROM test31 t31&#x0A;        WHERE t31.column_c_32 IN (&#x0A;            SELECT t32.id&#x0A;            FROM test32 t32&#x0A;            WHERE t32.column_f IN @@c_f_ids&#x0A;        )&#x0A;    )" category="DML" kind="update" cardinality="0">
   <in>
-   <value name="c_f_ids" type="set(Int)" nullable="true"/>
+   <value name="c_f_ids" type="set(Int)"/>
   </in>
   <out/>
  </stmt>
@@ -37,26 +37,26 @@
  </stmt>
  <stmt name="update_8" sql="UPDATE tbl4 t4&#x0A;SET t4.col3 = t4.col3 * 1.2&#x0A;WHERE t4.tbl3_id IN (&#x0A;    SELECT t3.id&#x0A;    FROM tbl3 t3&#x0A;    WHERE t3.col2 IN (&#x0A;        SELECT t2.col2&#x0A;        FROM tbl2 t2&#x0A;        WHERE t2.col1 IN (&#x0A;            SELECT t1.id&#x0A;            FROM tbl1 t1&#x0A;            WHERE t1.col2 IN @@t1_c2&#x0A;        )&#x0A;    )&#x0A;)" category="DML" kind="update" cardinality="0">
   <in>
-   <value name="t1_c2" type="set(Text)" nullable="true"/>
+   <value name="t1_c2" type="set(Text)"/>
   </in>
   <out/>
  </stmt>
  <stmt name="update_9" sql="UPDATE tbl3 t3&#x0A;SET t3.col3 = CONCAT('Updated: ', t3.col3)&#x0A;WHERE t3.tbl2_id IN (&#x0A;    SELECT t2.id&#x0A;    FROM tbl2 t2&#x0A;    WHERE t2.tbl1_id IN (&#x0A;        SELECT t1.id&#x0A;        FROM tbl1 t1&#x0A;        WHERE t1.col1 IN  @@t1_c1&#x0A;    )&#x0A;)" category="DML" kind="update" cardinality="0">
   <in>
-   <value name="t1_c1" type="set(Int)" nullable="true"/>
+   <value name="t1_c1" type="set(Int)"/>
   </in>
   <out/>
  </stmt>
  <stmt name="update_10" sql="UPDATE tbl2 t2&#x0A;SET t2.col1 = t2.col1 + 1000&#x0A;WHERE t2.id IN (&#x0A;    SELECT t3.tbl2_id&#x0A;    FROM tbl3 t3&#x0A;    WHERE t3.col2 IN (&#x0A;        SELECT t4.col2&#x0A;        FROM tbl4 t4&#x0A;        WHERE t4.col1 IN (&#x0A;            SELECT t1.id&#x0A;            FROM tbl1 t1&#x0A;            WHERE t1.col2 IN  @@t1_c2&#x0A;        )&#x0A;    )&#x0A;)" category="DML" kind="update" cardinality="0">
   <in>
-   <value name="t1_c2" type="set(Text)" nullable="true"/>
+   <value name="t1_c2" type="set(Text)"/>
   </in>
   <out/>
  </stmt>
  <stmt name="update_11" sql="UPDATE tbl2 t2&#x0A;SET t2.col1 = t2.col1 + 1000&#x0A;WHERE t2.id IN (&#x0A;    SELECT t3.tbl2_id&#x0A;    FROM tbl3 t3&#x0A;    WHERE t3.col2 IN (&#x0A;        SELECT t4.col2&#x0A;        FROM tbl4 t4&#x0A;        WHERE @left_side_isnt_missed IN (&#x0A;            SELECT t1.id&#x0A;            FROM tbl1 t1&#x0A;            WHERE t1.col2 IN  @@t1_c2&#x0A;        )&#x0A;    )&#x0A;)" category="DML" kind="update" cardinality="0">
   <in>
    <value name="left_side_isnt_missed" type="Int" nullable="true"/>
-   <value name="t1_c2" type="set(Text)" nullable="true"/>
+   <value name="t1_c2" type="set(Text)"/>
   </in>
   <out/>
  </stmt>

--- a/test/out/where_in_tuple_list.xml
+++ b/test/out/where_in_tuple_list.xml
@@ -10,8 +10,8 @@
    <value name="in_" type="list(Int, Text, Int, Text, Int, Int, Text)"/>
   </in>
   <out>
-   <value name="col1" type="Text" nullable="true"/>
-   <value name="col2" type="Int" nullable="true"/>
+   <value name="col1" type="Text"/>
+   <value name="col2" type="Int"/>
   </out>
  </stmt>
  <table name="table1">

--- a/test/out/window.xml
+++ b/test/out/window.xml
@@ -15,12 +15,12 @@
   </in>
   <out>
    <value name="pk" type="Int"/>
-   <value name="l" type="Int"/>
-   <value name="l1" type="Int"/>
-   <value name="l2" type="Int"/>
+   <value name="l" type="Int" nullable="true"/>
+   <value name="l1" type="Int" nullable="true"/>
+   <value name="l2" type="Int" nullable="true"/>
    <value name="l0" type="Int"/>
-   <value name="lm1" type="Int"/>
-   <value name="lm2" type="Int"/>
+   <value name="lm1" type="Int" nullable="true"/>
+   <value name="lm2" type="Int" nullable="true"/>
   </out>
  </stmt>
  <stmt name="select_3" sql="SELECT pk, LEAD(pk) OVER (ORDER BY pk) AS l,&#x0A;  LEAD(pk,1) OVER (ORDER BY pk) AS l1,&#x0A;  LEAD(pk+@inc,2) OVER (ORDER BY pk) AS l2,&#x0A;  LEAD(pk,0) OVER (ORDER BY pk) AS l0,&#x0A;  LEAD(pk,-1) OVER (ORDER BY pk) AS lm1,&#x0A;  LEAD(pk,-2) OVER (ORDER BY pk) AS lm2 &#x0A;FROM t1" category="DQL" kind="select" cardinality="n">
@@ -29,12 +29,12 @@
   </in>
   <out>
    <value name="pk" type="Int"/>
-   <value name="l" type="Int"/>
-   <value name="l1" type="Int"/>
-   <value name="l2" type="Int"/>
+   <value name="l" type="Int" nullable="true"/>
+   <value name="l1" type="Int" nullable="true"/>
+   <value name="l2" type="Int" nullable="true"/>
    <value name="l0" type="Int"/>
-   <value name="lm1" type="Int"/>
-   <value name="lm2" type="Int"/>
+   <value name="lm1" type="Int" nullable="true"/>
+   <value name="lm2" type="Int" nullable="true"/>
   </out>
  </stmt>
  <table name="t1">

--- a/test/property_based/dune
+++ b/test/property_based/dune
@@ -3,5 +3,5 @@
  (libraries
    extlib
    oUnit
-   qcheck-ounit
+   qcheck-core
    sqlgg))

--- a/test/property_based/test_property_based.ml
+++ b/test/property_based/test_property_based.ml
@@ -1,5 +1,6 @@
 (* Property-based laws for Type and Meta. *)
 
+open Printf
 open ExtLib
 open OUnit
 open Sqlgg
@@ -112,10 +113,435 @@ let test_type_laws = List.map qcheck [
       | None -> true);
 ]
 
+module Narrowing_model = struct
+
+  let t1 = Sql.make_table_name "t1"
+  let t2 = Sql.make_table_name "t2"
+
+  let columns = [| t1, "a"; t2, "a"; t1, "b" |]
+  let n_columns = Array.length columns
+  let all_columns = Array.to_list (Array.init n_columns (fun i -> i))
+
+  let show_column i = let (tn, name) = columns.(i) in sprintf "%s.%s" (Sql.show_table_name tn) name
+  let show_column_set m =
+    "{" ^ String.concat ", " (List.map show_column (List.filter (Array.get m) all_columns)) ^ "}"
+
+  let refs = [|
+    [ { cname = "a"; tname = Some t1 } ];
+    [ { cname = "a"; tname = Some t2 } ];
+    [ { cname = "b"; tname = Some t1 }; { cname = "b"; tname = None } ];
+  |]
+
+  let column_of_ref (c : col_name) =
+    let hit i =
+      let (tn, name) = columns.(i) in
+      String.equal name c.cname && Option.map_default (Sql.equal_table_name tn) true c.tname
+    in
+    match List.filter hit all_columns with
+    | [ i ] -> Some i
+    | [] | _ :: _ :: _ -> None
+
+  let call kind parameters = Sql.fn "test" kind parameters
+  let conj a b = call (Logical And) [ a; b ]
+  let neg a = call Negation [ a ]
+  let is_not_null a = call (Comparison Is_not_null) [ a ]
+  let subquery =
+    let select = { columns = []; from = None; where = None; group = []; having = None } in
+    SelectExpr ({ select_complete = { select = select, []; order = []; limit = None;
+                                      select_row_locking = None }; cte = None }, `AsValue)
+
+  let like a b = call Like [ a; b ]
+  let like_escape a b esc = call Like_escape [ like a b; esc ]
+
+  let list_param = make_located ~value:(Some "p") ~pos:(0, 0)
+
+  let in_param kind x =
+    let arg = Inparam (make_param ~id:list_param ~typ:(Source_type.depends Any), Meta.empty ()) in
+    InChoice (list_param, kind, call Membership [ x; arg ])
+
+  let in_tuple_list kind exprs =
+    InTupleList (make_located ~pos:(0, 0)
+      ~value:{ exprs; param_id = list_param; kind_in_tuple_list = kind })
+
+  let binary_comparisons = [ Comp_equal; Comp_num_eq; Comp_num_cmp; Comp_text_cmp; Not_distinct_op ]
+
+  let narrowed e =
+    let resolve (c : col_name) : table_name Schema.Source.Attr.t option =
+      column_of_ref c |> Option.map (fun i ->
+        let (tn, name) = columns.(i) in
+        { Schema.Source.Attr.attr = make_attribute' name Type.(nullable Int); sources = [ tn ] })
+    in
+    (Narrowing.narrow_columns ~resolve ~constrains:(fun _ -> true) e)
+      .Narrowing.Attr_refinement.not_null
+
+  let any_of l = QCheck2.Gen.(oneof (List.map return l))
+
+  let gen_column =
+    let open QCheck2.Gen in
+    int_range 0 (n_columns - 1) >>= fun i -> map Sql.column (any_of refs.(i))
+
+  let rec gen_scalar depth =
+    let open QCheck2.Gen in
+    if depth <= 0 then gen_column
+    else frequency [
+      5, gen_column;
+      2, map2 (fun a b -> call (Arith (Source_type.depends Any)) [ a; b ])
+           (gen_scalar (depth - 1)) (gen_scalar (depth - 1));
+      2, map2 (fun a b -> call (Null_handling (Coalesce (Type.Var 0, Type.Var 0))) [ a; b ])
+           (gen_scalar (depth - 1)) (gen_scalar (depth - 1));
+      1, map2 (fun a b -> call (Null_handling If_null) [ a; b ])
+           (gen_scalar (depth - 1)) (gen_scalar (depth - 1));
+      2, map2 (fun branches else_ -> Case { case = None; branches; else_ })
+           (list_size (int_range 1 2)
+              (map2 (fun when_ then_ -> { when_; then_ }) (gen_cond (depth - 1)) (gen_scalar (depth - 1))))
+           (option (gen_scalar (depth - 1)));
+      1, map3 (fun scrutinee branches else_ -> Case { case = Some scrutinee; branches; else_ })
+           (gen_scalar (depth - 1))
+           (list_size (int_range 1 2)
+              (map2 (fun when_ then_ -> { when_; then_ }) (gen_scalar (depth - 1)) (gen_scalar (depth - 1))))
+           (option (gen_scalar (depth - 1)));
+    ]
+
+  and gen_cond depth =
+    let open QCheck2.Gen in
+    let scalar = gen_scalar (min depth 2) in
+    let leaf = frequency [
+      4, map3 (fun op a b -> call (Comparison op) [ a; b ]) (any_of binary_comparisons) scalar scalar;
+      2, map is_not_null scalar;
+      2, map (fun x -> call (Comparison Is_null) [ x ]) scalar;
+      2, map2 (fun x l -> call Membership (x :: l)) scalar (list_size (int_range 1 2) scalar);
+      2, map (fun x -> call Membership [ x; subquery ]) scalar;
+      1, map3 (fun x lo hi -> call Range [ x; lo; hi ]) scalar scalar scalar;
+      2, map2 in_param (any_of [ `In; `NotIn ]) scalar;
+      2, map2 in_tuple_list (any_of [ `In; `NotIn ]) (list_size (int_range 1 2) scalar);
+      2, map3 (fun op quantifier x -> call (Quantified_comparison { op; quantifier }) [ x; subquery ])
+           (any_of binary_comparisons) (any_of [ `Any; `All ]) scalar;
+      1, map2 like scalar scalar;
+      1, map3 like_escape scalar scalar scalar;
+    ] in
+    if depth <= 0 then leaf
+    else frequency [
+      3, leaf;
+      3, map2 conj (gen_cond (depth - 1)) (gen_cond (depth - 1));
+      3, map2 (fun a b -> call (Logical Or) [ a; b ]) (gen_cond (depth - 1)) (gen_cond (depth - 1));
+      2, map2 (fun a b -> call (Logical Xor) [ a; b ]) (gen_cond (depth - 1)) (gen_cond (depth - 1));
+      2, map neg (gen_cond (depth - 1));
+      2, map2 (fun branches else_ -> Case { case = None; branches; else_ })
+           (list_size (int_range 1 2)
+              (map2 (fun when_ then_ -> { when_; then_ }) (gen_cond (depth - 1)) (gen_cond (depth - 1))))
+           (option (gen_cond (depth - 1)));
+      2, map3 (fun scrutinee branches else_ -> Case { case = Some scrutinee; branches; else_ })
+           scalar
+           (list_size (int_range 1 2)
+              (map2 (fun when_ then_ -> { when_; then_ }) scalar (gen_cond (depth - 1))))
+           (option (gen_cond (depth - 1)));
+      1, map2 (fun a b ->
+           Choices (make_located ~value:(Some "q") ~pos:(0, 0),
+             [ make_located ~value:(Some "A") ~pos:(0, 0), Some a;
+               make_located ~value:(Some "B") ~pos:(0, 0), Some b ]))
+           (gen_cond (depth - 1)) (gen_cond (depth - 1));
+    ]
+
+  type element = Equal | Distinct | Null
+  type in_side = Empty_list | One_tuple of element list
+
+  type row = { cols : int option array; sub : int option list; in_side : in_side }
+
+  let in_sides arity =
+    let rec patterns n =
+      if n = 0 then [ [] ]
+      else List.concat_map (fun c -> List.map (List.cons c) (patterns (n - 1))) [ Equal; Distinct; Null ]
+    in
+    Empty_list :: List.map (fun p -> One_tuple p) (patterns arity)
+
+  let rec max_in_arity e =
+    let own =
+      match e with
+      | InChoice (_, _, Fun { kind = Membership; parameters = _ :: _; _ }) -> 1
+      | InTupleList { value = { exprs; _ }; _ } -> List.length exprs
+      | Value _ | Param _ | Inparam _ | Choices _ | InChoice _ | Fun _ | SelectExpr _
+      | Column _ | OptionActions _ | Case _ | Of_values _ -> 0
+    in
+    List.fold_left (fun acc e -> max acc (max_in_arity e)) own (Sql.sub_exprs e)
+
+  let kleene_and a b =
+    match a, b with
+    | Some false, _ | _, Some false -> Some false
+    | Some true, Some true -> Some true
+    | None, _ | _, None -> None
+  let kleene_or a b =
+    match a, b with
+    | Some true, _ | _, Some true -> Some true
+    | Some false, Some false -> Some false
+    | None, _ | _, None -> None
+
+  let in_side_holds row values =
+    let compare_element element x =
+      match x, element with
+      | None, _ | Some _, Null -> None
+      | Some _, Equal -> Some true
+      | Some _, Distinct -> Some false
+    in
+    match row.in_side with
+    | Empty_list -> Some false
+    | One_tuple pattern ->
+      List.fold_left2 (fun acc element x -> kleene_and acc (compare_element element x))
+        (Some true) (List.take (List.length values) pattern) values
+
+  let rec eval_scalar row = function
+    | Column c -> Option.map_default (Array.get row.cols) None (column_of_ref c.collated)
+    | Fun { kind = Arith _; parameters = [ a; b ]; _ } ->
+      (match eval_scalar row a, eval_scalar row b with Some a, Some b -> Some (a + b) | _ -> None)
+    | Fun { kind = Null_handling (Coalesce _ | If_null); parameters = [ a; b ]; _ } ->
+      (match eval_scalar row a with None -> eval_scalar row b | v -> v)
+    | Case { case; branches; else_ } ->
+      let rec taken = function
+        | [] -> Option.map_default (eval_scalar row) None else_
+        | b :: rest -> if guard row case b = Some true then eval_scalar row b.then_ else taken rest
+      in
+      taken branches
+    | Value _ -> None
+    | Fun _ | Param _ | Inparam _ | Choices _ | InChoice _ | SelectExpr _
+    | InTupleList _ | OptionActions _ | Of_values _ as e ->
+      failwith ("oracle: not a scalar: " ^ Format.asprintf "%a" Sql.pp_expr e)
+
+  and strict_binop op row a b =
+    match eval_scalar row a, eval_scalar row b with Some a, Some b -> Some (op a b) | _ -> None
+
+  and guard row case { when_; _ } =
+    match case with
+    | None -> eval_condition row when_
+    | Some scrutinee -> strict_binop ( = ) row scrutinee when_
+
+  and kleene_cmp op a b =
+    let strict f = match a, b with Some a, Some b -> Some (f a b) | None, _ | _, None -> None in
+    match op with
+    | Comp_equal -> strict Int.equal
+    | Comp_num_eq -> strict (fun a b -> not (Int.equal a b))
+    | Comp_num_cmp -> strict (fun a b -> Int.compare a b < 0)
+    | Comp_text_cmp -> strict (fun a b -> Int.compare a b > 0)
+    | Not_distinct_op -> Some (Stdlib.Option.equal Int.equal a b)
+    | Is_null | Is_not_null -> failwith "oracle: unary comparison used as a binary one"
+
+  and eval_condition row e =
+    match e with
+    | Fun { kind = Comparison ((Comp_equal | Comp_num_eq | Comp_num_cmp | Comp_text_cmp
+                               | Not_distinct_op) as op); parameters = [ a; b ]; _ } ->
+      kleene_cmp op (eval_scalar row a) (eval_scalar row b)
+    | Fun { kind = Like; parameters = [ a; b ]; _ } -> strict_binop ( = ) row a b
+    | Fun { kind = Like_escape; parameters = [ e; esc ]; _ } ->
+      Option.map_default (fun _ -> eval_condition row e) None (eval_scalar row esc)
+    | Fun { kind = Comparison Is_null; parameters = [ a ]; _ } -> Some (eval_scalar row a = None)
+    | Fun { kind = Comparison Is_not_null; parameters = [ a ]; _ } -> Some (eval_scalar row a <> None)
+    | Fun { kind = Logical And; parameters = [ a; b ]; _ } -> kleene_and (eval_condition row a) (eval_condition row b)
+    | Fun { kind = Logical Or; parameters = [ a; b ]; _ } -> kleene_or (eval_condition row a) (eval_condition row b)
+    | Fun { kind = Logical Xor; parameters = [ a; b ]; _ } ->
+      (match eval_condition row a, eval_condition row b with Some a, Some b -> Some (a <> b) | _ -> None)
+    | Fun { kind = Negation; parameters = [ a ]; _ } -> Option.map not (eval_condition row a)
+    | Fun { kind = Membership; parameters = [ x; SelectExpr _ ]; _ } ->
+      let x = eval_scalar row x in
+      List.fold_left (fun acc v -> kleene_or acc (kleene_cmp Comp_equal x v)) (Some false) row.sub
+    | Fun { kind = Membership; parameters = x :: candidates; _ } ->
+      let x = eval_scalar row x in
+      List.fold_left (fun acc c -> kleene_or acc (kleene_cmp Comp_equal x (eval_scalar row c)))
+        (Some false) candidates
+    | Fun { kind = Range; parameters = [ x; lo; hi ]; _ } ->
+      kleene_and (strict_binop ( >= ) row x lo) (strict_binop ( <= ) row x hi)
+    | InChoice (_, kind, Fun { kind = Membership; parameters = x :: _; _ }) ->
+      let member = in_side_holds row [ eval_scalar row x ] in
+      begin match kind with `In -> member | `NotIn -> Option.map not member end
+    | InTupleList { value = { exprs; kind_in_tuple_list; _ }; _ } ->
+      let member = in_side_holds row (List.map (eval_scalar row) exprs) in
+      begin match kind_in_tuple_list with `In -> member | `NotIn -> Option.map not member end
+    | Fun { kind = Quantified_comparison { op; quantifier }; parameters = x :: _; _ } ->
+      let x = eval_scalar row x in
+      let fold combine unit = List.fold_left (fun acc v -> combine acc (kleene_cmp op x v)) unit row.sub in
+      begin match quantifier with
+      | `All -> fold kleene_and (Some true)
+      | `Any -> fold kleene_or (Some false)
+      end
+    | Case { case; branches; else_ } ->
+      let rec taken = function
+        | [] -> Option.map_default (eval_condition row) None else_
+        | b :: rest -> if guard row case b = Some true then eval_condition row b.then_ else taken rest
+      in
+      taken branches
+    | Fun _ | Value _ | Param _ | Inparam _ | Choices _ | InChoice _ | SelectExpr _
+    | OptionActions _ | Column _ | Of_values _ as e ->
+      failwith ("oracle: not a condition: " ^ Format.asprintf "%a" Sql.pp_expr e)
+
+  let rec disambiguate e =
+    let cartesian parameters =
+      List.fold_right (fun p acc ->
+        List.concat_map (fun p -> List.map (List.cons p) acc) (disambiguate p)) parameters [ [] ]
+    in
+    match e with
+    | Choices (_, alternatives) ->
+      List.concat_map (fun (_, e) -> Option.map_default disambiguate [] e) alternatives
+    | Fun ({ kind = Like_escape; parameters = [ Fun ({ kind = Like; parameters = [ a; b ]; _ } as inner); esc ]; _ } as f) ->
+      List.concat_map (fun a ->
+        List.concat_map (fun b ->
+          List.concat_map (fun esc ->
+            let node = Fun { f with parameters = [ Fun { inner with parameters = [ a; b ] }; esc ] } in
+            [ node; neg node ]) (disambiguate esc)) (disambiguate b)) (disambiguate a)
+    | Fun ({ kind = Membership | Range | Like | Like_escape; _ } as f) ->
+      List.concat_map (fun parameters ->
+        let node = Fun { f with parameters } in [ node; neg node ]) (cartesian f.parameters)
+    | Fun ({ parameters; _ } as f) ->
+      List.map (fun parameters -> Fun { f with parameters }) (cartesian parameters)
+    | InChoice (id, kind, Fun ({ kind = Membership; parameters = x :: rest; _ } as f)) ->
+      List.map (fun x -> InChoice (id, kind, Fun { f with parameters = x :: rest })) (disambiguate x)
+    | InTupleList ({ value = ({ exprs; _ } as tuples); _ } as l) ->
+      List.map (fun exprs -> InTupleList { l with value = { tuples with exprs } }) (cartesian exprs)
+    | Case { case; branches; else_ } ->
+      let opt = function None -> [ None ] | Some e -> List.map (fun e -> Some e) (disambiguate e) in
+      let branches =
+        List.fold_right (fun { when_; then_ } acc ->
+          List.concat_map (fun when_ ->
+            List.concat_map (fun then_ ->
+              List.map (List.cons { when_; then_ }) acc) (disambiguate then_)) (disambiguate when_))
+          branches [ [] ]
+      in
+      let elses = opt else_ in
+      List.concat_map (fun case ->
+        List.concat_map (fun branches ->
+          List.map (fun else_ -> Case { case; branches; else_ }) elses) branches) (opt case)
+    | e -> [ e ]
+
+  let rows_for arity =
+    let rec tuples values n =
+      if n = 0 then [ [] ]
+      else List.concat_map (fun v -> List.map (List.cons v) (tuples values (n - 1))) values
+    in
+    let cols = List.map Array.of_list (tuples [ None; Some 0; Some 1; Some 2 ] n_columns) in
+    let subs = [ []; [ Some 0 ]; [ Some 1 ]; [ None ]; [ Some 0; None ]; [ Some 0; Some 1 ] ] in
+    List.concat_map (fun cols ->
+      List.concat_map (fun sub ->
+        List.map (fun in_side -> { cols; sub; in_side }) (in_sides arity)) subs) cols
+
+  let show = Format.asprintf "%a" Sql.pp_expr
+
+  let shrink e =
+    let opt = Option.map_default (fun e -> [ e ]) [] in
+    List.to_seq @@
+    match e with
+    | Fun { kind = Logical _ | Negation; parameters; _ } -> parameters
+    | Case { case = None; branches; else_ } ->
+      List.concat_map (fun b -> [ b.when_; b.then_ ]) branches @ opt else_
+    | Case { case = Some _; branches; else_ } ->
+      List.map (fun b -> b.then_) branches @ opt else_
+    | Choices (_, alternatives) -> List.filter_map snd alternatives
+    | Fun _ | Value _ | Param _ | Inparam _ | InChoice _ | SelectExpr _ | Column _
+    | InTupleList _ | OptionActions _ | Of_values _ -> []
+
+  let any_condition = QCheck2.Gen.(set_shrink shrink (sized_size (int_range 0 3) gen_cond))
+
+  let marked_columns promised =
+    Narrowing.Qualified_attr.Set.elements promised
+    |> List.map (fun (k : Narrowing.Qualified_attr.t) ->
+      let hit i =
+        let (tn, name) = columns.(i) in
+        String.equal name k.name && (match k.sources with [ s ] -> Sql.equal_table_name tn s | _ -> false)
+      in
+      match List.find_opt hit all_columns with
+      | Some i -> i
+      | None ->
+        QCheck2.Test.fail_reportf "narrowing promised unknown column [%s].%s"
+          (String.concat ";" (List.map Sql.show_table_name k.sources)) k.name)
+
+  let column_set l = let a = Array.make n_columns false in List.iter (fun i -> a.(i) <- true) l; a
+
+  let marks_only_non_null e =
+    let promised = marked_columns (narrowed e) in
+    let promised_null row = List.find_opt (fun i -> row.cols.(i) = None) promised in
+    let broken =
+      if promised = [] then None
+      else
+        let rows = rows_for (max_in_arity e) in
+        List.find_map (fun instance ->
+          List.find_map (fun row ->
+            match promised_null row with
+            | Some i when eval_condition row instance = Some true -> Some (instance, row, i)
+            | Some _ | None -> None)
+            rows)
+          (disambiguate e)
+    in
+    match broken with
+    | None -> true
+    | Some (instance, row, i) ->
+      let show_in_side = function
+        | Empty_list -> "empty"
+        | One_tuple pattern ->
+          String.concat ", " (List.map (function Equal -> "equal" | Distinct -> "distinct" | Null -> "NULL") pattern)
+      in
+      QCheck2.Test.fail_reportf
+        "@[<v>promised %s is NULL in a kept row@,instance: %s@,row: %s@,subquery: %s@,list parameter: %s@]"
+        (show_column i) (show instance)
+        (String.concat ", " (List.mapi (fun i v ->
+          sprintf "%s=%s" (show_column i) (Option.map_default string_of_int "NULL" v)) (Array.to_list row.cols)))
+        (String.concat ", " (List.map (Option.map_default string_of_int "NULL") row.sub))
+        (show_in_side row.in_side)
+
+  let rec mentions acc = function
+    | Column c -> Option.map_default (fun i -> i :: acc) acc (column_of_ref c.collated)
+    | Fun { parameters; _ } -> List.fold_left mentions acc parameters
+    | InChoice (_, _, e) -> mentions acc e
+    | InTupleList { value = { exprs; _ }; _ } -> List.fold_left mentions acc exprs
+    | Case _ | Value _ | Param _ | Inparam _ | Choices _ | SelectExpr _
+    | OptionActions _ | Of_values _ -> acc
+
+  let rec gen_strict_scalar depth =
+    let open QCheck2.Gen in
+    if depth <= 0 then gen_column
+    else frequency [
+      3, gen_column;
+      2, map2 (fun a b -> call (Arith (Source_type.depends Any)) [ a; b ])
+           (gen_strict_scalar (depth - 1)) (gen_strict_scalar (depth - 1));
+    ]
+
+  let any_strict_conjunction =
+    let open QCheck2.Gen in
+    let scalar = gen_strict_scalar 2 in
+    let atom = frequency [
+      3, map3 (fun op a b -> call (Comparison op) [ a; b ])
+           (any_of [ Comp_equal; Comp_num_eq; Comp_num_cmp; Comp_text_cmp ]) scalar scalar;
+      2, map is_not_null scalar;
+      1, map2 like scalar scalar;
+      1, map3 like_escape scalar scalar scalar;
+      2, map (in_param `In) scalar;
+      2, map (in_tuple_list `In) (list_size (int_range 1 2) scalar);
+    ] in
+    set_shrink shrink
+      (sized_size (int_range 0 3)
+         (fix (fun self depth ->
+           if depth <= 0 then atom
+           else frequency [ 2, atom; 3, map2 conj (self (depth - 1)) (self (depth - 1)) ])))
+
+  let marks_every_non_null e =
+    let expected = column_set (mentions [] e) in
+    let got = column_set (marked_columns (narrowed e)) in
+    if expected = got then true
+    else
+      QCheck2.Test.fail_reportf
+        "@[<v>a conjunction of strict atoms must narrow every column it mentions@,expr: %s@,expected: %s@,got: %s@]"
+        (show e) (show_column_set expected) (show_column_set got)
+
+end
+
+let test_narrowing_laws = [
+  qcheck (QCheck2.Test.make ~count:2000 ~print:Narrowing_model.show
+    ~name:"soundness: where Kleene reads the condition TRUE, every column narrowing marked is non-NULL"
+    Narrowing_model.any_condition Narrowing_model.marks_only_non_null);
+  qcheck (QCheck2.Test.make ~count:1000 ~print:Narrowing_model.show
+    ~name:"completeness: on ANDed strict atoms, narrowing marks every column Kleene forces non-NULL"
+    Narrowing_model.any_strict_conjunction Narrowing_model.marks_every_non_null);
+]
+
 let () =
   let suite = "qcheck laws" >::: [
     "test_type_laws" >::: test_type_laws;
     "test_meta_laws" >::: test_meta_laws;
+    "test_narrowing_laws" >::: test_narrowing_laws;
   ] in
   let results = run_test_tt suite in
   exit @@ if List.exists (function RFailure _ | RError _ -> true | _ -> false) results then 1 else 0


### PR DESCRIPTION
### Description

This PR adds Kleene-logic nullability narrowing

```sql
CREATE TABLE t1 (pk INT NOT NULL, a INT NULL, b INT NULL);
CREATE TABLE t2 (d INT NULL);
```

A strict predicate is never true when its operand is NULL: `NULL > 5` is not true, it is NULL. `WHERE` and `ON` keep only true rows. So the columns used in such a predicate are not null in the result, even if they are nullable in the DDL

| SQL | before | after |
| --- | --- | --- |
| `WHERE a > 5` | `a: Int?` | `a: Int` |
| `WHERE a + 1 = 5` | `a: Int?` | `a: Int` |
| `WHERE a IN (1, 2)` | `a: Int?` | `a: Int` |
| `WHERE a IN @ids` | `a: Int?` | `a: Int` |
| `WHERE (a, b) IN @pairs` | `a, b: Int?` | `a, b: Int` |
| `WHERE a = 1 AND b = 2` | `a, b: Int?` | `a, b: Int` |
| `JOIN t2 ON a = d` | `a, d: Int?` | `a, d: Int` |

No narrowing when NULL can still pass:

| SQL | stays | why |
| --- | --- | --- |
| `WHERE a = 1 OR b = 2` | `a, b: Int?` | other branch can be true |
| `WHERE a <=> 5` | `a: Int?` | null-safe comparison |
| `WHERE a NOT IN @ids` | `a: Int?` | empty `@ids` is rendered as `TRUE`, which holds for NULL too |
| `WHERE a IN (SELECT d FROM t2)` | `a: Int?` | parses into the same node as `NOT IN` (grammar drops `NOT`), and `NOT IN` over an empty subquery is true for NULL |
| `LEFT JOIN t2 ON a = d` | `a, d: Int?` | padded with NULL |

Also fixed on the way: a window function is nullable when its frame can miss a row.

| SQL | before | after |
| --- | --- | --- |
| `SELECT LAG(pk) OVER (ORDER BY pk)` | `Int` | `Int?` |