### PR TITLE
Add filename to the query meta info

### DIFF
--- a/impl/ocaml/sqlgg_query.ml
+++ b/impl/ocaml/sqlgg_query.ml
@@ -18,9 +18,10 @@ type t = {
   sql : string;
   name : string;
   kind : kind;
+  filename : string option;
 }
 
-let make ~sql ~name ~kind = { sql; name; kind }
+let make ?filename ~sql ~name ~kind () = { sql; name; kind; filename }
 
 let append_comment q comment = { q with sql = q.sql ^ " " ^ comment }
 

--- a/impl/ocaml/sqlgg_query.mli
+++ b/impl/ocaml/sqlgg_query.mli
@@ -18,9 +18,10 @@ type t = private {
   sql : string;
   name : string;
   kind : kind;
+  filename : string option;
 }
 
-val make : sql:string -> name:string -> kind:kind -> t
+val make : ?filename:string -> sql:string -> name:string -> kind:kind -> unit -> t
 
 (** https://google.github.io/sqlcommenter/spec/ *)
 module Sqlcommenter : sig

--- a/src/cli.ml
+++ b/src/cli.ml
@@ -87,10 +87,15 @@ let parse_output s =
   | "none" -> None
   | _ -> failwith (sprintf "Unknown output language: %s" s)
 
+let stamp_source filename stmts =
+  List.map (fun (stmt : Gen.stmt) -> { stmt with props = Props.set stmt.props "file" filename }) stmts
+
 (* parse always runs for its schema-registration side effects, even in -gen none *)
 let read_statements = function
   | "-" -> Main.get_statements stdin
-  | filename -> Main.with_channel filename (Option.map_default Main.get_statements [])
+  | filename ->
+    Main.with_channel filename (Option.map_default Main.get_statements [])
+    |> stamp_source (Filename.basename filename)
 
 let filter_stmts ~output stmts =
   match output with

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -284,8 +284,12 @@ let query_expr ~sql index stmt =
     | Stmt.Other -> "Sqlgg_traits.Query.Other"
   in
   let name = choose_name stmt.Gen.props stmt.Gen.kind index |> String.uncapitalize_ascii in
-  sprintf "(Sqlgg_traits.Query.make ~sql:%s ~name:%s ~kind:%s)"
-    sql (quote name) kind
+  let filename =
+    "file" |> Props.get stmt.Gen.props |>
+    Option.map_default (fun file -> sprintf "~filename:%s " (quote file)) ""
+  in
+  sprintf "(Sqlgg_traits.Query.make %s~sql:%s ~name:%s ~kind:%s ())"
+    filename sql (quote name) kind
 
 let is_single_row_select stmt =
   match stmt.Gen.kind, stmt.Gen.schema with

--- a/test/cram/create_type.t
+++ b/test/cram/create_type.t
@@ -10,20 +10,20 @@ CREATE TYPE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
   
     let create_shirt db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ()) T.no_params
   
     let select_2 db  callback =
       let invoke_callback stmt =
         callback
           ~id:(T.get_column_Int stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let drop_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ()) T.no_params
   
     module Fold = struct
       let select_2 db  callback acc =
@@ -32,7 +32,7 @@ CREATE TYPE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -44,7 +44,7 @@ CREATE TYPE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -89,23 +89,23 @@ CREATE DROP CREATE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
   
     let drop_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ()) T.no_params
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('black', 'white')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('black', 'white')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
   
     let create_shirt db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ()) T.no_params
   
     let select_4 db  callback =
       let invoke_callback stmt =
         callback
           ~id:(T.get_column_Int stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_4 db  callback acc =
@@ -114,7 +114,7 @@ CREATE DROP CREATE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -126,7 +126,7 @@ CREATE DROP CREATE
             ~id:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'black'") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)

--- a/test/cram/dynamic_subquery.t
+++ b/test/cram/dynamic_subquery.t
@@ -61,7 +61,7 @@ Full generated code:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -75,7 +75,7 @@ Full generated code:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -92,7 +92,7 @@ Full generated code:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT * FROM (SELECT " ^ col.column ^ " FROM products WHERE price > ?) AS sub") ~name:"products_dyn" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -135,7 +135,7 @@ Full generated code:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -149,7 +149,7 @@ Full generated code:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -166,7 +166,7 @@ Full generated code:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id, name, price FROM products) AS sub WHERE sub.id = ?") ~name:"cols_over_subq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -176,7 +176,7 @@ Full generated code:
   
   
     let create_products db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/enum_literals.compare.ml
+++ b/test/cram/enum_literals.compare.ml
@@ -17,7 +17,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   let create_test_status db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_status (\n\
   status ENUM('Failed','Skipped','Passed') NOT NULL\n\
-)") ~name:"create_test_status" ~kind:Sqlgg_traits.Query.(Create "test_status")) T.no_params
+)") ~name:"create_test_status" ~kind:Sqlgg_traits.Query.(Create "test_status") ()) T.no_params
 
   let test1 db ~status_list callback =
     let invoke_callback stmt =
@@ -28,16 +28,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match status_list with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let create_users db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
   id INT NOT NULL,\n\
   status ENUM('Active','Inactive','Pending') NOT NULL\n\
-)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let test2 db ~rows =
-    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"test2" ~kind:Sqlgg_traits.Query.(Insert "users")) T.no_params )
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"test2" ~kind:Sqlgg_traits.Query.(Insert "users") ()) T.no_params )
 
   module Fold = struct
     let test1 db ~status_list callback acc =
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -66,7 +66,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/json_functions.compare.ml
+++ b/test/cram/json_functions.compare.ml
@@ -6,19 +6,19 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") ~name:"create_people" ~kind:Sqlgg_traits.Query.(Create "people")) T.no_params
+)") ~name:"create_people" ~kind:Sqlgg_traits.Query.(Create "people") ()) T.no_params
 
   let create_people_data_json_kind_never_null_but_col_nullable db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") ~name:"create_people_data_json_kind_never_null_but_col_nullable" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_but_col_nullable")) T.no_params
+)") ~name:"create_people_data_json_kind_never_null_but_col_nullable" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_but_col_nullable") ()) T.no_params
 
   let create_people_data_json_kind_never_null_and_col_strict db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON NOT NULL\n\
-)") ~name:"create_people_data_json_kind_never_null_and_col_strict" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_and_col_strict")) T.no_params
+)") ~name:"create_people_data_json_kind_never_null_and_col_strict" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_and_col_strict") ()) T.no_params
 
   let one db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO people (data) VALUES\n\
@@ -43,7 +43,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   (JSON_OBJECT(\n\
     'name', NULL,\n\
     'age', NULL\n\
-  ))") ~name:"one" ~kind:Sqlgg_traits.Query.(Insert "people")) T.no_params
+  ))") ~name:"one" ~kind:Sqlgg_traits.Query.(Insert "people") ()) T.no_params
 
   let two db  callback =
     let invoke_callback stmt =
@@ -53,7 +53,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let three db  callback =
     let invoke_callback stmt =
@@ -64,7 +64,7 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two"
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let four db  callback =
     let invoke_callback stmt =
@@ -75,7 +75,7 @@ FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params i
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let five db  callback =
     let invoke_callback stmt =
@@ -86,7 +86,7 @@ FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlg
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   module Fold = struct
     let two db  callback acc =
@@ -98,7 +98,7 @@ FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let three db  callback acc =
@@ -111,7 +111,7 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two"
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let four db  callback acc =
@@ -124,7 +124,7 @@ FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let five db  callback acc =
@@ -137,7 +137,7 @@ FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlg
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -152,7 +152,7 @@ FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, JSON_EXTRACT(data, '$.name') AS name\n\
 FROM people\n\
-WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let three db  callback =
@@ -165,7 +165,7 @@ WHERE JSON_UNQUOTE(JSON_EXTRACT(data, '$.address.city')) = 'Paris'") ~name:"two"
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let four db  callback =
@@ -178,7 +178,7 @@ FROM people") ~name:"three" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let five db  callback =
@@ -191,7 +191,7 @@ FROM people_data_json_kind_never_null_but_col_nullable") ~name:"four" ~kind:Sqlg
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT\n\
   id,\n\
   JSON_SET(data, '$.active', TRUE) AS data_with_active\n\
-FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM people_data_json_kind_never_null_and_col_strict") ~name:"five" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/not_null_refine.compare.ml
+++ b/test/cram/not_null_refine.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL AND descr IS NOT NULL") ~name:"dynamic_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items WHERE name IS NOT NULL OR descr IS NOT NULL") ~name:"dynamic_or_stays_nullable" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -149,14 +149,14 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   id INT NOT NULL,\n\
   name TEXT NULL,\n\
   descr TEXT NULL\n\
-)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
 
   let static_not_null db  callback =
     let invoke_callback stmt =
       callback
         ~name:(T.get_column_Text stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   module Fold = struct
     let static_not_null db  callback acc =
@@ -165,7 +165,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -177,7 +177,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT name FROM items WHERE name IS NOT NULL") ~name:"static_not_null" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/registration_feedbacks.compare.ml
+++ b/test/cram/registration_feedbacks.compare.ml
@@ -8,7 +8,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   `user_message_2` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks")) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ()) T.no_params
 
   let test_name db ~id ~search =
     let get_row stmt =
@@ -40,7 +40,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     OR `user_message_2` = " ^ "?" ^ " \n\
     OR " ^ (match xs with [] -> "FALSE" | _ :: _ -> "`user_message_2` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal xs) ^ ")") ^ "\n\
     OR " ^ (match xss with `A _ -> " ( user_message_2 = ? ) " | `B _ -> " ( user_message_2 = ? ) ") ^ "\n\
- " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
+ " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one) ()) set_params get_row
 
   module Single = struct
     let test_name db ~id ~search callback =
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     OR `user_message_2` = " ^ "?" ^ " \n\
     OR " ^ (match xs with [] -> "FALSE" | _ :: _ -> "`user_message_2` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal xs) ^ ")") ^ "\n\
     OR " ^ (match xss with `A _ -> " ( user_message_2 = ? ) " | `B _ -> " ( user_message_2 = ? ) ") ^ "\n\
- " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params invoke_callback
+ " ^ " ) " | None -> " TRUE ")) ~name:"test_name" ~kind:Sqlgg_traits.Query.(Select Zero_one) ()) set_params invoke_callback
 
   end (* module Single *)
 end (* module Sqlgg *)

--- a/test/cram/reusable_queries_as_ctes.compare.ml
+++ b/test/cram/reusable_queries_as_ctes.compare.ml
@@ -6,7 +6,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE categories (\n\
     id SERIAL PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL\n\
-)") ~name:"create_categories" ~kind:Sqlgg_traits.Query.(Create "categories")) T.no_params
+)") ~name:"create_categories" ~kind:Sqlgg_traits.Query.(Create "categories") ()) T.no_params
 
   let create_products db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
@@ -15,7 +15,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     category_id INTEGER,\n\
     price NUMERIC(10, 2) NOT NULL,\n\
     FOREIGN KEY (category_id) REFERENCES categories(id)\n\
-)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
 
   let test2 db ~five ~param ~test ~test2 ~test5 callback =
     let invoke_callback stmt =
@@ -40,7 +40,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let test3 db ~five ~param ~test ~test2 ~test5 callback =
     let invoke_callback stmt =
@@ -65,7 +65,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let reuseme db  callback =
     let invoke_callback stmt =
@@ -82,7 +82,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let reuse_reusable db  callback =
     let invoke_callback stmt =
@@ -104,7 +104,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let test2 db ~five ~param ~test ~test2 ~test5 callback acc =
@@ -131,7 +131,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let test3 db ~five ~param ~test ~test2 ~test5 callback acc =
@@ -158,7 +158,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let reuseme db  callback acc =
@@ -177,7 +177,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x 
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let reuse_reusable db  callback acc =
@@ -201,7 +201,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -231,7 +231,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM x") ~name:"test2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let test3 db ~five ~param ~test ~test2 ~test5 callback =
@@ -258,7 +258,7 @@ FROM ( \n\
 ) AS x \n\
 WHERE " ^ (match param with `None -> " ( TRUE ) " | `Some -> " ( FALSE ) ") ^ ")\n\
 SELECT 1 + ? - ? + ? + x.y1 as y2\n\
-FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let reuseme db  callback =
@@ -277,7 +277,7 @@ FROM x") ~name:"test3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x 
     )\n\
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
-JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let reuse_reusable db  callback =
@@ -301,7 +301,7 @@ JOIN categories c ON inner_cte.category_id = c.id") ~name:"reuseme" ~kind:Sqlgg_
 SELECT inner_cte.*, c.name AS category_name\n\
 FROM inner_cte\n\
 JOIN categories c ON inner_cte.category_id = c.id)\n\
-SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT * FROM outer_cte") ~name:"reuse_reusable" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/reusable_queries_postgresql_params.t
+++ b/test/cram/reusable_queries_postgresql_params.t
@@ -42,7 +42,7 @@ PostgreSQL parameter numbering in reusable queries, distinct parameters:
   SELECT *\n\
   FROM \"user\"\n\
   JOIN person ON person.user_id = \"user\".id\n\
-  WHERE \"user\".id > $2") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  WHERE \"user\".id > $2") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
 PostgreSQL parameter numbering in reusable queries, shared parameter:
 
@@ -98,7 +98,7 @@ PostgreSQL parameter numbering in reusable queries, shared parameter:
   JOIN person ON person.user_id = \"user\".id\n\
   WHERE\n\
     username LIKE $3\n\
-    AND \"user\".id > $4") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    AND \"user\".id > $4") ~name:"get_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
 PostgreSQL parameter numbering with two reusable queries in one outer query:
 
@@ -138,7 +138,7 @@ PostgreSQL parameter numbering with two reusable queries in one outer query:
       T.select db (Sqlgg_traits.Query.make ~sql:("WITH p AS (SELECT * FROM person WHERE name LIKE $1), a AS (SELECT * FROM \"user\" WHERE username LIKE $2)\n\
   SELECT p.id, a.username\n\
   FROM p JOIN a ON a.id = p.user_id\n\
-  WHERE p.id > $3") ~name:"two_ctes" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  WHERE p.id > $3") ~name:"two_ctes" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
 PostgreSQL parameter numbering with reusable queries threaded into each other:
 
@@ -173,4 +173,4 @@ PostgreSQL parameter numbering with reusable queries threaded into each other:
       in
       T.select db (Sqlgg_traits.Query.make ~sql:("WITH p AS (WITH inner_p AS (SELECT * FROM person WHERE name LIKE $1)\n\
   SELECT * FROM inner_p WHERE inner_p.id > $2)\n\
-  SELECT * FROM p WHERE p.user_id > $3") ~name:"outer_q" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  SELECT * FROM p WHERE p.user_id > $3") ~name:"outer_q" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback

--- a/test/cram/set_default_syntax.compare.ml
+++ b/test/cram/set_default_syntax.compare.ml
@@ -8,7 +8,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),\n\
   `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks")) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ()) T.no_params
 
   let insert_registration_feedbacks_1 db ~user_message ~grant_types =
     let set_params stmt =
@@ -23,6 +23,6 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO `registration_feedbacks`\n\
 SET\n\
   `user_message` = " ^ (match user_message with Some _ -> " ( " ^ " CONCAT(" ^ "?" ^ ", '22222') " ^ " ) " | None -> " DEFAULT ") ^ ",\n\
-  `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> " ('2') " | `B -> " ('2') ") ^ " " ^ " ) " | None -> " DEFAULT ")) ~name:"insert_registration_feedbacks_1" ~kind:Sqlgg_traits.Query.(Insert "registration_feedbacks")) set_params
+  `grant_types` = " ^ (match grant_types with Some (grant_types) -> " ( " ^ " " ^ (match grant_types with `A -> " ('2') " | `B -> " ('2') ") ^ " " ^ " ) " | None -> " DEFAULT ")) ~name:"insert_registration_feedbacks_1" ~kind:Sqlgg_traits.Query.(Insert "registration_feedbacks") ()) set_params
 
 end (* module Sqlgg *)

--- a/test/cram/sqlcommenter.t
+++ b/test/cram/sqlcommenter.t
@@ -3,7 +3,7 @@ url encoded, pairs are sorted, and an empty list leaves the query untouched.
 Only [sql] changes, so [name] and [kind] stay usable after annotating.
 
   $ cat > sqlcommenter_test.ml <<'EOF'
-  > let q = Sqlgg_traits.Query.make ~sql:"SELECT id FROM users WHERE id = ?" ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)
+  > let q = Sqlgg_traits.Query.make ~sql:"SELECT id FROM users WHERE id = ?" ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat) ()
   > let show (q : Sqlgg_traits.Query.t) = Printf.printf "name=%s sql=%s\n" q.name q.sql
   > let () =
   >   show q;
@@ -32,12 +32,12 @@ behind the metadata is rejected, so the only way to change it is a helper.
   [2]
 
   $ cat > forge.ml <<'EOF'
-  > let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other }
+  > let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other; filename = None }
   > EOF
   $ ocamlfind ocamlc -package sqlgg.traits -c forge.ml
-  File "forge.ml", line 1, characters 14-114:
-  1 | let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other }
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "forge.ml", line 1, characters 14-131:
+  1 | let evil () = { Sqlgg_traits.Query.sql = "DROP TABLE users"; name = "find_user"; kind = Sqlgg_traits.Query.Other; filename = None }
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Error: Cannot create values of the private type Sqlgg_traits.Query.t
   [2]
 
@@ -77,7 +77,7 @@ Annotating twice appends a second comment instead of replacing the first, so a
 query that is already annotated should not be handed to another annotator.
 
   $ cat > twice.ml <<'EOF'
-  > let q = Sqlgg_traits.Query.make ~sql:"SELECT 1" ~name:"one" ~kind:Sqlgg_traits.Query.(Select One)
+  > let q = Sqlgg_traits.Query.make ~sql:"SELECT 1" ~name:"one" ~kind:Sqlgg_traits.Query.(Select One) ()
   > let () =
   >   let q = Sqlgg_traits.Query.Sqlcommenter.annotate [ "a", "1" ] q in
   >   let q = Sqlgg_traits.Query.Sqlcommenter.annotate [ "b", "2" ] q in

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -919,13 +919,13 @@ Test Single style for SELECT 1/0..1 and hide empty modules:
     module IO = Sqlgg_io.Blocking
   
     let create_test20250902 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") ~name:"create_test20250902" ~kind:Sqlgg_traits.Query.(Create "test20250902")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") ~name:"create_test20250902" ~kind:Sqlgg_traits.Query.(Create "test20250902") ()) T.no_params
   
     let select_1 db  =
       let get_row stmt =
         (T.get_column_Int stmt 0)
       in
-      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
   
     module Single = struct
       let select_1 db  callback =
@@ -933,7 +933,7 @@ Test Single style for SELECT 1/0..1 and hide empty modules:
           callback
             ~r:(T.get_column_Int stmt 0)
         in
-        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) FROM test20250902") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -973,7 +973,7 @@ Test non_nullifiable when update:
       name TEXT,\n\
           updated_at DATETIME NULL,\n\
       updated_at_not_nullable DATETIME NOT NULL\n\
-  )") ~name:"create_non_nullifiable" ~kind:Sqlgg_traits.Query.(Create "non_nullifiable")) T.no_params
+  )") ~name:"create_non_nullifiable" ~kind:Sqlgg_traits.Query.(Create "non_nullifiable") ()) T.no_params
   
     let update_non_nullifiable_1 db ~updated_at =
       let set_params stmt =
@@ -981,7 +981,7 @@ Test non_nullifiable when update:
         T.set_param_Datetime p updated_at;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE non_nullifiable SET updated_at = ? WHERE name = 'example'") ~name:"update_non_nullifiable_1" ~kind:Sqlgg_traits.Query.(Update (Some "non_nullifiable"))) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE non_nullifiable SET updated_at = ? WHERE name = 'example'") ~name:"update_non_nullifiable_1" ~kind:Sqlgg_traits.Query.(Update (Some "non_nullifiable")) ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1071,10 +1071,10 @@ Test non_nullifiable with multi-row INSERT (NULL allowed on insert):
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_insert_multi" ~kind:Sqlgg_traits.Query.(Create "nn_insert_multi")) T.no_params
+  )") ~name:"create_nn_insert_multi" ~kind:Sqlgg_traits.Query.(Create "nn_insert_multi") ()) T.no_params
   
     let insert_nn_insert_multi_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") ~name:"insert_nn_insert_multi_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_multi")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") ~name:"insert_nn_insert_multi_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_multi") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1125,7 +1125,7 @@ Test non_nullifiable with INSERT ... ON DUPLICATE KEY UPDATE (values nullable, N
       id INT PRIMARY KEY,\n\
           column1 INT NULL,\n\
           column2 VARCHAR(255) NULL\n\
-  )") ~name:"create_nn_upsert" ~kind:Sqlgg_traits.Query.(Create "nn_upsert")) T.no_params
+  )") ~name:"create_nn_upsert" ~kind:Sqlgg_traits.Query.(Create "nn_upsert") ()) T.no_params
   
     let insert_nn_upsert_1 db ~v1 ~v2 =
       let set_params stmt =
@@ -1138,7 +1138,7 @@ Test non_nullifiable with INSERT ... ON DUPLICATE KEY UPDATE (values nullable, N
   VALUES (1, ?, ?)\n\
   ON DUPLICATE KEY UPDATE \n\
     column1 = VALUES(column1),\n\
-    column2 = VALUES(column2)") ~name:"insert_nn_upsert_1" ~kind:Sqlgg_traits.Query.(Insert "nn_upsert")) set_params
+    column2 = VALUES(column2)") ~name:"insert_nn_upsert_1" ~kind:Sqlgg_traits.Query.(Insert "nn_upsert") ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1165,17 +1165,17 @@ Test non_nullifiable with INSERT ... SELECT (source may produce NULLs):
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_src (\n\
       id INT PRIMARY KEY,\n\
       ts DATETIME\n\
-  )") ~name:"create_nn_src" ~kind:Sqlgg_traits.Query.(Create "nn_src")) T.no_params
+  )") ~name:"create_nn_src" ~kind:Sqlgg_traits.Query.(Create "nn_src") ()) T.no_params
   
     let create_nn_dst db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_dst (\n\
       id INT PRIMARY KEY,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_dst" ~kind:Sqlgg_traits.Query.(Create "nn_dst")) T.no_params
+  )") ~name:"create_nn_dst" ~kind:Sqlgg_traits.Query.(Create "nn_dst") ()) T.no_params
   
     let insert_nn_dst_2 db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_dst (id, published_at)\n\
-  SELECT id, ts FROM nn_src") ~name:"insert_nn_dst_2" ~kind:Sqlgg_traits.Query.(Insert "nn_dst")) T.no_params
+  SELECT id, ts FROM nn_src") ~name:"insert_nn_dst_2" ~kind:Sqlgg_traits.Query.(Insert "nn_dst") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1198,10 +1198,10 @@ Test INSERT (.. ) VALUES @rows with non_nullifiable column (NULL allowed on inse
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_insert_param" ~kind:Sqlgg_traits.Query.(Create "nn_insert_param")) T.no_params
+  )") ~name:"create_nn_insert_param" ~kind:Sqlgg_traits.Query.(Create "nn_insert_param") ()) T.no_params
   
     let insert_nn_insert_param_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_nn_insert_param_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_param")) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_nn_insert_param_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_param") ()) T.no_params )
   
   end (* module Sqlgg *)
 
@@ -1215,10 +1215,10 @@ Test INSERT (..) VALUES @rows with columns whose names are OCaml keywords (must 
     module IO = Sqlgg_io.Blocking
   
     let create_kw_rows db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw_rows (type INTEGER, val TEXT)") ~name:"create_kw_rows" ~kind:Sqlgg_traits.Query.(Create "kw_rows")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw_rows (type INTEGER, val TEXT)") ~name:"create_kw_rows" ~kind:Sqlgg_traits.Query.(Create "kw_rows") ()) T.no_params
   
     let insert_kw_rows_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_kw_rows_1" ~kind:Sqlgg_traits.Query.(Insert "kw_rows")) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_kw_rows_1" ~kind:Sqlgg_traits.Query.(Insert "kw_rows") ()) T.no_params )
   
   end (* module Sqlgg *)
 
@@ -1352,10 +1352,10 @@ order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let update_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None) ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -1369,7 +1369,7 @@ parametrized order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let update_1 db ~order ~direction ~limit =
       let set_params stmt =
@@ -1377,7 +1377,7 @@ parametrized order by and limit are supported with update stmt + table alias:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY " ^ (match order with `Id -> " (t.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY " ^ (match order with `Id -> " (t.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None) ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1391,7 +1391,7 @@ limit is supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let update_1 db ~limit =
       let set_params stmt =
@@ -1399,7 +1399,7 @@ limit is supported with update stmt + table alias:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None)) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' LIMIT ?") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None) ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1414,10 +1414,10 @@ order by and limit are supported with update stmt + table alias + join:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let create_test2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") ~name:"create_test2" ~kind:Sqlgg_traits.Query.(Create "test2")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") ~name:"create_test2" ~kind:Sqlgg_traits.Query.(Create "test2") ()) T.no_params
   
     let update_2 db ~value ~order ~direction ~limit =
       let set_params stmt =
@@ -1427,7 +1427,7 @@ order by and limit are supported with update stmt + table alias + join:
         T.set_param_Int p limit;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t JOIN test2 t2 ON t.id = t2.test_id SET t.column_a = ?, t2.column_a = ? ORDER BY " ^ (match order with `Id_1 -> " (t.id) " | `Id_2 -> " (t2.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_2" ~kind:Sqlgg_traits.Query.(Update None)) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t JOIN test2 t2 ON t.id = t2.test_id SET t.column_a = ?, t2.column_a = ? ORDER BY " ^ (match order with `Id_1 -> " (t.id) " | `Id_2 -> " (t2.id) ") ^ " " ^ (match direction with `ASC -> "ASC" | `DESC -> "DESC") ^ " LIMIT ?") ~name:"update_2" ~kind:Sqlgg_traits.Query.(Update None) ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1471,14 +1471,14 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_1 DATE,\n\
       table_no INT\n\
-  )") ~name:"create_table_1_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_1_2025_09_26")) T.no_params
+  )") ~name:"create_table_1_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_1_2025_09_26") ()) T.no_params
   
     let create_table_2_2025_09_26 db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_2_2025_09_26 (\n\
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_2 DATE,\n\
       table_no INT\n\
-  )") ~name:"create_table_2_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_2_2025_09_26")) T.no_params
+  )") ~name:"create_table_2_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_2_2025_09_26") ()) T.no_params
   
     let select_2 db ~order_kind ~par callback =
       let invoke_callback stmt =
@@ -1510,7 +1510,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
   
     module Fold = struct
       let select_2 db ~order_kind ~par callback acc =
@@ -1544,7 +1544,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1581,7 +1581,7 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
   FROM table_1_2025_09_26 t1\n\
   JOIN table_2_2025_09_26 t2 ON t1.table_no = t2.table_no AND t1.id > ?\n\
   GROUP BY t1.table_no\n\
-  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  ORDER BY dates_from_t1") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1607,7 +1607,7 @@ INSERT ... SELECT with UNION ALL and enum meta propagation (short):
     let create_t_enum_union db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_union (\n\
       pending_type ENUM('downgrade','upgrade') NOT NULL\n\
-  )") ~name:"create_t_enum_union" ~kind:Sqlgg_traits.Query.(Create "t_enum_union")) T.no_params
+  )") ~name:"create_t_enum_union" ~kind:Sqlgg_traits.Query.(Create "t_enum_union") ()) T.no_params
   
     let insert_t_enum_union_1 db ~p =
       let set_params stmt =
@@ -1619,7 +1619,7 @@ INSERT ... SELECT with UNION ALL and enum meta propagation (short):
       T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t_enum_union (pending_type)\n\
   SELECT pending_type FROM t_enum_union WHERE pending_type = ?\n\
   UNION ALL\n\
-  SELECT ?") ~name:"insert_t_enum_union_1" ~kind:Sqlgg_traits.Query.(Insert "t_enum_union")) set_params
+  SELECT ?") ~name:"insert_t_enum_union_1" ~kind:Sqlgg_traits.Query.(Insert "t_enum_union") ()) set_params
   
   end (* module Sqlgg *)
   $ echo $?
@@ -1646,7 +1646,7 @@ INSERT ... SELECT with meta propagation:
     let create_t_dst db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_dst (\n\
     status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_dst" ~kind:Sqlgg_traits.Query.(Create "t_dst")) T.no_params
+  )") ~name:"create_t_dst" ~kind:Sqlgg_traits.Query.(Create "t_dst") ()) T.no_params
   
     let insert_t_dst_1 db ~s =
       let set_params stmt =
@@ -1655,7 +1655,7 @@ INSERT ... SELECT with meta propagation:
         T.finish_params p
       in
       T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t_dst (status)\n\
-  SELECT ?") ~name:"insert_t_dst_1" ~kind:Sqlgg_traits.Query.(Insert "t_dst")) set_params
+  SELECT ?") ~name:"insert_t_dst_1" ~kind:Sqlgg_traits.Query.(Insert "t_dst") ()) set_params
   
   end (* module Sqlgg *)
   $ echo $?
@@ -1717,7 +1717,7 @@ Test UINT64 mapping for UNSIGNED INT:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1727,7 +1727,7 @@ Test UINT64 mapping for UNSIGNED INT:
           ~calc_2:(T.get_column_Float_nullable stmt 2)
           ~v:(T.get_column_Int_nullable stmt 3)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1735,7 +1735,7 @@ Test UINT64 mapping for UNSIGNED INT:
         begin match id with None -> T.set_param_null p | Some v -> T.set_param_UInt64 p v end;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1") ()) set_params
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1747,7 +1747,7 @@ Test UINT64 mapping for UNSIGNED INT:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1762,7 +1762,7 @@ Test UINT64 mapping for UNSIGNED INT:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1786,7 +1786,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (\n\
    id BIGINT UNSIGNED,\n\
    v INT\n\
-  )") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
+  )") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1796,7 +1796,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
           ~calc_2:(T.get_column_Float_nullable stmt 2)
           ~v:(T.get_column_Int_nullable stmt 3)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1804,7 +1804,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
         begin match id with None -> T.set_param_null p | Some id -> T.set_param_uint64 p (Wrap_it.set_param id); end;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1") ()) set_params
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1816,7 +1816,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1831,7 +1831,7 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
             ~v:(T.get_column_Int_nullable stmt 3)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, id + 669 - 2 as id_with_calc, id / 2 + 300000 as calc_2, v FROM t1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1849,7 +1849,7 @@ Test UINT64 in type spec:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
   
     let insert_t1_1 db ~id =
       let set_params stmt =
@@ -1857,7 +1857,7 @@ Test UINT64 in type spec:
         T.set_param_UInt64 p id;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_1" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_1" ~kind:Sqlgg_traits.Query.(Insert "t1") ()) set_params
   
     let insert_t1_2 db ~id =
       let set_params stmt =
@@ -1865,7 +1865,7 @@ Test UINT64 in type spec:
         begin match id with None -> T.set_param_null p | Some v -> T.set_param_UInt64 p v end;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_2" ~kind:Sqlgg_traits.Query.(Insert "t1") ()) set_params
   
     let insert_t1_3 db ~id =
       let set_params stmt =
@@ -1873,7 +1873,7 @@ Test UINT64 in type spec:
         T.set_param_Int p id;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_3" ~kind:Sqlgg_traits.Query.(Insert "t1")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO t1 (id, v) VALUES (?, 123)") ~name:"insert_t1_3" ~kind:Sqlgg_traits.Query.(Insert "t1") ()) set_params
   
   end (* module Sqlgg *)
 
@@ -1893,14 +1893,14 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Enum_0.get_column stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1909,7 +1909,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1921,7 +1921,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1944,14 +1944,14 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Enum_0.get_column stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -1960,7 +1960,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -1972,7 +1972,7 @@ Enum generation without custom module (should generate open variants):
             ~status:(Enum_0.get_column stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum1") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -1995,14 +1995,14 @@ Enum generation with custom module (should not generate open variants, should us
     let create_t_enum2 db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2")) T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Custom.get_column (T.get_column_string stmt 0))
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2011,7 +2011,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2023,7 +2023,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2045,14 +2045,14 @@ Enum generation with custom module (should not generate open variants, should us
     let create_t_enum2 db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2")) T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~status:(Custom.get_column (T.get_column_string stmt 0))
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2061,7 +2061,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2073,7 +2073,7 @@ Enum generation with custom module (should not generate open variants, should us
             ~status:(Custom.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM t_enum2") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2105,7 +2105,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_mix (\n\
     col_a ENUM('a','b') NOT NULL,\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") ~name:"create_t_enum_mix" ~kind:Sqlgg_traits.Query.(Create "t_enum_mix")) T.no_params
+  )") ~name:"create_t_enum_mix" ~kind:Sqlgg_traits.Query.(Create "t_enum_mix") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2113,7 +2113,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
           ~col_a:(Enum_0.get_column stmt 0)
           ~col_b:(Custom.get_column (T.get_column_string stmt 1))
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2123,7 +2123,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
             ~col_b:(Custom.get_column (T.get_column_string stmt 1))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2136,7 +2136,7 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
             ~col_b:(Custom.get_column (T.get_column_string stmt 1))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_a, col_b FROM t_enum_mix") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2157,7 +2157,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
     let create_t_enum_tuple db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_tuple (\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") ~name:"create_t_enum_tuple" ~kind:Sqlgg_traits.Query.(Create "t_enum_tuple")) T.no_params
+  )") ~name:"create_t_enum_tuple" ~kind:Sqlgg_traits.Query.(Create "t_enum_tuple") ()) T.no_params
   
     let select_1 db ~vals callback =
       let invoke_callback stmt =
@@ -2168,7 +2168,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
         let p = T.start_params stmt (0 + (match vals with [] -> 0 | _ :: _ -> 0)) in
         T.finish_params p
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~vals callback acc =
@@ -2181,7 +2181,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2197,7 +2197,7 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col_b FROM t_enum_tuple WHERE " ^ (match vals with [] -> "FALSE" | _ :: _ -> "col_b IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Custom.set_param v)) vals) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2218,14 +2218,14 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
     let create_test_ifnull_enum db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_ifnull_enum (\n\
       priority ENUM('low','medium','high') NULL\n\
-  )") ~name:"create_test_ifnull_enum" ~kind:Sqlgg_traits.Query.(Create "test_ifnull_enum")) T.no_params
+  )") ~name:"create_test_ifnull_enum" ~kind:Sqlgg_traits.Query.(Create "test_ifnull_enum") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~r:(Priority.get_column (T.get_column_string stmt 0))
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2234,7 +2234,7 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
             ~r:(Priority.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2246,7 +2246,7 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
             ~r:(Priority.get_column (T.get_column_string stmt 0))
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT IFNULL(priority, 'medium') FROM test_ifnull_enum") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2267,7 +2267,7 @@ Test meta propagation: INSERT with Choices should propagate ENUM metadata to cho
     let create_test_insert_choices db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_insert_choices (\n\
       status ENUM('pending','completed') NOT NULL\n\
-  )") ~name:"create_test_insert_choices" ~kind:Sqlgg_traits.Query.(Create "test_insert_choices")) T.no_params
+  )") ~name:"create_test_insert_choices" ~kind:Sqlgg_traits.Query.(Create "test_insert_choices") ()) T.no_params
   
     let insert_test_insert_choices_1 db ~x =
       let set_params stmt =
@@ -2279,7 +2279,7 @@ Test meta propagation: INSERT with Choices should propagate ENUM metadata to cho
         end;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_insert_choices SET status = " ^ (match x with `Set _ -> " ( ? ) " | `Default -> " ( 'pending' ) ")) ~name:"insert_test_insert_choices_1" ~kind:Sqlgg_traits.Query.(Insert "test_insert_choices")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_insert_choices SET status = " ^ (match x with `Set _ -> " ( ? ) " | `Default -> " ( 'pending' ) ")) ~name:"insert_test_insert_choices_1" ~kind:Sqlgg_traits.Query.(Insert "test_insert_choices") ()) set_params
   
   end (* module Sqlgg *)
 
@@ -2296,7 +2296,7 @@ Test FloatingLiteral:
         (T.get_column_Float stmt 0)
       in
       T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT 1.2\n\
-  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
   
     module Single = struct
       let select_0 db  callback =
@@ -2305,7 +2305,7 @@ Test FloatingLiteral:
             ~r:(T.get_column_Float stmt 0)
         in
         T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT 1.2\n\
-  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+  ") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -2327,7 +2327,7 @@ Test numeric literals and decimal types:
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shop_items (\n\
    id INT PRIMARY KEY,\n\
    pending_price DECIMAL(12,3)\n\
-  )") ~name:"create_shop_items" ~kind:Sqlgg_traits.Query.(Create "shop_items")) T.no_params
+  )") ~name:"create_shop_items" ~kind:Sqlgg_traits.Query.(Create "shop_items") ()) T.no_params
   
     let select_1 db ~pending_price callback =
       let invoke_callback stmt =
@@ -2341,7 +2341,7 @@ Test numeric literals and decimal types:
         T.finish_params p
       in
       T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~pending_price callback acc =
@@ -2357,7 +2357,7 @@ Test numeric literals and decimal types:
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2376,7 +2376,7 @@ Test numeric literals and decimal types:
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM shop_items si\n\
-  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  WHERE si.pending_price <=> NULLIF(CAST(? + 0.0 AS DECIMAL(12, 3)), CAST(-1 AS DECIMAL))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2392,10 +2392,10 @@ Test numeric literal to float:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2409,10 +2409,10 @@ Test numeric literal to decimal - valid:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2435,10 +2435,10 @@ Test numeric literal to decimal - invalid (too many decimals):
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.999)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.999)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2470,7 +2470,7 @@ Test decimal to float - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2478,7 +2478,7 @@ Test decimal to float - allowed:
           ~price:(T.get_column_Decimal_nullable stmt 0)
           ~price_float:(T.get_column_Float_nullable stmt 1)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2488,7 +2488,7 @@ Test decimal to float - allowed:
             ~price_float:(T.get_column_Float_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2501,7 +2501,7 @@ Test decimal to float - allowed:
             ~price_float:(T.get_column_Float_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price_float = CAST(price AS FLOAT)") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2517,10 +2517,10 @@ Test int to decimal - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (100)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (100)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2535,17 +2535,17 @@ Test decimal arithmetic preserves scale:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (col1 DECIMAL(10,2))") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (col1 DECIMAL(10,2))") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
   
     let create_t2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t2 (col2 DECIMAL(12,3))") ~name:"create_t2" ~kind:Sqlgg_traits.Query.(Create "t2")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t2 (col2 DECIMAL(12,3))") ~name:"create_t2" ~kind:Sqlgg_traits.Query.(Create "t2") ()) T.no_params
   
     let select_2 db  callback =
       let invoke_callback stmt =
         callback
           ~total:(T.get_column_Decimal_nullable stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_2 db  callback acc =
@@ -2554,7 +2554,7 @@ Test decimal arithmetic preserves scale:
             ~total:(T.get_column_Decimal_nullable stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2566,7 +2566,7 @@ Test decimal arithmetic preserves scale:
             ~total:(T.get_column_Decimal_nullable stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT col1 + col2 as total FROM t1, t2") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2582,7 +2582,7 @@ Test parameter with decimal cast:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(12,3))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(12,3))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     let select_1 db ~price callback =
       let invoke_callback stmt =
@@ -2594,7 +2594,7 @@ Test parameter with decimal cast:
         T.set_param_Any p price;
         T.finish_params p
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
   
     module Fold = struct
       let select_1 db ~price callback acc =
@@ -2608,7 +2608,7 @@ Test parameter with decimal cast:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2625,7 +2625,7 @@ Test parameter with decimal cast:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM items WHERE price <=> CAST(? AS DECIMAL(12,3))") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2641,10 +2641,10 @@ Test REPLACE function for string substitution:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ()) T.no_params
   
     let update_table_24_10_2025_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") ~name:"update_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Update (Some "table_24_10_2025"))) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") ~name:"update_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Update (Some "table_24_10_2025")) ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -2658,7 +2658,7 @@ Test REPLACE function with INSERT REPLACE in same query:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ()) T.no_params
   
     let insert_table_24_10_2025_1 db ~value =
       let set_params stmt =
@@ -2666,7 +2666,7 @@ Test REPLACE function with INSERT REPLACE in same query:
         T.set_param_Text p value;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("REPLACE INTO table_24_10_2025 (col_1, col_2) VALUES (REPLACE(?, ',', ' '), 'data')") ~name:"insert_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Insert "table_24_10_2025")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("REPLACE INTO table_24_10_2025 (col_1, col_2) VALUES (REPLACE(?, ',', ' '), 'data')") ~name:"insert_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Insert "table_24_10_2025") ()) set_params
   
   end (* module Sqlgg *)
 
@@ -2693,7 +2693,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
     counter INT(10) UNSIGNED NOT NULL,\n\
     counter2 BIGINT(10) UNSIGNED NOT NULL DEFAULT 0,\n\
     name TEXT\n\
-  )") ~name:"create_test_table" ~kind:Sqlgg_traits.Query.(Create "test_table")) T.no_params
+  )") ~name:"create_test_table" ~kind:Sqlgg_traits.Query.(Create "test_table") ()) T.no_params
   
     let select_1 db ~id callback =
       let invoke_callback stmt =
@@ -2708,7 +2708,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         T.set_param_uint64 p (TestModule.set_param id);
         T.finish_params p
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
   
     let insert_test_table_2 db ~id ~counter ~counter2 ~name =
       let set_params stmt =
@@ -2719,7 +2719,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         begin match name with None -> T.set_param_null p | Some v -> T.set_param_Text p v end;
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_table (id, counter, counter2, name) VALUES (?, ?, ?, ?)") ~name:"insert_test_table_2" ~kind:Sqlgg_traits.Query.(Insert "test_table")) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO test_table (id, counter, counter2, name) VALUES (?, ?, ?, ?)") ~name:"insert_test_table_2" ~kind:Sqlgg_traits.Query.(Insert "test_table") ()) set_params
   
     let update_test_table_3 db ~counter ~counter2 ~name ~id =
       let set_params stmt =
@@ -2730,7 +2730,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
         T.set_param_uint64 p (TestModule.set_param id);
         T.finish_params p
       in
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test_table SET counter = ?, counter2 = ?, name = ? WHERE id = ?") ~name:"update_test_table_3" ~kind:Sqlgg_traits.Query.(Update (Some "test_table"))) set_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test_table SET counter = ?, counter2 = ?, name = ? WHERE id = ?") ~name:"update_test_table_3" ~kind:Sqlgg_traits.Query.(Update (Some "test_table")) ()) set_params
   
     module Fold = struct
       let select_1 db ~id callback acc =
@@ -2747,7 +2747,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
           T.finish_params p
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -2767,7 +2767,7 @@ Test BIGINT(20) UNSIGNED with module annotation:
           T.finish_params p
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, counter, counter2, name FROM test_table WHERE id = ?") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -2841,7 +2841,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     quantity INT NOT NULL,\n\
     price DECIMAL(10,2) NOT NULL,\n\
     description TEXT\n\
-  )") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
+  )") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2853,7 +2853,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_2 db  callback =
       let invoke_callback stmt =
@@ -2865,7 +2865,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_3 db  callback =
       let invoke_callback stmt =
@@ -2877,7 +2877,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_4 db  callback =
       let invoke_callback stmt =
@@ -2889,7 +2889,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_5 db  callback =
       let invoke_callback stmt =
@@ -2901,7 +2901,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_6 db  callback =
       let invoke_callback stmt =
@@ -2913,7 +2913,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_7 db  callback =
       let invoke_callback stmt =
@@ -2925,7 +2925,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_8 db  callback =
       let invoke_callback stmt =
@@ -2937,7 +2937,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let select_9 db  callback =
       let invoke_callback stmt =
@@ -2949,7 +2949,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -2963,7 +2963,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_2 db  callback acc =
@@ -2977,7 +2977,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_3 db  callback acc =
@@ -2991,7 +2991,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_4 db  callback acc =
@@ -3005,7 +3005,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_5 db  callback acc =
@@ -3019,7 +3019,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_6 db  callback acc =
@@ -3033,7 +3033,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_7 db  callback acc =
@@ -3047,7 +3047,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_8 db  callback acc =
@@ -3061,7 +3061,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
       let select_9 db  callback acc =
@@ -3075,7 +3075,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3092,7 +3092,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(product, ':', quantity) as products_with_qty\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_2 db  callback =
@@ -3106,7 +3106,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     GROUP_CONCAT(DISTINCT product, ':', quantity ORDER BY product) as unique_combos\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_3 db  callback =
@@ -3120,7 +3120,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product) as products_json\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_4 db  callback =
@@ -3134,7 +3134,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product) as unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_4" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_5 db  callback =
@@ -3148,7 +3148,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC) as products_by_price\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_5" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_6 db  callback =
@@ -3162,7 +3162,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(DISTINCT product ORDER BY product ASC) as sorted_unique_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_6" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_7 db  callback =
@@ -3176,7 +3176,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(product ORDER BY price DESC LIMIT 3) as top_3_products\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_7" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_8 db  callback =
@@ -3190,7 +3190,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description) as descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_8" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
       let select_9 db  callback =
@@ -3204,7 +3204,7 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     customer_id,\n\
     JSON_ARRAYAGG(description ORDER BY id) as ordered_descriptions\n\
   FROM orders\n\
-  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  GROUP BY customer_id") ~name:"select_9" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3223,14 +3223,14 @@ Test test date functions that are both expressions and functions:
       let get_row stmt =
         (T.get_column_Datetime stmt 0), (T.get_column_Datetime stmt 1), (T.get_column_Datetime stmt 2)
       in
-      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
   
     let select_1 db  =
       let get_row stmt =
         (T.get_column_Int stmt 0)
       in
       T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT DAY(CURRENT_DATE)\n\
-  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
   
     module Single = struct
       let select_0 db  callback =
@@ -3240,7 +3240,7 @@ Test test date functions that are both expressions and functions:
             ~r0:(T.get_column_Datetime stmt 1)
             ~r1:(T.get_column_Datetime stmt 2)
         in
-        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+        T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT CURRENT_DATE(), CURRENT_TIME(), CURRENT_TIMESTAMP()") ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
   
       let select_1 db  callback =
         let invoke_callback stmt =
@@ -3248,7 +3248,7 @@ Test test date functions that are both expressions and functions:
             ~r:(T.get_column_Int stmt 0)
         in
         T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT DAY(CURRENT_DATE)\n\
-  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+  ") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
   
     end (* module Single *)
   end (* module Sqlgg *)
@@ -3273,17 +3273,17 @@ Test DEFAULT dialect feature valid for mysql:
     let create_ok_ts_interval db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_interval (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") ~name:"create_ok_ts_interval" ~kind:Sqlgg_traits.Query.(Create "ok_ts_interval")) T.no_params
+  )") ~name:"create_ok_ts_interval" ~kind:Sqlgg_traits.Query.(Create "ok_ts_interval") ()) T.no_params
   
     let create_ok_ts_func db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_func (\n\
     ts DATETIME DEFAULT (DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 DAY))\n\
-  )") ~name:"create_ok_ts_func" ~kind:Sqlgg_traits.Query.(Create "ok_ts_func")) T.no_params
+  )") ~name:"create_ok_ts_func" ~kind:Sqlgg_traits.Query.(Create "ok_ts_func") ()) T.no_params
   
     let create_ok_tidb_ts db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3321,7 +3321,7 @@ Test DEFAULT dialect feature valid for tidb:
     let create_ok_tidb_ts db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3348,7 +3348,7 @@ Test DEFAULT dialect feature valid for sqlite:
     let create_ok_tidb_ts db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts")) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3367,7 +3367,7 @@ Test DEFAULT dialect feature valid json for tidb:
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t4 (\n\
     id bigint PRIMARY KEY,\n\
     j json DEFAULT (JSON_OBJECT(\"a\", 1, \"b\", 2))\n\
-  )") ~name:"create_t4" ~kind:Sqlgg_traits.Query.(Create "t4")) T.no_params
+  )") ~name:"create_t4" ~kind:Sqlgg_traits.Query.(Create "t4") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3396,7 +3396,7 @@ Test DEFAULT dialect feature valid json for tidb:
     let create_user_status db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE user_status (\n\
    status ENUM('active', 'inactive', 'banned') NOT NULL DEFAULT 'active'\n\
-  )") ~name:"create_user_status" ~kind:Sqlgg_traits.Query.(Create "user_status")) T.no_params
+  )") ~name:"create_user_status" ~kind:Sqlgg_traits.Query.(Create "user_status") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3414,7 +3414,7 @@ Test DEFAULT dialect feature valid json for tidb:
     let create_tbl db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE tbl (\n\
    f1 INT NOT NULL DEFAULT 1\n\
-  )") ~name:"create_tbl" ~kind:Sqlgg_traits.Query.(Create "tbl")) T.no_params
+  )") ~name:"create_tbl" ~kind:Sqlgg_traits.Query.(Create "tbl") ()) T.no_params
   
   end (* module Sqlgg *)
 
@@ -3439,7 +3439,7 @@ Test IS NOT NULL type refinement:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3447,7 +3447,7 @@ Test IS NOT NULL type refinement:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text stmt 1)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3457,7 +3457,7 @@ Test IS NOT NULL type refinement:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3470,7 +3470,7 @@ Test IS NOT NULL type refinement:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3486,7 +3486,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3494,7 +3494,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text stmt 1)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3504,7 +3504,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3517,7 +3517,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
             ~name:(T.get_column_Text stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NOT NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3533,7 +3533,7 @@ Test IS NOT NULL type refinement with IS NULL:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3541,7 +3541,7 @@ Test IS NOT NULL type refinement with IS NULL:
           ~str:(T.get_column_Text_nullable stmt 0)
           ~name:(T.get_column_Text_nullable stmt 1)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -3551,7 +3551,7 @@ Test IS NOT NULL type refinement with IS NULL:
             ~name:(T.get_column_Text_nullable stmt 1)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -3564,7 +3564,7 @@ Test IS NOT NULL type refinement with IS NULL:
             ~name:(T.get_column_Text_nullable stmt 1)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT str, name FROM test WHERE name IS NULL") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)
@@ -3594,7 +3594,7 @@ independently, so precedence is protected at each depth:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'WHERE FALSE AND' | head -1
   > SELECT 1 WHERE FALSE AND @a { Outer { @b { P { TRUE } | Q { FALSE OR TRUE } } } | Other { 1 = 1 } };
   > EOF
-      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match a with `Outer (b) -> " ( " ^ (match b with `P -> " ( TRUE ) " | `Q -> " ( FALSE OR TRUE ) ") ^ " ) " | `Other -> " ( 1 = 1 ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match a with `Outer (b) -> " ( " ^ (match b with `P -> " ( TRUE ) " | `Q -> " ( FALSE OR TRUE ) ") ^ " ) " | `Other -> " ( 1 = 1 ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one) ()) set_params get_row
 
 Composite: a choice branch with bound params and a compound AND body is wrapped
 as a whole:
@@ -3602,7 +3602,7 @@ as a whole:
   > CREATE TABLE t (a INT, b INT, c INT);
   > SELECT a FROM t WHERE TRUE OR @b { S { a = @p AND b = @q } | T { c > @r } };
   > EOF
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE TRUE OR " ^ (match b with `S _ -> " ( a = ? AND b = ? ) " | `T _ -> " ( c > ? ) ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE TRUE OR " ^ (match b with `S _ -> " ( a = ? AND b = ? ) " | `T _ -> " ( c > ? ) ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
 Composite: a bool-choice ({...}?) whose body itself contains a nested choice —
 the bool-choice wraps the active branch and the inner choice wraps each branch:
@@ -3610,19 +3610,19 @@ the bool-choice wraps the active branch and the inner choice wraps each branch:
   > CREATE TABLE t (a INT, b INT);
   > SELECT a FROM t WHERE FALSE AND { a = @v OR @c { A { b = 1 } | B { b = 2 } } }?;
   > EOF
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE FALSE AND " ^ (match v with Some (_, c) -> " ( " ^ " a = " ^ "?" ^ " OR " ^ (match c with `A -> " ( b = 1 ) " | `B -> " ( b = 2 ) ") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT a FROM t WHERE FALSE AND " ^ (match v with Some (_, c) -> " ( " ^ " a = " ^ "?" ^ " OR " ^ (match c with `A -> " ( b = 1 ) " | `B -> " ( b = 2 ) ") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
 PoC: without hand-written parentheses, the branch body is grouped correctly as
 FALSE AND ( FALSE OR TRUE ) instead of leaking into FALSE AND FALSE OR TRUE:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'SELECT 1 WHERE' | head -1
   > SELECT 1 WHERE FALSE AND @b { None { TRUE } | Some { FALSE OR TRUE } };
   > EOF
-      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( FALSE OR TRUE ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( FALSE OR TRUE ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one) ()) set_params get_row
 
 PoC: hand-written parentheses are now redundant — same semantics, just an extra
 harmless pair:
   $ sqlgg -gen caml -params unnamed -no-header - <<'EOF' 2>&1 | grep -F 'SELECT 1 WHERE' | head -1
   > SELECT 1 WHERE FALSE AND @b { None { TRUE } | Some { (FALSE OR TRUE) } };
   > EOF
-      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( (FALSE OR TRUE) ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one)) set_params get_row
+      T.select_one_maybe db (Sqlgg_traits.Query.make ~sql:("SELECT 1 WHERE FALSE AND " ^ (match b with `None -> " ( TRUE ) " | `Some -> " ( (FALSE OR TRUE) ) ")) ~name:"select_0" ~kind:Sqlgg_traits.Query.(Select Zero_one) ()) set_params get_row
 

--- a/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"ok" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -133,7 +133,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -150,7 +150,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN orders o ON o.user_id = u.id WHERE u.id = ?") ~name:"nonuniq" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -193,7 +193,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -207,7 +207,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -224,7 +224,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE p.bio = ?") ~name:"ref_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -234,13 +234,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_orders db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
+++ b/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.profile_id = p.id WHERE u.id = ?") ~name:"chain_bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -86,13 +86,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ " WHERE u.id = ?") ~name:"chain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -137,7 +137,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -151,7 +151,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -168,7 +168,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = a.badge_id" else "") ^ " WHERE u.id = ?") ~name:"chain3" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -220,7 +220,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -234,7 +234,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -251,7 +251,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = p.avatar_id" else "") ^ (if List.mem Badges col.deps then " LEFT JOIN badges b ON b.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"diamond" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -312,7 +312,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -326,7 +326,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -343,7 +343,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = p.avatar_id LEFT JOIN badges b ON b.id = a.badge_id WHERE b.label = ?") ~name:"chain_pinned" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -353,16 +353,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
 
   let create_badges db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") ~name:"create_badges" ~kind:Sqlgg_traits.Query.(Create "badges")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") ~name:"create_badges" ~kind:Sqlgg_traits.Query.(Create "badges") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/example.t/example.compare.ml
+++ b/test/cram/test_build_dynamic_join/example.t/example.compare.ml
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -135,7 +135,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -154,7 +154,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing  b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -171,7 +171,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
   email TEXT NOT NULL,\n\
   created_at TIMESTAMP NOT NULL,\n\
   deleted BOOLEAN NOT NULL\n\
-)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (\n\
@@ -180,7 +180,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
   avatar_url TEXT,\n\
   location TEXT,\n\
   website TEXT\n\
-)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_billing db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (\n\
@@ -188,7 +188,7 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
   plan TEXT NOT NULL,\n\
   paid_until DATETIME,\n\
   balance INT NOT NULL\n\
-)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing")) T.no_params
+)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"inner_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p USING (user_id) WHERE u.id = ?") ~name:"join_using" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u NATURAL LEFT JOIN profiles p WHERE u.id = ?") ~name:"join_natural" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -267,7 +267,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -281,7 +281,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -298,7 +298,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id JOIN orders o USING (bio) WHERE u.id = ?") ~name:"using_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -350,7 +350,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -364,7 +364,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -381,7 +381,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id NATURAL JOIN orders o WHERE u.id = ?") ~name:"natural_after_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -424,7 +424,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -438,7 +438,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -455,7 +455,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u RIGHT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"right_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -498,7 +498,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -512,7 +512,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -529,7 +529,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u, profiles p WHERE u.id = ?") ~name:"comma_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -581,7 +581,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -595,7 +595,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -612,7 +612,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u JOIN shipments s USING (user_id)" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"implicit_before_candidate" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -622,16 +622,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_orders db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (bio TEXT, amount INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (bio TEXT, amount INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
 
   let create_shipments db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shipments (user_id INT, status TEXT)") ~name:"create_shipments" ~kind:Sqlgg_traits.Query.(Create "shipments")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shipments (user_id INT, status TEXT)") ~name:"create_shipments" ~kind:Sqlgg_traits.Query.(Create "shipments") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Accounts col.deps then " LEFT JOIN accounts a ON a.email = u.email" else "") ^ " WHERE u.id = ?") ~name:"unique_key" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN memberships m ON m.org = u.org WHERE u.id = ?") ~name:"composite_partial" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Memberships col.deps then " LEFT JOIN memberships m ON m.org = u.org AND m.dept = u.dept" else "") ^ " WHERE u.id = ?") ~name:"composite_full" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -225,13 +225,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_accounts db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
 
   let create_memberships db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") ~name:"create_memberships" ~kind:Sqlgg_traits.Query.(Create "memberships")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") ~name:"create_memberships" ~kind:Sqlgg_traits.Query.(Create "memberships") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
+++ b/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
@@ -45,7 +45,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -59,7 +59,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -76,7 +76,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Avatars col.deps then " LEFT JOIN avatars a ON a.id = u.id" else "") ^ " WHERE u.id = ?") ~name:"two_indep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -128,7 +128,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -142,7 +142,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -159,7 +159,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id LEFT JOIN avatars a ON a.id = (SELECT MAX(id) FROM avatars) WHERE u.id = ?") ~name:"subq_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -211,7 +211,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -225,7 +225,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -242,7 +242,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles_p1 col.deps then " LEFT JOIN profiles p1 ON p1.user_id = u.id" else "") ^ (if List.mem Profiles_p2 col.deps then " LEFT JOIN profiles p2 ON p2.user_id = u.mentor_id" else "") ^ " WHERE u.id = ?") ~name:"same_twice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -252,13 +252,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
@@ -37,7 +37,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -52,7 +52,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -70,7 +70,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = ? WHERE u.id = ?") ~name:"param_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -113,7 +113,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -127,7 +127,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -144,7 +144,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id AND p.bio = 'x'" else "") ^ " WHERE u.id = ?") ~name:"extra_const_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -187,7 +187,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -201,7 +201,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -218,7 +218,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id > u.id WHERE u.id = ?") ~name:"on_inequality" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -261,7 +261,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -275,7 +275,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -292,7 +292,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles ON profiles.user_id = u.id" else "") ^ " WHERE u.id = ?") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -335,7 +335,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -349,7 +349,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -366,7 +366,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON u.id = p.user_id" else "") ^ " WHERE u.id = ?") ~name:"flipped_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -409,7 +409,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -423,7 +423,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -440,7 +440,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = 5" else "") ^ " WHERE u.id = ?") ~name:"const_key_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -483,7 +483,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -497,7 +497,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -514,7 +514,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id OR p.user_id = 0 WHERE u.id = ?") ~name:"or_in_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -557,7 +557,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -571,7 +571,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -588,7 +588,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = (SELECT MAX(id) FROM users) WHERE u.id = ?") ~name:"subq_own_on" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -598,10 +598,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY p.bio") ~name:"ref_in_group" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id ORDER BY p.bio") ~name:"ref_in_order" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -177,7 +177,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -190,7 +190,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -206,7 +206,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id GROUP BY u.id HAVING MAX(p.user_id) > 0") ~name:"ref_in_having" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -249,7 +249,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -263,7 +263,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -280,7 +280,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"complex_proj" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -322,7 +322,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -335,7 +335,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -351,7 +351,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id IN (SELECT user_id FROM profiles)") ~name:"subq_in_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -393,7 +393,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -406,7 +406,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -422,7 +422,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE bio = 'x'") ~name:"unqualified_where" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -465,7 +465,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -479,7 +479,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -496,7 +496,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN profiles p ON p.user_id = u.id WHERE u.id = ?") ~name:"join_unreferenced" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -506,10 +506,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
+++ b/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
@@ -35,7 +35,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -48,7 +48,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -64,7 +64,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1 LEFT JOIN users u2 ON u2.manager_id = u1.id") ~name:"bad" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -106,7 +106,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -119,7 +119,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -135,7 +135,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u1" ^ (if List.mem Users col.deps then " LEFT JOIN users u2 ON u2.id = u1.manager_id" else "")) ~name:"good" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -145,7 +145,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
+++ b/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"join_subq_source" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -110,7 +110,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -124,7 +124,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -141,7 +141,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT p.user_id, p.bio FROM profiles p, users x) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_join_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -198,7 +198,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -215,7 +215,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users u LEFT JOIN (SELECT user_id, bio FROM profiles UNION ALL SELECT user_id, bio FROM profiles) s ON s.user_id = u.id WHERE u.id = ?") ~name:"subq_union_dup" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -257,7 +257,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -270,7 +270,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -286,7 +286,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM (SELECT id FROM users) s" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = s.id" else "")) ~name:"subq_base_join" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -296,10 +296,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
+++ b/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
@@ -56,7 +56,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -72,7 +72,7 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_t
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -91,7 +91,7 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_t
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM users u" ^ (if List.mem Profiles col.deps then " LEFT JOIN profiles p ON p.user_id = u.id" else "") ^ (if List.mem Billing col.deps then " LEFT JOIN billing b ON b.user_id = u.id" else "") ^ "\n\
-WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -101,13 +101,13 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_t
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
 
   let create_billing db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_cached_prepared_stmts.ml
+++ b/test/cram/test_cached_prepared_stmts.ml
@@ -27,7 +27,7 @@ module Small_Cache = Sqlgg_stmt_cache.Make(Small_Cache_Config)(Print_impl)
 module Medium_Cache = Sqlgg_stmt_cache.Make(Medium_Cache_Config)(Print_impl)
 module Large_Cache = Sqlgg_stmt_cache.Make(Large_Cache_Config)(Print_impl)
 
-let q sql = Sqlgg_traits.Query.make ~sql ~name:"test" ~kind:Sqlgg_traits.Query.(Select Nat)
+let q sql = Sqlgg_traits.Query.make ~sql ~name:"test" ~kind:Sqlgg_traits.Query.(Select Nat) ()
 
 let setup_mock_responses n =
   for i = 1 to n do

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -464,7 +464,7 @@ Test DynamicSelect edge: single column:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -477,7 +477,7 @@ Test DynamicSelect edge: single column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -493,7 +493,7 @@ Test DynamicSelect edge: single column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"single_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -503,7 +503,7 @@ Test DynamicSelect edge: single column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -556,7 +556,7 @@ DynamicSelect: SELECT * remains static select:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -569,7 +569,7 @@ DynamicSelect: SELECT * remains static select:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -585,7 +585,7 @@ DynamicSelect: SELECT * remains static select:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -595,7 +595,7 @@ DynamicSelect: SELECT * remains static select:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -657,7 +657,7 @@ DynamicSelect: SELECT * with expression in same list:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -670,7 +670,7 @@ DynamicSelect: SELECT * with expression in same list:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -686,7 +686,7 @@ DynamicSelect: SELECT * with expression in same list:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"all_cols_plus_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -696,7 +696,7 @@ DynamicSelect: SELECT * with expression in same list:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -758,7 +758,7 @@ DynamicSelect: auto names for expressions without alias:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -771,7 +771,7 @@ DynamicSelect: auto names for expressions without alias:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -787,7 +787,7 @@ DynamicSelect: auto names for expressions without alias:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"auto_names" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -797,7 +797,7 @@ DynamicSelect: auto names for expressions without alias:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -841,7 +841,7 @@ Test DynamicSelect edge: expression at first position:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -854,7 +854,7 @@ Test DynamicSelect edge: expression at first position:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -870,7 +870,7 @@ Test DynamicSelect edge: expression at first position:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"expr_first" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -880,7 +880,7 @@ Test DynamicSelect edge: expression at first position:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -933,7 +933,7 @@ Test DynamicSelect edge: literal only:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -946,7 +946,7 @@ Test DynamicSelect edge: literal only:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -962,7 +962,7 @@ Test DynamicSelect edge: literal only:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"literal_only" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -972,7 +972,7 @@ Test DynamicSelect edge: literal only:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1052,7 +1052,7 @@ Test DynamicSelect edge: many columns:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1065,7 +1065,7 @@ Test DynamicSelect edge: many columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1081,7 +1081,7 @@ Test DynamicSelect edge: many columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"many_cols" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1091,7 +1091,7 @@ Test DynamicSelect edge: many columns:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1153,7 +1153,7 @@ Test DynamicSelect edge: no space after commas:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1166,7 +1166,7 @@ Test DynamicSelect edge: no space after commas:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1182,7 +1182,7 @@ Test DynamicSelect edge: no space after commas:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_space" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1192,7 +1192,7 @@ Test DynamicSelect edge: no space after commas:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1245,7 +1245,7 @@ Test DynamicSelect edge: minimal spacing:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1258,7 +1258,7 @@ Test DynamicSelect edge: minimal spacing:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1274,7 +1274,7 @@ Test DynamicSelect edge: minimal spacing:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tight" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1284,7 +1284,7 @@ Test DynamicSelect edge: minimal spacing:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1328,7 +1328,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1341,7 +1341,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1357,7 +1357,7 @@ Test DynamicSelect edge: column without alias gets auto name:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"no_alias" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1367,7 +1367,7 @@ Test DynamicSelect edge: column without alias gets auto name:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1447,7 +1447,7 @@ Test DynamicSelect with dynamic_select flag:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1461,7 +1461,7 @@ Test DynamicSelect with dynamic_select flag:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1478,7 +1478,7 @@ Test DynamicSelect with dynamic_select flag:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM accounts WHERE id > ?") ~name:"select_ids2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1488,7 +1488,7 @@ Test DynamicSelect with dynamic_select flag:
   
   
     let create_accounts db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1559,7 +1559,7 @@ Test DynamicSelect with two dynamic columns:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1572,7 +1572,7 @@ Test DynamicSelect with two dynamic columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1588,7 +1588,7 @@ Test DynamicSelect with two dynamic columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM items") ~name:"multi_dynamic" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1598,7 +1598,7 @@ Test DynamicSelect with two dynamic columns:
   
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1660,7 +1660,7 @@ Test DynamicSelect with Verbatim branches:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1673,7 +1673,7 @@ Test DynamicSelect with Verbatim branches:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1689,7 +1689,7 @@ Test DynamicSelect with Verbatim branches:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"with_verbatim" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1699,7 +1699,7 @@ Test DynamicSelect with Verbatim branches:
   
   
     let create_users db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT, status TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT, status TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1752,7 +1752,7 @@ Test DynamicSelect at beginning of SELECT:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1765,7 +1765,7 @@ Test DynamicSelect at beginning of SELECT:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1781,7 +1781,7 @@ Test DynamicSelect at beginning of SELECT:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM data") ~name:"first_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1791,7 +1791,7 @@ Test DynamicSelect at beginning of SELECT:
   
   
     let create_data db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE data (a INT, b TEXT)") ~name:"create_data" ~kind:Sqlgg_traits.Query.(Create "data")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE data (a INT, b TEXT)") ~name:"create_data" ~kind:Sqlgg_traits.Query.(Create "data") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1844,7 +1844,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -1857,7 +1857,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -1873,7 +1873,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t1") ~name:"with_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -1883,7 +1883,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
   
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -1951,7 +1951,7 @@ Test DynamicSelect with module annotation:
           T.finish_params p
         in
         T.select_one_maybe db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM wrapped WHERE id = ?") ~name:"with_module" ~kind:Sqlgg_traits.Query.(Select Zero_one))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM wrapped WHERE id = ?") ~name:"with_module" ~kind:Sqlgg_traits.Query.(Select Zero_one) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
   
     end
@@ -1962,7 +1962,7 @@ Test DynamicSelect with module annotation:
           id INT PRIMARY KEY,\n\
       name TEXT,\n\
       price DECIMAL(10,2)\n\
-  )") ~name:"create_wrapped" ~kind:Sqlgg_traits.Query.(Create "wrapped")) T.no_params
+  )") ~name:"create_wrapped" ~kind:Sqlgg_traits.Query.(Create "wrapped") ()) T.no_params
   
     module Single = struct
     end (* module Single *)
@@ -2013,14 +2013,14 @@ Test DynamicSelect with LIMIT 1 (select_one):
           T.finish_params p
         in
         T.select_one_maybe db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ? LIMIT 1") ~name:"select_one_product" ~kind:Sqlgg_traits.Query.(Select Zero_one))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ? LIMIT 1") ~name:"select_one_product" ~kind:Sqlgg_traits.Query.(Select Zero_one) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
   
     end
   
   
     let create_products db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
   
     module Single = struct
     end (* module Single *)
@@ -2114,7 +2114,7 @@ Test DynamicSelect comprehensive list:
         T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2129,7 +2129,7 @@ Test DynamicSelect comprehensive list:
           IO.(>>=) (T.select db
           (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2147,7 +2147,7 @@ Test DynamicSelect comprehensive list:
           IO.(>>=) (T.select db
           (Sqlgg_traits.Query.make ~sql:("SELECT\n\
      " ^ col.column ^ "\n\
-  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat))
+  FROM products") ~name:"ultimate_combo_simple2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2163,7 +2163,7 @@ Test DynamicSelect comprehensive list:
    price DECIMAL(10,2),\n\
    category TEXT,\n\
    stock INT\n\
-  )") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
+  )") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2221,7 +2221,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2235,7 +2235,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2252,7 +2252,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"bare_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2262,7 +2262,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, val TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, val TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2323,7 +2323,7 @@ Virtual select: consecutive params as columns:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2336,7 +2336,7 @@ Virtual select: consecutive params as columns:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2352,7 +2352,7 @@ Virtual select: consecutive params as columns:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"multi_param" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2362,7 +2362,7 @@ Virtual select: consecutive params as columns:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2438,7 +2438,7 @@ Virtual select: mixed columns and params without spaces after commas:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2452,7 +2452,7 @@ Virtual select: mixed columns and params without spaces after commas:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2469,7 +2469,7 @@ Virtual select: mixed columns and params without spaces after commas:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"tight_commas" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2479,7 +2479,7 @@ Virtual select: mixed columns and params without spaces after commas:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2532,7 +2532,7 @@ Virtual select: subquery expression as dynamic column:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2545,7 +2545,7 @@ Virtual select: subquery expression as dynamic column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2561,7 +2561,7 @@ Virtual select: subquery expression as dynamic column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"subquery_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2571,7 +2571,7 @@ Virtual select: subquery expression as dynamic column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2630,7 +2630,7 @@ Virtual select: CASE WHEN as dynamic column:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2643,7 +2643,7 @@ Virtual select: CASE WHEN as dynamic column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2659,7 +2659,7 @@ Virtual select: CASE WHEN as dynamic column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"case_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2669,7 +2669,7 @@ Virtual select: CASE WHEN as dynamic column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, status INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, status INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2722,7 +2722,7 @@ Virtual select: function call with multiple args as column:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2735,7 +2735,7 @@ Virtual select: function call with multiple args as column:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2751,7 +2751,7 @@ Virtual select: function call with multiple args as column:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"func_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2761,7 +2761,7 @@ Virtual select: function call with multiple args as column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2819,7 +2819,7 @@ Virtual select: arithmetic with param at expression start:
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2833,7 +2833,7 @@ Virtual select: arithmetic with param at expression start:
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2850,7 +2850,7 @@ Virtual select: arithmetic with param at expression start:
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE id = ?") ~name:"param_start_expr" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2860,7 +2860,7 @@ Virtual select: arithmetic with param at expression start:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)
@@ -2920,7 +2920,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           T.finish_params p
         in
         T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col)
   
@@ -2933,7 +2933,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           in
           let r_acc = ref acc in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
             __sqlgg_r_col !r_acc)))
           (fun () -> IO.return !r_acc)
@@ -2949,7 +2949,7 @@ Virtual select: tab-separated columns (non-space whitespace):
           in
           let r_acc = ref [] in
           IO.(>>=) (T.select db
-          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat))
+          (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t") ~name:"tab_sep" ~kind:Sqlgg_traits.Query.(Select Nat) ())
           set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
           (fun () -> IO.return (List.rev !r_acc))
   
@@ -2959,7 +2959,7 @@ Virtual select: tab-separated columns (non-space whitespace):
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?") ~name:"in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -109,7 +109,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +122,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +138,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"tuple_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -185,7 +185,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -203,7 +203,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -224,7 +224,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match v with Some _ -> " ( " ^ " id = " ^ "?" ^ " " ^ " ) " | None -> " TRUE "))) ~name:"opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -266,7 +266,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -279,7 +279,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -295,7 +295,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -337,7 +337,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -350,7 +350,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -366,7 +366,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t ORDER BY id" ^ "," ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"order_comma_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -413,7 +413,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -431,7 +431,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -452,7 +452,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"where_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -506,7 +506,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -531,7 +531,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -559,7 +559,7 @@ WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
 WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
-  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+  AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)") ~name:"shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -622,7 +622,7 @@ WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.co
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -656,7 +656,7 @@ WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.co
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -693,7 +693,7 @@ WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.co
   AND " ^ ((match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ "\n\
   AND " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ "\n\
   AND (" ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ " OR id = 0)\n\
-ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat))
+ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"kitchen_sink" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -706,7 +706,7 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"k
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT,\n\
     name TEXT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -38,7 +38,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -54,7 +54,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:S
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -73,7 +73,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:S
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -118,7 +118,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_plain" ~kind:S
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -134,7 +134,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -153,7 +153,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ^ " AND name = ?)\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -201,7 +201,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE id > ?") ~name:"cte_in_list" ~kind
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -220,7 +220,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -242,7 +242,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"cte_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -290,7 +290,7 @@ SELECT " ^ col.column ^ " FROM filtered ORDER BY " ^ ((match sort with `I -> " (
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -309,7 +309,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -331,7 +331,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match st with Some _ -> " ( " ^ " status = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALSE" | _ :: _ -> "(id, name) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (pairs_0n, pairs_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match pairs_0n with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match pairs_1n with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') pairs; Buffer.contents _sqlgg_b) ^ ")"))) ~name:"cte_opt_filter" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -384,7 +384,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match pairs with [] -> "FALS
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -408,7 +408,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -435,7 +435,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH filtered AS (SELECT id, name FROM t WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ^ ")\n\
-SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) "))) ~name:"cte_shared_choice" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -492,7 +492,7 @@ SELECT " ^ col.column ^ " FROM filtered WHERE " ^ ((match f with `All -> " ( TRU
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -507,7 +507,7 @@ SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -525,7 +525,7 @@ SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("WITH recent AS (SELECT id, name, status FROM t WHERE status = ?)\n\
-SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat))
+SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -569,7 +569,7 @@ SELECT " ^ col.column ^ " FROM recent") ~name:"cte_param_col" ~kind:Sqlgg_traits
       in
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -584,7 +584,7 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
         let r_acc = ref acc in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -602,7 +602,7 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
         let r_acc = ref [] in
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM t\n\
-WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ^ ")") ~name:"where_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -616,7 +616,7 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
     id INT,\n\
     name TEXT,\n\
     status INT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_meta/meta.compare.ml
+++ b/test/cram/test_meta/meta.compare.ml
@@ -8,88 +8,88 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     cid BIGINT NOT NULL,\n\
     status TEXT NOT NULL,\n\
   plain TEXT NOT NULL\n\
-)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts")) T.no_params
+)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
 
   let create_orders db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
     id BIGINT NOT NULL,\n\
     amount DECIMAL(10,2) NOT NULL\n\
-)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders")) T.no_params
+)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
 
   let create_events db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE events (\n\
   order_ref BIGINT NOT NULL,\n\
   amount BIGINT NOT NULL\n\
-)") ~name:"create_events" ~kind:Sqlgg_traits.Query.(Create "events")) T.no_params
+)") ~name:"create_events" ~kind:Sqlgg_traits.Query.(Create "events") ()) T.no_params
 
   let create_named_owners db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owners (\n\
     id BIGINT NOT NULL,\n\
   title TEXT NOT NULL\n\
-)") ~name:"create_named_owners" ~kind:Sqlgg_traits.Query.(Create "named_owners")) T.no_params
+)") ~name:"create_named_owners" ~kind:Sqlgg_traits.Query.(Create "named_owners") ()) T.no_params
 
   let create_named_owned db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owned (\n\
   id BIGINT NOT NULL,\n\
   note TEXT NOT NULL\n\
-)") ~name:"create_named_owned" ~kind:Sqlgg_traits.Query.(Create "named_owned")) T.no_params
+)") ~name:"create_named_owned" ~kind:Sqlgg_traits.Query.(Create "named_owned") ()) T.no_params
 
   let create_other_domain db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE other_domain (\n\
     id BIGINT NOT NULL\n\
-)") ~name:"create_other_domain" ~kind:Sqlgg_traits.Query.(Create "other_domain")) T.no_params
+)") ~name:"create_other_domain" ~kind:Sqlgg_traits.Query.(Create "other_domain") ()) T.no_params
 
   let create_owners db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owners (\n\
     id BIGINT NOT NULL PRIMARY KEY\n\
-)") ~name:"create_owners" ~kind:Sqlgg_traits.Query.(Create "owners")) T.no_params
+)") ~name:"create_owners" ~kind:Sqlgg_traits.Query.(Create "owners") ()) T.no_params
 
   let create_owned db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owned (\n\
   owner_ref BIGINT NOT NULL,\n\
   loose BIGINT NOT NULL,\n\
   FOREIGN KEY (owner_ref) REFERENCES owners(id)\n\
-)") ~name:"create_owned" ~kind:Sqlgg_traits.Query.(Create "owned")) T.no_params
+)") ~name:"create_owned" ~kind:Sqlgg_traits.Query.(Create "owned") ()) T.no_params
 
   let create_unrelated db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE unrelated (\n\
   owner_ref BIGINT NOT NULL\n\
-)") ~name:"create_unrelated" ~kind:Sqlgg_traits.Query.(Create "unrelated")) T.no_params
+)") ~name:"create_unrelated" ~kind:Sqlgg_traits.Query.(Create "unrelated") ()) T.no_params
 
   let create_projects db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE projects (\n\
   id BIGINT NOT NULL,\n\
     company_id BIGINT NOT NULL\n\
-)") ~name:"create_projects" ~kind:Sqlgg_traits.Query.(Create "projects")) T.no_params
+)") ~name:"create_projects" ~kind:Sqlgg_traits.Query.(Create "projects") ()) T.no_params
 
   let create_alerts db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE alerts (\n\
   dashboard_id BIGINT NOT NULL,\n\
   company_id BIGINT NOT NULL\n\
-)") ~name:"create_alerts" ~kind:Sqlgg_traits.Query.(Create "alerts")) T.no_params
+)") ~name:"create_alerts" ~kind:Sqlgg_traits.Query.(Create "alerts") ()) T.no_params
 
   let create_courses db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE courses (\n\
     slug TEXT NOT NULL,\n\
     seconds BIGINT NOT NULL\n\
-)") ~name:"create_courses" ~kind:Sqlgg_traits.Query.(Create "courses")) T.no_params
+)") ~name:"create_courses" ~kind:Sqlgg_traits.Query.(Create "courses") ()) T.no_params
 
   let create_left_rows db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE left_rows (\n\
     id BIGINT NOT NULL\n\
-)") ~name:"create_left_rows" ~kind:Sqlgg_traits.Query.(Create "left_rows")) T.no_params
+)") ~name:"create_left_rows" ~kind:Sqlgg_traits.Query.(Create "left_rows") ()) T.no_params
 
   let create_right_rows db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE right_rows (\n\
     id BIGINT NOT NULL,\n\
     status ENUM('draft','published','failed') NOT NULL\n\
-)") ~name:"create_right_rows" ~kind:Sqlgg_traits.Query.(Create "right_rows")) T.no_params
+)") ~name:"create_right_rows" ~kind:Sqlgg_traits.Query.(Create "right_rows") ()) T.no_params
 
   let create_codec_rows db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE codec_rows (\n\
   id INT NOT NULL,\n\
       status ENUM('new','paid','shipped') NOT NULL\n\
-)") ~name:"create_codec_rows" ~kind:Sqlgg_traits.Query.(Create "codec_rows")) T.no_params
+)") ~name:"create_codec_rows" ~kind:Sqlgg_traits.Query.(Create "codec_rows") ()) T.no_params
 
   let shared_by_equality db  callback =
     let invoke_callback stmt =
@@ -97,35 +97,35 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~order_ref:(Codecs.Order_id.get_column (T.get_column_int64 stmt 0))
         ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let disjunction_withdraws_it db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(T.get_column_Int stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let representation_mismatch db  callback =
     let invoke_callback stmt =
       callback
         ~amount:(T.get_column_Int stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let towards_the_nullable_side db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let towards_the_preserved_side db  callback =
     let invoke_callback stmt =
       callback
         ~order_ref:(T.get_column_Int stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let no_join db  callback =
     let invoke_callback stmt =
@@ -133,21 +133,21 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
         ~loose:(T.get_column_Int stmt 1)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let outer_join_preserved_side db  callback =
     let invoke_callback stmt =
       callback
         ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let without_the_declaration db  callback =
     let invoke_callback stmt =
       callback
         ~owner_ref:(T.get_column_Int stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let through_a_null_handling_call db ~a ~b callback =
     let invoke_callback stmt =
@@ -160,7 +160,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_string p (Codecs.Status.set_param b);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let through_nested_coalesce db ~a ~b callback =
     let invoke_callback stmt =
@@ -173,7 +173,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_int64 p (Codecs.Cid.set_param b);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let through_nullif db ~param callback =
     let invoke_callback stmt =
@@ -185,14 +185,14 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_string p (Codecs.Status.set_param param);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let greatest_over_a_literal db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let least_feeds_the_param db ~param callback =
     let invoke_callback stmt =
@@ -204,7 +204,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_int64 p (Codecs.Cid.set_param param);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let untyped_sibling db  callback =
     let invoke_callback stmt =
@@ -212,26 +212,26 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~company_id:(Codecs.Company_id.get_column (T.get_column_int64 stmt 0))
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let literal_fallback db  callback =
     let invoke_callback stmt =
       callback
         ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let selecting_aggregate_keeps_it db  =
     let get_row stmt =
       (Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
     in
-    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
 
   let computing_aggregate_keeps_it db  =
     let get_row stmt =
       (Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
     in
-    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
 
   let transforming_function db ~param callback =
     let invoke_callback stmt =
@@ -243,7 +243,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       T.set_param_Text p param;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let arithmetic db ~param callback =
     let invoke_callback stmt =
@@ -255,21 +255,21 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       T.set_param_Int p param;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let concatenation db  callback =
     let invoke_callback stmt =
       callback
         ~s:(T.get_column_Text stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let case_literal_fallback db  callback =
     let invoke_callback stmt =
       callback
         ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let param_branch db ~param callback =
     let invoke_callback stmt =
@@ -281,7 +281,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       T.set_param_string p (Codecs.Status.set_param param);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let condition_is_not_a_branch db ~cond callback =
     let invoke_callback stmt =
@@ -293,7 +293,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       T.set_param_string p (Codecs.Status.set_param cond);
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let fetch_merged db  callback =
     let invoke_callback stmt =
@@ -304,21 +304,21 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let scalar_subquery db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let scalar_subquery_with_cte db  callback =
     let invoke_callback stmt =
       callback
         ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let one_typed_one_not db ~cid ~id callback =
     let invoke_callback stmt =
@@ -331,7 +331,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let param_list db ~cids callback =
     let invoke_callback stmt =
@@ -342,7 +342,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       let p = T.start_params stmt (0 + (match cids with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let assignment db ~cid ~id =
     let set_params stmt =
@@ -351,7 +351,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE accounts SET cid = ? WHERE id = ?") ~name:"assignment" ~kind:Sqlgg_traits.Query.(Update (Some "accounts"))) set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE accounts SET cid = ? WHERE id = ?") ~name:"assignment" ~kind:Sqlgg_traits.Query.(Update (Some "accounts")) ()) set_params
 
   let insert_from_select db ~cid =
     let set_params stmt =
@@ -359,7 +359,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_int64 p (Codecs.Cid.set_param cid);
       T.finish_params p
     in
-    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO accounts (id, cid, status, plain) SELECT id, ?, status, plain FROM accounts") ~name:"insert_from_select" ~kind:Sqlgg_traits.Query.(Insert "accounts")) set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO accounts (id, cid, status, plain) SELECT id, ?, status, plain FROM accounts") ~name:"insert_from_select" ~kind:Sqlgg_traits.Query.(Insert "accounts") ()) set_params
 
   let get_status db ~id callback =
     let invoke_callback stmt =
@@ -371,7 +371,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let set_status db ~status ~id =
     let set_params stmt =
@@ -380,35 +380,35 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE codec_rows SET status = ? WHERE id = ?") ~name:"set_status" ~kind:Sqlgg_traits.Query.(Update (Some "codec_rows"))) set_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE codec_rows SET status = ? WHERE id = ?") ~name:"set_status" ~kind:Sqlgg_traits.Query.(Update (Some "codec_rows")) ()) set_params
 
   let spelled_with_on db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let spelled_with_using db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let spelled_naturally db  callback =
     let invoke_callback stmt =
       callback
         ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let outer_join_by_name_stays_silent db  callback =
     let invoke_callback stmt =
       callback
         ~id:(T.get_column_Int stmt 0)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   let param_meets_two_domains db ~needle callback =
     let invoke_callback stmt =
@@ -422,7 +422,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       T.finish_params p
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Single = struct
     let selecting_aggregate_keeps_it db  callback =
@@ -430,14 +430,14 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         callback
           ~longest:(Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
       in
-      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(MAX(seconds), 0) AS longest FROM courses") ~name:"selecting_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
 
     let computing_aggregate_keeps_it db  callback =
       let invoke_callback stmt =
         callback
           ~total:(Codecs.Db_int.get_column (T.get_column_int64 stmt 0))
       in
-      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(SUM(seconds), 0) AS total FROM courses") ~name:"computing_aggregate_keeps_it" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
 
   end (* module Single *)
   
@@ -449,7 +449,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let disjunction_withdraws_it db  callback acc =
@@ -458,7 +458,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let representation_mismatch db  callback acc =
@@ -467,7 +467,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~amount:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let towards_the_nullable_side db  callback acc =
@@ -476,7 +476,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let towards_the_preserved_side db  callback acc =
@@ -485,7 +485,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let no_join db  callback acc =
@@ -495,7 +495,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~loose:(T.get_column_Int stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let outer_join_preserved_side db  callback acc =
@@ -504,7 +504,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let without_the_declaration db  callback acc =
@@ -513,7 +513,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~owner_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_a_null_handling_call db ~a ~b callback acc =
@@ -528,7 +528,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_nested_coalesce db ~a ~b callback acc =
@@ -543,7 +543,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let through_nullif db ~param callback acc =
@@ -557,7 +557,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let greatest_over_a_literal db  callback acc =
@@ -566,7 +566,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let least_feeds_the_param db ~param callback acc =
@@ -580,7 +580,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let untyped_sibling db  callback acc =
@@ -590,7 +590,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
       in
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let literal_fallback db  callback acc =
@@ -599,7 +599,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let transforming_function db ~param callback acc =
@@ -613,7 +613,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let arithmetic db ~param callback acc =
@@ -627,7 +627,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let concatenation db  callback acc =
@@ -636,7 +636,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~s:(T.get_column_Text stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let case_literal_fallback db  callback acc =
@@ -645,7 +645,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_branch db ~param callback acc =
@@ -659,7 +659,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let condition_is_not_a_branch db ~cond callback acc =
@@ -673,7 +673,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let fetch_merged db  callback acc =
@@ -686,7 +686,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let scalar_subquery db  callback acc =
@@ -695,7 +695,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let scalar_subquery_with_cte db  callback acc =
@@ -704,7 +704,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let one_typed_one_not db ~cid ~id callback acc =
@@ -719,7 +719,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_list db ~cids callback acc =
@@ -732,7 +732,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let get_status db ~id callback acc =
@@ -746,7 +746,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_with_on db  callback acc =
@@ -755,7 +755,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_with_using db  callback acc =
@@ -764,7 +764,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let spelled_naturally db  callback acc =
@@ -773,7 +773,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let outer_join_by_name_stays_silent db  callback acc =
@@ -782,7 +782,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(T.get_column_Int stmt 0)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let param_meets_two_domains db ~needle callback acc =
@@ -798,7 +798,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       in
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -811,7 +811,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~id:(Codecs.Order_id.get_column (T.get_column_int64 stmt 1))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref, orders.id FROM orders JOIN events ON orders.id = events.order_ref") ~name:"shared_by_equality" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let disjunction_withdraws_it db  callback =
@@ -820,7 +820,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders JOIN events ON orders.id = events.order_ref OR events.order_ref = 0") ~name:"disjunction_withdraws_it" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let representation_mismatch db  callback =
@@ -829,7 +829,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~amount:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.amount FROM orders JOIN events ON orders.amount = events.amount") ~name:"representation_mismatch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let towards_the_nullable_side db  callback =
@@ -838,7 +838,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(Codecs.Order_id.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM orders LEFT JOIN events ON orders.id = events.order_ref") ~name:"towards_the_nullable_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let towards_the_preserved_side db  callback =
@@ -847,7 +847,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~order_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT events.order_ref FROM events LEFT JOIN orders ON orders.id = events.order_ref") ~name:"towards_the_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let no_join db  callback =
@@ -857,7 +857,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~loose:(T.get_column_Int stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owner_ref, loose FROM owned") ~name:"no_join" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let outer_join_preserved_side db  callback =
@@ -866,7 +866,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~owner_ref:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT owned.owner_ref FROM owned LEFT JOIN owners ON owners.id = owned.owner_ref") ~name:"outer_join_preserved_side" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let without_the_declaration db  callback =
@@ -875,7 +875,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~owner_ref:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT unrelated.owner_ref FROM unrelated LEFT JOIN owners ON owners.id = unrelated.owner_ref") ~name:"without_the_declaration" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_a_null_handling_call db ~a ~b callback =
@@ -890,7 +890,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE IFNULL(?, status) = ?") ~name:"through_a_null_handling_call" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_nested_coalesce db ~a ~b callback =
@@ -905,7 +905,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(COALESCE(cid, ?), ?) AS c FROM accounts") ~name:"through_nested_coalesce" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let through_nullif db ~param callback =
@@ -919,7 +919,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT NULLIF(status, ?) AS s FROM accounts") ~name:"through_nullif" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let greatest_over_a_literal db  callback =
@@ -928,7 +928,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
           ~c:(Codecs.Cid.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT GREATEST(cid, 0) AS c FROM accounts") ~name:"greatest_over_a_literal" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let least_feeds_the_param db ~param callback =
@@ -942,7 +942,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = LEAST(?, 0)") ~name:"least_feeds_the_param" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let untyped_sibling db  callback =
@@ -952,7 +952,7 @@ WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domai
       in
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(projects.company_id, alerts.company_id) AS company_id\n\
-FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"untyped_sibling" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let literal_fallback db  callback =
@@ -961,7 +961,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~module_slug:(Codecs.Slug.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT COALESCE(slug, '') AS module_slug FROM courses") ~name:"literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let transforming_function db ~param callback =
@@ -975,7 +975,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE LOWER(status) = ?") ~name:"transforming_function" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let arithmetic db ~param callback =
@@ -989,7 +989,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM accounts WHERE cid = ? + 1") ~name:"arithmetic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let concatenation db  callback =
@@ -998,7 +998,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~s:(T.get_column_Text stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CONCAT(status, plain) AS s FROM accounts") ~name:"concatenation" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let case_literal_fallback db  callback =
@@ -1007,7 +1007,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
           ~s:(Codecs.Status.get_column (T.get_column_string stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE 'active' END AS s FROM accounts") ~name:"case_literal_fallback" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_branch db ~param callback =
@@ -1021,7 +1021,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN id = 1 THEN status ELSE ? END AS s FROM accounts") ~name:"param_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let condition_is_not_a_branch db ~cond callback =
@@ -1035,7 +1035,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT CASE WHEN status = ? THEN plain ELSE '' END AS s FROM accounts") ~name:"condition_is_not_a_branch" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let fetch_merged db  callback =
@@ -1048,7 +1048,7 @@ FROM alerts LEFT JOIN projects ON alerts.dashboard_id = projects.id") ~name:"unt
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT l.id AS left_id, NULL AS right_id, 'published' AS row_status FROM left_rows l\n\
 UNION ALL\n\
-SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows r") ~name:"fetch_merged" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let scalar_subquery db  callback =
@@ -1057,7 +1057,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (SELECT cid FROM accounts LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let scalar_subquery_with_cte db  callback =
@@ -1066,7 +1066,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~c:(Codecs.Cid.get_column_nullable (T.get_column_int64_nullable stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT (WITH c AS (SELECT cid FROM accounts) SELECT cid FROM c LIMIT 1) AS c FROM accounts") ~name:"scalar_subquery_with_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let one_typed_one_not db ~cid ~id callback =
@@ -1081,7 +1081,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE cid = ? AND id = ?") ~name:"one_typed_one_not" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_list db ~cids callback =
@@ -1094,7 +1094,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT plain FROM accounts WHERE " ^ (match cids with [] -> "FALSE" | _ :: _ -> "cid IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Int.int64_to_literal (Codecs.Cid.set_param v)) cids) ^ ")")) ~name:"param_list" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let get_status db ~id callback =
@@ -1108,7 +1108,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT status FROM codec_rows WHERE id = ?") ~name:"get_status" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_with_on db  callback =
@@ -1117,7 +1117,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners ON named_owned.id = named_owners.id") ~name:"spelled_with_on" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_with_using db  callback =
@@ -1126,7 +1126,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned JOIN named_owners USING (id)") ~name:"spelled_with_using" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let spelled_naturally db  callback =
@@ -1135,7 +1135,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(Codecs.Owner_id.get_column (T.get_column_int64 stmt 0))
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned NATURAL JOIN named_owners") ~name:"spelled_naturally" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let outer_join_by_name_stays_silent db  callback =
@@ -1144,7 +1144,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
           ~id:(T.get_column_Int stmt 0)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owned.id FROM named_owned LEFT JOIN named_owners USING (id)") ~name:"outer_join_by_name_stays_silent" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let param_meets_two_domains db ~needle callback =
@@ -1160,7 +1160,7 @@ SELECT NULL AS left_id, r.id AS right_id, r.status AS row_status FROM right_rows
       in
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT named_owners.title FROM named_owners, other_domain\n\
-WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE named_owners.id = ? AND other_domain.id = ?") ~name:"param_meets_two_domains" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_migrations/closed-loop-5tables.t/run.t
+++ b/test/cram/test_migrations/closed-loop-5tables.t/run.t
@@ -17,10 +17,10 @@ Step 2 - day-to-day change: target.sql adds `posts.views`.
     module IO = T.IO
   
     let apply_20260101000000_alter_posts_add_col_views db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") ~name:"apply_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") ~name:"apply_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_posts_add_col_views db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `views`") ~name:"revert_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `views`") ~name:"revert_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("20260101000000_alter_posts_add_col_views", apply_20260101000000_alter_posts_add_col_views, revert_20260101000000_alter_posts_add_col_views);

--- a/test/cram/test_migrations/diff-add-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101000000_alter_users_add_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/diff-add-index.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-index.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") ~name:"apply_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") ~name:"apply_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP INDEX `email_idx`") ~name:"revert_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP INDEX `email_idx`") ~name:"revert_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_unique_email_idx", apply_20260101000000_alter_users_add_unique_email_idx, revert_20260101000000_alter_users_add_unique_email_idx);

--- a/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_pk db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") ~name:"apply_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") ~name:"apply_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101000000_alter_users_add_pk db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP PRIMARY KEY") ~name:"revert_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP PRIMARY KEY") ~name:"revert_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_add_pk", apply_20260101000000_alter_users_add_pk, revert_20260101000000_alter_users_add_pk);

--- a/test/cram/test_migrations/diff-change-type.t/migrations.ml
+++ b/test/cram/test_migrations/diff-change-type.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101000000_alter_users_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_change_col_id", apply_20260101000000_alter_users_change_col_id, revert_20260101000000_alter_users_change_col_id);

--- a/test/cram/test_migrations/diff-create-unique-index.t/run.t
+++ b/test/cram/test_migrations/diff-create-unique-index.t/run.t
@@ -15,10 +15,10 @@ the whole apply string, so it shows the result.)
   
     let apply_20260101000000_create_u db  =
       T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE `u` (`id` INT, `email` VARCHAR(255), PRIMARY KEY (`id`));\n\
-  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") ~name:"apply_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other) T.no_params
+  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") ~name:"apply_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_create_u db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TABLE `u`") ~name:"revert_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TABLE `u`") ~name:"revert_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("20260101000000_create_u", apply_20260101000000_create_u, revert_20260101000000_create_u);

--- a/test/cram/test_migrations/diff-drop-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-drop-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_drop_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"apply_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"apply_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101000000_alter_users_drop_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"revert_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"revert_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101000000_alter_users_drop_col_age", apply_20260101000000_alter_users_drop_col_age, revert_20260101000000_alter_users_drop_col_age);

--- a/test/cram/test_migrations/diff-three-changes.t/migrations.ml
+++ b/test/cram/test_migrations/diff-three-changes.t/migrations.ml
@@ -3,22 +3,22 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101120000_alter_c_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101120000_alter_c_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let apply_20260101120000_alter_b_drop_col_old db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` DROP COLUMN `old`") ~name:"apply_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` DROP COLUMN `old`") ~name:"apply_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101120000_alter_b_drop_col_old db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") ~name:"revert_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") ~name:"revert_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let apply_20260101120000_alter_a_add_col_x db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") ~name:"apply_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") ~name:"apply_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let revert_20260101120000_alter_a_add_col_x db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` DROP COLUMN `x`") ~name:"revert_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` DROP COLUMN `x`") ~name:"revert_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
 
   let migrations = [
     ("20260101120000_alter_c_change_col_id", apply_20260101120000_alter_c_change_col_id, revert_20260101120000_alter_c_change_col_id);

--- a/test/cram/test_migrations/diff-ttl.t/run.t
+++ b/test/cram/test_migrations/diff-ttl.t/run.t
@@ -57,10 +57,10 @@ The full -migrate cycle generates apply/revert code for the TTL change:
     module IO = T.IO
   
     let apply_20260101000000_alter_foo_set_ttl db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") ~name:"apply_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") ~name:"apply_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_foo_set_ttl db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` REMOVE TTL") ~name:"revert_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` REMOVE TTL") ~name:"revert_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("20260101000000_alter_foo_set_ttl", apply_20260101000000_alter_foo_set_ttl, revert_20260101000000_alter_foo_set_ttl);

--- a/test/cram/test_migrations/dune-codegen.t/run.t
+++ b/test/cram/test_migrations/dune-codegen.t/run.t
@@ -35,16 +35,16 @@ current, so -migrate only regenerates and prints the human note to stderr:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-irreversible.t
+++ b/test/cram/test_migrations/migrate-irreversible.t
@@ -30,17 +30,17 @@ delta keeps a real one:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN legacy") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN legacy") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_0 db  =
       ignore db;
       IO.return { T.affected_rows = 0L; insert_id = None }
   
     let apply_20260101000000_alter_users_add_col_name db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `name` TEXT") ~name:"apply_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `name` TEXT") ~name:"apply_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_users_add_col_name db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `name`") ~name:"revert_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `name`") ~name:"revert_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
+++ b/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
@@ -76,40 +76,40 @@ The generated code merges everything by id: manual (day-pinned) and generated
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `email` TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `email` TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `email`") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `email`") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_alter_posts_2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") ~name:"apply_alter_posts_2" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") ~name:"apply_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_posts_2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `author_id`") ~name:"revert_alter_posts_2" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `author_id`") ~name:"revert_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_alter_posts_3 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts ADD COLUMN body TEXT") ~name:"apply_alter_posts_3" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts ADD COLUMN body TEXT") ~name:"apply_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_posts_3 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts DROP COLUMN body") ~name:"revert_alter_posts_3" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts DROP COLUMN body") ~name:"revert_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_20260101000000_alter_posts_add_col_published db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") ~name:"apply_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") ~name:"apply_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_posts_add_col_published db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `published`") ~name:"revert_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `published`") ~name:"revert_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `created_at`") ~name:"revert_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `created_at`") ~name:"revert_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-loop.t/run.t
+++ b/test/cram/test_migrations/migrate-loop.t/run.t
@@ -24,10 +24,10 @@ The code is regenerated from the migration SQL:
     module IO = T.IO
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/migrate-manual-mix.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-mix.t/run.t
@@ -34,16 +34,16 @@ The code merges both by id (manual day 20251231 first, generated 20260101000000_
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-manual-only.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-only.t/run.t
@@ -26,10 +26,10 @@ But the code is regenerated and contains the hand-written rename:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email TO email_address") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email TO email_address") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email_address TO email") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email_address TO email") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-timestamp.t/run.t
+++ b/test/cram/test_migrations/migrate-timestamp.t/run.t
@@ -42,22 +42,22 @@ The code merges all three by id, so the manual `status` sits between `age` and
     module IO = T.IO
   
     let apply_20260101120000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260101120000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN status") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN status") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let apply_20260102000000_alter_users_add_col_city db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `city` TEXT") ~name:"apply_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `city` TEXT") ~name:"apply_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let revert_20260102000000_alter_users_add_col_city db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `city`") ~name:"revert_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `city`") ~name:"revert_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
   
     let migrations = [
       ("20260101120000_alter_users_add_col_age", apply_20260101120000_alter_users_add_col_age, revert_20260101120000_alter_users_add_col_age);

--- a/test/cram/test_query_meta/app.ml
+++ b/test/cram/test_query_meta/app.ml
@@ -27,12 +27,12 @@ module Annotating_impl = struct
     match q.kind with
     | Create _ | Alter _ | Drop _ -> q
     | _ ->
-      Sqlgg_traits.Query.Sqlcommenter.annotate [
+      Sqlgg_traits.Query.Sqlcommenter.annotate ([
         "app", "users api";
         "query", q.name;
         "kind", kind_name q.kind;
         "request_id", !current_request;
-      ] q
+      ] @ (match q.filename with None -> [] | Some file -> [ "file", file ])) q
 
   let select db q = Print_ocaml_impl.select db (annotate q)
   let select_one db q = Print_ocaml_impl.select_one db (annotate q)

--- a/test/cram/test_query_meta/queries.compare.ml
+++ b/test/cram/test_query_meta/queries.compare.ml
@@ -3,7 +3,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let find_user db ~id callback =
     let invoke_callback stmt =
@@ -16,13 +16,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let select_2 db  =
     let get_row stmt =
       (T.get_column_Int stmt 0)
     in
-    T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params get_row
+    T.select_one db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params get_row
 
   let find_users db ~ids callback =
     let invoke_callback stmt =
@@ -34,10 +34,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match ids with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let add_users db ~rows =
-    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, name) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal name); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users")) T.no_params )
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("INSERT INTO users (id, name) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal name); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users") ()) T.no_params )
 
   let rename_user db ~name ~id =
     let set_params stmt =
@@ -46,7 +46,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE users SET name = ? WHERE id = ?") ~name:"rename_user" ~kind:Sqlgg_traits.Query.(Update (Some "users"))) set_params
+    T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("UPDATE users SET name = ? WHERE id = ?") ~name:"rename_user" ~kind:Sqlgg_traits.Query.(Update (Some "users")) ()) set_params
 
   let delete_users_6 db ~id =
     let set_params stmt =
@@ -54,7 +54,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.execute db (Sqlgg_traits.Query.make ~sql:("DELETE FROM users WHERE id = ?") ~name:"delete_users_6" ~kind:Sqlgg_traits.Query.(Delete ["users"])) set_params
+    T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("DELETE FROM users WHERE id = ?") ~name:"delete_users_6" ~kind:Sqlgg_traits.Query.(Delete ["users"]) ()) set_params
 
   module Single = struct
     let select_2 db  callback =
@@ -62,7 +62,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         callback
           ~total:(T.get_column_Int stmt 0)
       in
-      T.select_one db (Sqlgg_traits.Query.make ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One)) T.no_params invoke_callback
+      T.select_one db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT COUNT(*) AS total FROM users") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select One) ()) T.no_params invoke_callback
 
   end (* module Single *)
   
@@ -79,7 +79,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let find_users db ~ids callback acc =
@@ -93,7 +93,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -111,7 +111,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"find_user" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let find_users db ~ids callback =
@@ -125,7 +125,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_query_meta/run.t
+++ b/test/cram/test_query_meta/run.t
@@ -1,15 +1,23 @@
 Generated code passes a query record to the traits instead of a bare sql string.
 [name] is the name from -- @name or a generated fallback, [kind] mirrors the
-statement kind, and [sql] is the only field that may be assembled at runtime
-(see the IN list and the batch insert in queries.compare.ml).
+statement kind, [filename] is the sql file the statement was read from, and
+[sql] is the only field that may be assembled at runtime (see the IN list and
+the batch insert in queries.compare.ml).
 
-  $ /bin/sh ../sqlgg_test.sh queries.sql queries.compare.ml
+  $ sqlgg -no-header -gen caml -params unnamed queries.sql > output.ml
+  $ diff output.ml queries.compare.ml
   $ echo $?
+  0
+
+Statements read from stdin have no file to point at, so [filename] stays unset.
+
+  $ sqlgg -no-header -gen caml -params unnamed - < queries.sql | grep -c '~filename:' || true
   0
 
 The implementation receives that record, so annotating is plain user code: it
 picks the attributes, sqlcommenter only serializes them into a comment. app.ml
-attaches the query name, the kind, and a per request id, and skips DDL.
+attaches the query name, the kind, the source file, and a per request id, and
+skips DDL.
 
   $ cp ../print_ocaml_impl.ml ../print_impl.ml .
   $ ocamlfind ocamlc -package sqlgg.traits -c output.ml
@@ -20,7 +28,7 @@ attaches the query name, the kind, and a per request id, and skips DDL.
   
   === named select, parameters stay bound ===
   [MOCK SELECT] Connection type: [> `RO ]
-  [SQL] SELECT id, name FROM users WHERE id = 1 /*app='users%20api',kind='select',query='find_user',request_id='req-1'*/
+  [SQL] SELECT id, name FROM users WHERE id = 1 /*app='users%20api',file='queries.sql',kind='select',query='find_user',request_id='req-1'*/
   [MOCK] Returning 1 rows
     Row 0: col0=1 col1=alice 
   [MOCK] get_column_Text[1] = "alice"
@@ -29,24 +37,24 @@ attaches the query name, the kind, and a per request id, and skips DDL.
   
   === unnamed select gets a generated name ===
   [MOCK SELECT_ONE] Connection type: [> `RO ]
-  [SQL] SELECT COUNT(*) AS total FROM users /*app='users%20api',kind='select_one',query='select_2',request_id='req-1'*/
+  [SQL] SELECT COUNT(*) AS total FROM users /*app='users%20api',file='queries.sql',kind='select_one',query='select_2',request_id='req-1'*/
   [MOCK] Returning one row
   [MOCK] get_column_Int[0] = 7
   total: 7
   
   === runtime assembled sql, same name and kind ===
   [MOCK SELECT] Connection type: [> `RO ]
-  [SQL] SELECT id, name FROM users WHERE id IN (1, 2, 3) /*app='users%20api',kind='select',query='find_users',request_id='req-1'*/
+  [SQL] SELECT id, name FROM users WHERE id IN (1, 2, 3) /*app='users%20api',file='queries.sql',kind='select',query='find_users',request_id='req-1'*/
   [MOCK] Returning 0 rows
   
   === batch insert ===
   [MOCK EXECUTE] Connection type: [> `WR ]
-  [SQL] INSERT INTO users (id, name) VALUES (1, 'alice'), (2, 'bob') /*app='users%20api',kind='insert%20users',query='add_users',request_id='req-1'*/
+  [SQL] INSERT INTO users (id, name) VALUES (1, 'alice'), (2, 'bob') /*app='users%20api',file='queries.sql',kind='insert%20users',query='add_users',request_id='req-1'*/
   [MOCK] Execute result: affected_rows=2, insert_id=10
   
   === per request attributes change, sql of the query does not ===
   [MOCK EXECUTE] Connection type: [> `WR ]
-  [SQL] UPDATE users SET name = 'carol' WHERE id = 1 /*app='users%20api',kind='update%20users',query='rename_user',request_id='req-2'*/
+  [SQL] UPDATE users SET name = 'carol' WHERE id = 1 /*app='users%20api',file='queries.sql',kind='update%20users',query='rename_user',request_id='req-2'*/
   [MOCK] Execute result: affected_rows=1, insert_id=None
   
   === ddl is left alone by this implementation ===

--- a/test/cram/test_scoped_select/scope.expected.ml
+++ b/test/cram/test_scoped_select/scope.expected.ml
@@ -54,7 +54,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select_one_maybe db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ?") ~name:"scope_q1" ~kind:Sqlgg_traits.Query.(Select Zero_one))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE id = ?") ~name:"scope_q1" ~kind:Sqlgg_traits.Query.(Select Zero_one) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col))
 
   end
@@ -103,7 +103,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -117,7 +117,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -134,7 +134,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM products WHERE stock > ?") ~name:"scope_q2" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -150,7 +150,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     price DECIMAL(10,2),\n\
     category TEXT,\n\
     stock INT\n\
-)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products")) T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
 
   module Single = struct
   end (* module Single *)

--- a/test/cram/test_shared_choice/shared.compare.ml
+++ b/test/cram/test_shared_choice/shared.compare.ml
@@ -7,7 +7,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     id INT NOT NULL,\n\
     name TEXT,\n\
     status INT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t")) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
 
   let shared_const db ~x callback =
     let invoke_callback stmt =
@@ -20,7 +20,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let shared_param_same_name db ~x callback =
     let invoke_callback stmt =
@@ -43,7 +43,7 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let shared_params_diff_names db ~f callback =
     let invoke_callback stmt =
@@ -66,7 +66,7 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let shared_cte db ~f callback =
     let invoke_callback stmt =
@@ -90,7 +90,7 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
     T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let shared_mixed db ~ids ~nm ~f ~sort callback =
     let invoke_callback stmt =
@@ -121,7 +121,7 @@ WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.con
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let shared_const db ~x callback acc =
@@ -136,7 +136,7 @@ ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"sha
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_param_same_name db ~x callback acc =
@@ -161,7 +161,7 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_params_diff_names db ~f callback acc =
@@ -186,7 +186,7 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_cte db ~f callback acc =
@@ -212,7 +212,7 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let shared_mixed db ~ids ~nm ~f ~sort callback acc =
@@ -245,7 +245,7 @@ WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.con
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -263,7 +263,7 @@ ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"sha
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
-   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+   OR status = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ")) ~name:"shared_const" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_param_same_name db ~x callback =
@@ -288,7 +288,7 @@ WHERE id = " ^ (match x with `Small -> " ( 1 ) " | `Big -> " ( 100 ) ") ^ "\n\
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
-   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+   OR status = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ")) ~name:"shared_param_same_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_params_diff_names db ~f callback =
@@ -313,7 +313,7 @@ WHERE id = " ^ (match x with `Const -> " ( 1 ) " | `Param _ -> " ( ? ) ") ^ "\n\
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM t\n\
 WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
-  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( id <> ? ) ")) ~name:"shared_params_diff_names" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_cte db ~f callback =
@@ -339,7 +339,7 @@ WHERE " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) "
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("WITH recent AS (\n\
   SELECT id FROM t WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ") ^ "\n\
 )\n\
-SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+SELECT id FROM recent WHERE " ^ (match f with `All -> " ( TRUE ) " | `ById _ -> " ( id = ? ) ")) ~name:"shared_cte" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let shared_mixed db ~ids ~nm ~f ~sort callback =
@@ -372,7 +372,7 @@ WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.con
   AND " ^ (match nm with Some _ -> " ( " ^ " name = " ^ "?" ^ " " ^ " ) " | None -> " TRUE ") ^ "\n\
   AND " ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ "\n\
   AND (" ^ (match f with `All -> " ( TRUE ) " | `ByStatus _ -> " ( status = ? ) ") ^ " OR id = 0)\n\
-ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+ORDER BY " ^ (match sort with `I -> " ( id ) " | `N -> " ( name ) ")) ~name:"shared_mixed" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/both.t/both.compare.ml
+++ b/test/cram/test_static_flags/both.t/both.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -90,7 +90,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -105,7 +105,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -123,7 +123,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
+++ b/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_static_flags/global.t/global.compare.ml
+++ b/test/cram/test_static_flags/global.t/global.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -109,7 +109,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -122,7 +122,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -138,7 +138,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users") ~name:"list_users" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -148,7 +148,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -161,7 +161,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let list_users_static db  callback =
     let invoke_callback stmt =
@@ -169,7 +169,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         ~id:(T.get_column_Int stmt 0)
         ~name:(T.get_column_Text_nullable stmt 1)
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -184,7 +184,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let list_users_static db  callback acc =
@@ -194,7 +194,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text_nullable stmt 1)
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -212,7 +212,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let list_users_static db  callback =
@@ -222,7 +222,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
           ~name:(T.get_column_Text_nullable stmt 1)
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users") ~name:"list_users_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/je_static.t/je_static.compare.ml
+++ b/test/cram/test_static_flags/je_static.t/je_static.compare.ml
@@ -47,7 +47,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.select db
       (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -63,7 +63,7 @@ WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -82,7 +82,7 @@ WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
         IO.(>>=) (T.select db
         (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ "\n\
 FROM items i" ^ (if List.mem Stats col.deps then " LEFT JOIN stats s ON s.item_id = i.id" else "") ^ "\n\
-WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
+WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -92,10 +92,10 @@ WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
 
 
   let create_items db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
 
   let create_stats db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") ~name:"create_stats" ~kind:Sqlgg_traits.Query.(Create "stats")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") ~name:"create_stats" ~kind:Sqlgg_traits.Query.(Create "stats") ()) T.no_params
 
   let wide_static db ~min_id callback =
     let invoke_callback stmt =
@@ -112,7 +112,7 @@ WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat))
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let wide_static db ~min_id callback acc =
@@ -131,7 +131,7 @@ WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -153,7 +153,7 @@ WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT i.id, i.name, s.sold\n\
 FROM items i\n\
 LEFT JOIN stats s ON s.item_id = i.id\n\
-WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE i.id > ?") ~name:"wide_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/test_static_flags/override.t/override.compare.ml
+++ b/test/cram/test_static_flags/override.t/override.compare.ml
@@ -36,7 +36,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       T.select db
-      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+      (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
       set_params (fun row -> let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col)
 
@@ -50,7 +50,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref acc in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in callback
           __sqlgg_r_col !r_acc)))
         (fun () -> IO.return !r_acc)
@@ -67,7 +67,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         in
         let r_acc = ref [] in
         IO.(>>=) (T.select db
-        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat))
+        (Sqlgg_traits.Query.make ~sql:("SELECT " ^ col.column ^ " FROM users WHERE id = ?") ~name:"get_user" ~kind:Sqlgg_traits.Query.(Select Nat) ())
         set_params (fun row -> r_acc := (let (__sqlgg_r_col, __sqlgg_idx_after_col) = col.read row 0 in (__sqlgg_r_col)) :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
 
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users")) T.no_params
+    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =
@@ -90,7 +90,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let get_user_classic db ~id callback =
     let invoke_callback stmt =
@@ -103,7 +103,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       T.set_param_Int p id;
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let get_user_static db ~id callback acc =
@@ -118,7 +118,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let get_user_classic db ~id callback acc =
@@ -133,7 +133,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -151,7 +151,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_static" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let get_user_classic db ~id callback =
@@ -166,7 +166,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id, name FROM users WHERE id = ?") ~name:"get_user_classic" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_mappings.compare.ml
+++ b/test/cram/type_mappings.compare.ml
@@ -6,13 +6,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_37 (\n\
                 col_1 INT PRIMARY KEY,\n\
                         col_2 INT NOT NULL\n\
-      )") ~name:"create_table_37" ~kind:Sqlgg_traits.Query.(Create "table_37")) T.no_params
+      )") ~name:"create_table_37" ~kind:Sqlgg_traits.Query.(Create "table_37") ()) T.no_params
 
   let create_table_38 db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_38 (\n\
                 col_3 INT PRIMARY KEY,\n\
         col_4 TEXT NOT NULL\n\
-      )") ~name:"create_table_38" ~kind:Sqlgg_traits.Query.(Create "table_38")) T.no_params
+      )") ~name:"create_table_38" ~kind:Sqlgg_traits.Query.(Create "table_38") ()) T.no_params
 
   let select_2 db  callback =
     let invoke_callback stmt =
@@ -41,7 +41,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
 
   module Fold = struct
     let select_2 db  callback acc =
@@ -72,7 +72,7 @@ LEFT JOIN table_38\n\
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -106,7 +106,7 @@ LEFT JOIN table_38\n\
   col_4\n\
 FROM table_37\n\
 LEFT JOIN table_38\n\
-  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  ON table_37.col_1 = table_38.col_3") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_mappings_params.compare.ml
+++ b/test/cram/type_mappings_params.compare.ml
@@ -7,7 +7,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL,\n\
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP\n\
-)") ~name:"create_example" ~kind:Sqlgg_traits.Query.(Create "example")) T.no_params
+)") ~name:"create_example" ~kind:Sqlgg_traits.Query.(Create "example") ()) T.no_params
 
   let select_1 db ~x callback =
     let invoke_callback stmt =
@@ -18,13 +18,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
       let p = T.start_params stmt (0 + (match x with [] -> 0 | _ :: _ -> 0)) in
       T.finish_params p
     in
-    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let create_example2 db  =
     T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example2 (\n\
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name_2 VARCHAR(255) NOT NULL\n\
-)") ~name:"create_example2" ~kind:Sqlgg_traits.Query.(Create "example2")) T.no_params
+)") ~name:"create_example2" ~kind:Sqlgg_traits.Query.(Create "example2") ()) T.no_params
 
   let select_3 db ~name ~name_2 ~id callback =
     let invoke_callback stmt =
@@ -40,7 +40,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let select_1 db ~x callback acc =
@@ -53,7 +53,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref acc in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let select_3 db ~name ~name_2 ~id callback acc =
@@ -71,7 +71,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -87,7 +87,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
         T.finish_params p
       in
       let r_acc = ref [] in
-      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let select_3 db ~name ~name_2 ~id callback =
@@ -105,7 +105,7 @@ WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT example2.id, name_2 \n\
 FROM example\n\
 JOIN example2 ON example.id = example2.id\n\
-WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE " ^ (match name with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name.set_param v)) name) ^ ")") ^ " AND " ^ (match name_2 with [] -> "FALSE" | _ :: _ -> "example2.name_2 IN " ^  "(" ^ String.concat ", " (List.map (fun v -> T.Types.Text.string_to_literal (Name2.set_param v)) name_2) ^ ")") ^ " AND example.id = ?") ~name:"select_3" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)

--- a/test/cram/type_unreserved.t
+++ b/test/cram/type_unreserved.t
@@ -129,14 +129,14 @@ produce a bare `type` keyword clash):
     module IO = Sqlgg_io.Blocking
   
     let create_kw db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw (type INT NOT NULL)") ~name:"create_kw" ~kind:Sqlgg_traits.Query.(Create "kw")) T.no_params
+      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw (type INT NOT NULL)") ~name:"create_kw" ~kind:Sqlgg_traits.Query.(Create "kw") ()) T.no_params
   
     let select_1 db  callback =
       let invoke_callback stmt =
         callback
           ~type_:(T.get_column_Int stmt 0)
       in
-      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params invoke_callback
+      T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     module Fold = struct
       let select_1 db  callback acc =
@@ -145,7 +145,7 @@ produce a bare `type` keyword clash):
             ~type_:(T.get_column_Int stmt 0)
         in
         let r_acc = ref acc in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x !r_acc))
         (fun () -> IO.return !r_acc)
   
     end (* module Fold *)
@@ -157,7 +157,7 @@ produce a bare `type` keyword clash):
             ~type_:(T.get_column_Int stmt 0)
         in
         let r_acc = ref [] in
-        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+        IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT type FROM kw") ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params (fun x -> r_acc := invoke_callback x :: !r_acc))
         (fun () -> IO.return (List.rev !r_acc))
   
     end (* module List *)

--- a/test/cram/where_in_composable.compare.ml
+++ b/test/cram/where_in_composable.compare.ml
@@ -7,7 +7,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `id2` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_random_table_1" ~kind:Sqlgg_traits.Query.(Create "random_table_1")) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_random_table_1" ~kind:Sqlgg_traits.Query.(Create "random_table_1") ()) T.no_params
 
   let select_1 db ~id ~ids2 callback =
     let invoke_callback stmt =
@@ -27,7 +27,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let select_2 db ~ids2 callback =
     let invoke_callback stmt =
@@ -39,7 +39,7 @@ WHERE \n\
       T.finish_params p
     in
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params invoke_callback
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   module Fold = struct
     let select_1 db ~id ~ids2 callback acc =
@@ -61,7 +61,7 @@ WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
     let select_2 db ~ids2 callback acc =
@@ -75,7 +75,7 @@ WHERE \n\
       in
       let r_acc = ref acc in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
       (fun () -> IO.return !r_acc)
 
   end (* module Fold *)
@@ -100,7 +100,7 @@ WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
 WHERE \n\
   " ^ (match id with `Another (ids) -> " ( " ^ (match ids with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids_0n, ids_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids_1n); Buffer.add_char _sqlgg_b ')') ids; Buffer.contents _sqlgg_b) ^ ")") ^ " ) " | `Andanother _ -> " ( ? > 2 ) " | `Lol (idss) -> " ( " ^ (match idss with [] -> "FALSE" | _ :: _ -> "`id` IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal idss) ^ ")") ^ " ) ") ^ " \n\
-  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+  OR " ^ (match ids2 with Some (ids2) -> " ( " ^ " " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")") ^ " " ^ " ) " | None -> " TRUE ")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
     let select_2 db ~ids2 callback =
@@ -114,7 +114,7 @@ WHERE \n\
       in
       let r_acc = ref [] in
       IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM random_table_1\n\
-WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat)) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+WHERE " ^ (match ids2 with [] -> "FALSE" | _ :: _ -> "(`id`, `id2`) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (ids2_0n, ids2_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Int.to_literal ids2_1n); Buffer.add_char _sqlgg_b ')') ids2; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
       (fun () -> IO.return (List.rev !r_acc))
 
   end (* module List *)


### PR DESCRIPTION
### Description

This PR adds `filename` to the query meta, so a query can be attributed to the sql file it was read from (unset for stdin).
