### PR TITLE
add -open <file>: load definitions without generating code for them

### DIFF
--- a/doc/_cli-options.md
+++ b/doc/_cli-options.md
@@ -4,6 +4,7 @@
   -name <identifier>                               Set output module name (default: sqlgg)
   -params named|unnamed|oracle|postgresql|none     Output query parameters substitution (default: auto-detected from dialect, can be overridden)
   -category {all|none|[-]<category>{,<category>}+} Only generate code for these specific query categories (possible values: DDL DQL DML DCL TCL)
+  -open <file>                                     Make definitions (schema, reusable queries) from <file> available without generating code for it (unless the file is also given as an input)
   -dynamic-select                                  Generate static and dynamic version for every SELECT (dynamic allows to pick columns per call)
   -                                                Read sql from stdin
 

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -87,18 +87,15 @@ let parse_output s =
   | "none" -> None
   | _ -> failwith (sprintf "Unknown output language: %s" s)
 
-let each_input ~output =
-  let run input =
-    (* parse always runs for its schema-registration side effects, even in -gen none *)
-    let stmts = match input with Some ch -> Main.get_statements ch | None -> [] in
-    match !output with
-    | None -> []
-    | Some _ ->
-      stmts |> List.filter (fun stmt -> filter_category (Stmt.category_of_stmt_kind stmt.Gen.kind))
-  in
-  function
-  | "-" -> run (Some stdin)
-  | filename -> Main.with_channel filename run
+(* parse always runs for its schema-registration side effects, even in -gen none *)
+let read_statements = function
+  | "-" -> Main.get_statements stdin
+  | filename -> Main.with_channel filename (Option.map_default Main.get_statements [])
+
+let filter_stmts ~output stmts =
+  match output with
+  | None -> []
+  | Some _ -> List.filter (fun stmt -> filter_category (Stmt.category_of_stmt_kind stmt.Gen.kind)) stmts
 
 let generate ~output ~name results =
   match output with
@@ -307,7 +304,25 @@ let parse_args () =
   let now = ref None in
   let max_id_length = ref None in
   let ddl_as_migration = ref false in
-  let work s = inputs := each_input ~output s :: !inputs in
+  let files : (string, [ `Open of Gen.stmt list | `Positional ]) Hashtbl.t = Hashtbl.create 4 in
+  let canonical = function
+    | "-" -> "-"
+    | f -> (try Unix.realpath f with Unix.Unix_error _ -> fatal "cannot open file : %s" f)
+  in
+  let open_input f =
+    let key = canonical f in
+    if not (Hashtbl.mem files key) then Hashtbl.replace files key (`Open (read_statements f))
+  in
+  let work s =
+    let key = canonical s in
+    let stmts =
+      match Hashtbl.find_opt files key with
+      | Some (`Open stmts) -> (* was used with -open before so we reuse *) stmts
+      | Some `Positional | None -> read_statements s
+    in
+    Hashtbl.replace files key `Positional;
+    inputs := filter_stmts ~output:!output stmts :: !inputs
+  in
   let groups =
   [
     { title = "Code generation"; opts =
@@ -316,6 +331,7 @@ let parse_args () =
       "-name", Arg.String (fun x -> name := x), "<identifier> Set output module name (default: sqlgg)";
       "-params", Arg.String set_params_mode, "named|unnamed|oracle|postgresql|none Output query parameters substitution (default: auto-detected from dialect, can be overridden)";
       "-category", Arg.String set_category, sprintf "{all|none|[-]<category>{,<category>}+} Only generate code for these specific query categories (possible values: %s)" all_categories;
+      "-open", Arg.String open_input, "<file> Make definitions (schema, reusable queries) from <file> available without generating code for it (unless the file is also given as an input)";
       "-dynamic-select", Arg.Set Sqlgg_config.dynamic_select,
         " Generate static and dynamic version for every SELECT (dynamic allows to pick columns per call)";
       "-", Arg.Unit (fun () -> work "-"), " Read sql from stdin";
@@ -389,6 +405,13 @@ let parse_args () =
       max_id_length = !max_id_length;
       ddl_as_migration = !ddl_as_migration }
   in
+  (* these modes reset the schema and rebuild it from -base/-target/-initial,
+     silently discarding whatever -open loaded *)
+  let has_open =
+    Hashtbl.fold (fun _ v acc -> acc || (match v with `Open _ -> true | `Positional -> false)) files false
+  in
+  if has_open && (!migrate_mode || !diff_mode) then
+    fatal "-open is not supported with -diff/-migrate";
   match !migrate_mode, !diff_mode with
   | true, true -> fatal "-migrate and -diff are mutually exclusive"
   | true, false ->

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,5 +1,6 @@
 (cram
  (deps
+  (package sqlgg)
   %{bin:sqlgg}
   (glob_files *.sql)
   (glob_files *.compare.ml)

--- a/test/cram/dune_dialect.t/a.sql
+++ b/test/cram/dune_dialect.t/a.sql
@@ -1,0 +1,2 @@
+-- @count_persons
+SELECT count(*) FROM person;

--- a/test/cram/dune_dialect.t/b.sql
+++ b/test/cram/dune_dialect.t/b.sql
@@ -1,0 +1,3 @@
+-- @list_adults
+WITH p AS &adults
+SELECT * FROM p;

--- a/test/cram/dune_dialect.t/ddl.sql
+++ b/test/cram/dune_dialect.t/ddl.sql
@@ -1,0 +1,4 @@
+CREATE TABLE person (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/test/cram/dune_dialect.t/dune
+++ b/test/cram/dune_dialect.t/dune
@@ -1,0 +1,3 @@
+(library
+ (name queries)
+ (libraries sqlgg.traits))

--- a/test/cram/dune_dialect.t/dune-project
+++ b/test/cram/dune_dialect.t/dune-project
@@ -1,0 +1,7 @@
+(lang dune 3.9)
+(dialect
+ (name sqlgg)
+ (implementation
+  (extension sql)
+  (preprocess
+   (run sqlgg -no-header -open %{dep:ddl.sql} -open %{dep:shared.sql} -gen caml %{input-file}))))

--- a/test/cram/dune_dialect.t/run.t
+++ b/test/cram/dune_dialect.t/run.t
@@ -1,0 +1,42 @@
+sqlgg as a dune dialect: every .sql file in the project becomes an OCaml
+module, preprocessed by `sqlgg -open ddl.sql -open shared.sql <file>`.
+
+The -open'ed files provide the schema and reusable queries to every module
+without their code being duplicated into each of them (because of -open).
+
+The project is committed as a fixture next to this file: ddl.sql (schema only),
+shared.sql (a reusable query only), a.sql and b.sql (plain queries), wired up
+by the dialect stanza. %{dep:...} is required for the -open'ed files -- dialect
+preprocess actions are sandboxed with only %{input-file} present, so plain
+filenames would not resolve:
+
+  $ cat dune-project
+  (lang dune 3.9)
+  (dialect
+   (name sqlgg)
+   (implementation
+    (extension sql)
+    (preprocess
+     (run sqlgg -no-header -open %{dep:ddl.sql} -open %{dep:shared.sql} -gen caml %{input-file}))))
+
+  $ cat dune
+  (library
+   (name queries)
+   (libraries sqlgg.traits))
+
+  $ dune build --root .
+
+Each module contains exactly the functions of its own file, Shared is empty:
+
+  $ for f in ddl shared a b; do echo "$f:"; grep -coE '^  let [a-z_]+ db' _build/default/$f.sql.ml; grep -oE '^  let [a-z_]+ db' _build/default/$f.sql.ml | sed 's/^ *//'; done
+  ddl:
+  1
+  let create_person db
+  shared:
+  0
+  a:
+  1
+  let count_persons db
+  b:
+  1
+  let list_adults db

--- a/test/cram/dune_dialect.t/shared.sql
+++ b/test/cram/dune_dialect.t/shared.sql
@@ -1,0 +1,2 @@
+-- @adults | include: reuse
+SELECT * FROM person WHERE id > @min_id;

--- a/test/cram/open_option.t
+++ b/test/cram/open_option.t
@@ -1,0 +1,68 @@
+`-open` makes definitions from a file available without generating code for it.
+
+  $ cat > defs.sql <<'EOF'
+  > CREATE TABLE person (
+  >     id INT PRIMARY KEY,
+  >     name TEXT NOT NULL
+  > );
+  > -- @get_persons | include: reuse
+  > SELECT * FROM person WHERE name LIKE @name;
+  > -- @delete_person
+  > DELETE FROM person WHERE id = @id;
+  > EOF
+
+  $ cat > queries.sql <<'EOF'
+  > -- @count_persons
+  > SELECT count(*) FROM person;
+  > -- @list_persons
+  > WITH p AS &get_persons
+  > SELECT * FROM p;
+  > EOF
+
+  $ sqlgg -no-header -open defs.sql -gen caml queries.sql > out.ml
+  $ grep -q 'let count_persons' out.ml && echo generated
+  generated
+  $ grep -q 'let list_persons' out.ml && echo generated
+  generated
+
+no code for anything from the opened file:
+
+  $ grep -E 'get_persons|delete_person|CREATE TABLE' out.ml
+  [1]
+
+Nothing is generated for `-open`ed files alone:
+
+  $ sqlgg -no-header -gen caml -open defs.sql
+
+`-open x.sql x.sql` is the same as `x.sql` -- the file is parsed once and its code
+is generated once:
+
+  $ cat > all.sql <<'EOF'
+  > CREATE TABLE t (
+  >     id INT PRIMARY KEY,
+  >     v TEXT NOT NULL
+  > );
+  > -- @get_t
+  > SELECT * FROM t WHERE id = @id;
+  > EOF
+
+  $ sqlgg -no-header -gen caml all.sql > plain.ml
+
+  $ sqlgg -no-header -gen caml -open all.sql all.sql > open_then_input.ml
+  $ diff plain.ml open_then_input.ml
+
+Repeating `-open` for the same file processes it only once.
+
+  $ sqlgg -no-header -gen caml -open all.sql -open all.sql all.sql > double_open.ml
+  $ diff plain.ml double_open.ml
+
+The file is recognized under a different spelling of the same path.
+
+  $ sqlgg -no-header -gen caml -open ./all.sql all.sql > spelled_open.ml
+  $ diff plain.ml spelled_open.ml
+
+`-open` only makes sense for code generation.
+
+  $ sqlgg -diff -open all.sql -base all.sql -target all.sql
+  -open is not supported with -diff/-migrate
+  [1]


### PR DESCRIPTION
-open parses the file at its position on the command line for its side
effects (schema, include:reuse queries) but emits no code, so shared
definitions can back several generated modules without duplication.
A file both -open'ed and given as an input is processed once, as a
regular input (files are identified by canonical path), which makes a
single command shape work for every file of a project - e.g. as a dune
dialect preprocessor, see test/cram/dune_dialect.t.

🤖 Generated with [Claude Code](https://claude.com/claude-code)