### PR TITLE
Update mariadb 2.1.0 and use COM_QUERY for statements without placeholders

### DIFF
--- a/impl/ocaml/mariadb/sqlgg_mariadb.ml
+++ b/impl/ocaml/mariadb/sqlgg_mariadb.ml
@@ -586,6 +586,17 @@ let select_one db q set_params convert =
 let execute db q set_params =
   with_stmt db q (fun stmt -> execute_with_stmt stmt set_params)
 
+let execute_unprepared db (q : Sqlgg_traits.Query.t) =
+  let open IO in
+  M.exec db q.sql >>=
+  check >>= fun (res : M.exec_result) ->
+  let insert_id =
+    match res.M.insert_id with
+    | 0 -> None
+    | x -> Some (Int64.of_int x)
+  in
+  return { affected_rows = Int64.of_int res.M.affected_rows; insert_id }
+
 let prepare db sql =
   let open IO in
   M.prepare db sql >>=

--- a/impl/ocaml/mysql/sqlgg_mysql.ml
+++ b/impl/ocaml/mysql/sqlgg_mysql.ml
@@ -444,6 +444,20 @@ let execute db q set_params =
   with_stmt db q (fun stmt ->
     execute_with_stmt stmt set_params)
 
+let execute_unprepared db (q : Sqlgg_traits.Query.t) =
+  let (_ : Mysql.result) = Mysql.exec db q.sql in
+  begin match Mysql.status db with
+  | Mysql.StatusError _ ->
+    oops "execute_unprepared (%s)" (match Mysql.errmsg db with Some e -> e | None -> "unknown error")
+  | Mysql.StatusOK | Mysql.StatusEmpty -> ()
+  end;
+  let insert_id =
+    match Mysql.insert_id db with
+    | 0L -> None
+    | x -> Some x
+  in
+  { affected_rows = Mysql.affected db; insert_id }
+
 let select_one_maybe db q set_params convert =
   with_stmt db q (fun stmt ->
     select_one_maybe_with_stmt stmt set_params convert)

--- a/impl/ocaml/sqlgg_stmt_cache.ml
+++ b/impl/ocaml/sqlgg_stmt_cache.ml
@@ -253,6 +253,9 @@ module Make_with_clock (Clock : Clock) (Config : Cache_config) (Impl : Cached_m)
     with_prepared_stmt cached_conn q (fun stmt ->
       Impl.execute_with_stmt stmt set_params)
 
+  let execute_unprepared cached_conn q =
+    Impl.execute_unprepared cached_conn.original q
+
   let cache_stats cached_conn =
     let state = cached_conn.state in
     Printf.sprintf "Cache: %d/%d items, %d ops since start" 
@@ -316,8 +319,12 @@ module SharedConnectionCache (MutexImpl : Mutex_intf) (Config : Cache_config)
       select_one_maybe conn.base_conn q set_params convert)
     
   let execute conn q set_params =
-    MutexImpl.with_lock conn.mutex (fun () -> 
+    MutexImpl.with_lock conn.mutex (fun () ->
       execute conn.base_conn q set_params)
+
+  let execute_unprepared conn q =
+    MutexImpl.with_lock conn.mutex (fun () ->
+      execute_unprepared conn.base_conn q)
 
   let cache_stats conn =  cache_stats conn.base_conn
 

--- a/impl/ocaml/sqlgg_traits.ml
+++ b/impl/ocaml/sqlgg_traits.ml
@@ -68,6 +68,12 @@ module type FNS = sig
     @raise Oops on error
   *)
   val execute : [>`WR] connection -> Query.t -> (statement -> result io_future) -> execute_response io_future
+
+  (** Execute non-query without preparing it on the server:
+    single statement, no placeholders, no result set.
+    @raise Oops on error
+  *)
+  val execute_unprepared : [>`WR] connection -> Query.t -> execute_response io_future
 end
 
 module type M = sig

--- a/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
+++ b/impl/ocaml/sqlite3/sqlgg_sqlite3.ml
@@ -320,6 +320,15 @@ let execute db q set_params =
   with_stmt db q (fun stmt ->
     execute_with_stmt stmt set_params)
 
+let execute_unprepared db (q : Sqlgg_traits.Query.t) =
+  test_ok q.sql (S.exec db q.sql);
+  let insert_id =
+    match S.last_insert_rowid db with
+    | 0L -> None
+    | x -> Some x
+  in
+  { affected_rows = Int64.of_int (S.changes db); insert_id }
+
 let select_one_maybe db q set_params convert =
   with_stmt db q (fun stmt ->
     select_one_maybe_with_stmt stmt set_params convert)

--- a/sqlgg.opam
+++ b/sqlgg.opam
@@ -40,5 +40,5 @@ of output columns and query parameters to the host language, trying to be as uno
 as possible and leaving the choice of SQL database (and API to access it) to the developer."""
 
 conflicts: [
-  "mariadb" {<= "1.3.0"}
+  "mariadb" {< "2.1.0"}
 ]

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -643,6 +643,14 @@ let output_params_binder _ vars =
   | [] -> "T.no_params"
   | vars -> emit_set_params ~count:(eval_count_params vars) (fun () -> List.iteri set_var vars)
 
+let rec has_bound_params vars =
+  List.exists (function
+    | Sql.Single _ -> true
+    | v -> has_bound_params (Sql.sub_vars v)) vars
+
+let can_execute_unprepared stmt =
+  stmt.Gen.schema = [] && not (has_bound_params stmt.Gen.vars)
+
 
 let make_to_literal meta typ =
   match resolve_codec codec_set_param typ meta with
@@ -976,7 +984,8 @@ let generate_stmt ~module_kind index stmt =
       | (`Direct | `Fold | `List), Stmt.Select (`Zero_one | `One) -> output_select1_cb index stmt.schema
       | _ -> output_schema_binder_labeled index stmt.schema
   in
-  let params_binder_name = output_params_binder index stmt.vars in
+  let unprepared = can_execute_unprepared stmt in
+  let params_binder_name = if unprepared then "" else output_params_binder index stmt.vars in
   c.c_init ();
   let callback =
     c.c_callback
@@ -985,7 +994,12 @@ let generate_stmt ~module_kind index stmt =
       ~list:(sprintf "(fun x -> r_acc := %s x :: !r_acc)" callback)
   in
   let (bind, bind_end) = c.c_bind in
-  let exec = sprintf "T.%s db %s %s %s%s" func (query_expr ~sql index stmt) params_binder_name callback bind_end in
+  let exec =
+    if unprepared then
+      sprintf "T.execute_unprepared db %s%s" (query_expr ~sql index stmt) bind_end
+    else
+      sprintf "T.%s db %s %s %s%s" func (query_expr ~sql index stmt) params_binder_name callback bind_end
+  in
   let exec =
     match
       List.find_map

--- a/src/gen_caml.ml
+++ b/src/gen_caml.ml
@@ -652,13 +652,15 @@ let can_execute_unprepared stmt =
   stmt.Gen.schema = [] && not (has_bound_params stmt.Gen.vars)
 
 
+let as_literal_type t = match t.Type.t with Blob -> Sql.Type.type_name t | _ -> L.as_lang_type t
+
 let make_to_literal meta typ =
   match resolve_codec codec_set_param typ meta with
   | Custom_codec setter ->
-    let trait_type_name = match typ.Type.t with | Union _ -> "Text" | StringLiteral _ -> "Text" | _ -> L.as_lang_type typ in
+    let trait_type_name = match typ.Type.t with | Union _ -> "Text" | StringLiteral _ -> "Text" | _ -> as_literal_type typ in
     sprintf "(fun v -> T.Types.%s.%s_to_literal (%s v))" trait_type_name (L.as_runtime_repr_name typ) setter
   | Enum_codec m -> sprintf "%s.to_literal" m
-  | Builtin_codec t -> sprintf "T.Types.%s.to_literal" (L.as_lang_type t)
+  | Builtin_codec t -> sprintf "T.Types.%s.to_literal" (as_literal_type t)
 
 let gen_in_substitution meta var =
   if Option.is_none var.id.value then failwith "empty label in IN param";

--- a/test/cram/blob_literal.compare.ml
+++ b/test/cram/blob_literal.compare.ml
@@ -1,0 +1,87 @@
+module Sqlgg (T : Sqlgg_traits.M) = struct
+
+  module IO = Sqlgg_io.Blocking
+
+  let create_files db  =
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE files (id INT, data BLOB, name TEXT)") ~name:"create_files" ~kind:Sqlgg_traits.Query.(Create "files") ())
+
+  let by_data db ~datas callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int_nullable stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match datas with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match datas with [] -> "FALSE" | _ :: _ -> "data IN " ^  "(" ^ String.concat ", " (List.map T.Types.Blob.to_literal datas) ^ ")")) ~name:"by_data" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  let by_name db ~names callback =
+    let invoke_callback stmt =
+      callback
+        ~id:(T.get_column_Int_nullable stmt 0)
+    in
+    let set_params stmt =
+      let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+      T.finish_params p
+    in
+    T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"by_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
+
+  module Fold = struct
+    let by_data db ~datas callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match datas with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match datas with [] -> "FALSE" | _ :: _ -> "data IN " ^  "(" ^ String.concat ", " (List.map T.Types.Blob.to_literal datas) ^ ")")) ~name:"by_data" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+    let by_name db ~names callback acc =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref acc in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"by_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x !r_acc))
+      (fun () -> IO.return !r_acc)
+
+  end (* module Fold *)
+  
+  module List = struct
+    let by_data db ~datas callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match datas with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match datas with [] -> "FALSE" | _ :: _ -> "data IN " ^  "(" ^ String.concat ", " (List.map T.Types.Blob.to_literal datas) ^ ")")) ~name:"by_data" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+    let by_name db ~names callback =
+      let invoke_callback stmt =
+        callback
+          ~id:(T.get_column_Int_nullable stmt 0)
+      in
+      let set_params stmt =
+        let p = T.start_params stmt (0 + (match names with [] -> 0 | _ :: _ -> 0)) in
+        T.finish_params p
+      in
+      let r_acc = ref [] in
+      IO.(>>=) (T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM files WHERE " ^ (match names with [] -> "FALSE" | _ :: _ -> "name IN " ^  "(" ^ String.concat ", " (List.map T.Types.Text.to_literal names) ^ ")")) ~name:"by_name" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params (fun x -> r_acc := invoke_callback x :: !r_acc))
+      (fun () -> IO.return (List.rev !r_acc))
+
+  end (* module List *)
+end (* module Sqlgg *)

--- a/test/cram/blob_literal.sql
+++ b/test/cram/blob_literal.sql
@@ -1,0 +1,7 @@
+CREATE TABLE files (id INT, data BLOB, name TEXT);
+
+-- @by_data
+SELECT id FROM files WHERE data IN @datas;
+
+-- @by_name
+SELECT id FROM files WHERE name IN @names;

--- a/test/cram/blob_literal.t
+++ b/test/cram/blob_literal.t
@@ -1,0 +1,34 @@
+Values spliced into SQL as literals are serialised by the traits, and a BLOB is not
+a TEXT there: `x'..'` versus `'..'`. So the literal path keeps them apart, even though
+the generated host language type is `string` for both.
+
+  $ /bin/sh ./sqlgg_test.sh blob_literal.sql blob_literal.compare.ml
+  $ echo $?
+  0
+
+The two serialisations through the mock traits:
+
+  $ cat blob_literal.sql | sqlgg -no-header -params unnamed -gen caml - > output.ml
+  $ cat > check.ml <<'EOF'
+  > module S = Output.Sqlgg (Print_impl)
+  > 
+  > let () =
+  >   Print_impl.clear_mock_responses ();
+  >   Print_impl.setup_select_response [];
+  >   S.by_data ~datas:[ "ab" ] () (fun ~id -> ignore id);
+  >   Print_impl.setup_select_response [];
+  >   S.by_name ~names:[ "ab" ] () (fun ~id -> ignore id)
+  > EOF
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c print_impl.ml
+  $ ocamlfind ocamlc -package sqlgg.traits -I . -c output.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -c check.ml
+  $ ocamlfind ocamlc -package sqlgg.traits,yojson -I . -linkpkg -o check.exe print_impl.cmo output.cmo check.cmo
+  $ ./check.exe
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[1]: SELECT id FROM files WHERE data IN (X'6162')
+  [SQL] SELECT id FROM files WHERE data IN (X'6162')
+  [MOCK] Returning 0 rows
+  [MOCK SELECT] Connection type: [> `RO ]
+  [MOCK] PREPARE[2]: SELECT id FROM files WHERE name IN ('ab')
+  [SQL] SELECT id FROM files WHERE name IN ('ab')
+  [MOCK] Returning 0 rows

--- a/test/cram/create_type.t
+++ b/test/cram/create_type.t
@@ -10,10 +10,10 @@ CREATE TYPE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ())
   
     let create_shirt db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ())
   
     let select_2 db  callback =
       let invoke_callback stmt =
@@ -23,7 +23,7 @@ CREATE TYPE
       T.select db (Sqlgg_traits.Query.make ~sql:("SELECT \"id\" FROM \"shirt\" WHERE \"color\" = 'red'") ~name:"select_2" ~kind:Sqlgg_traits.Query.(Select Nat) ()) T.no_params invoke_callback
   
     let drop_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ())
   
     module Fold = struct
       let select_2 db  callback acc =
@@ -89,16 +89,16 @@ CREATE DROP CREATE
     module IO = Sqlgg_io.Blocking
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('red', 'green', 'blue')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ())
   
     let drop_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("DROP TYPE \"color\"") ~name:"drop_type_color" ~kind:Sqlgg_traits.Query.(DropType "color") ())
   
     let create_type_color db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('black', 'white')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TYPE \"color\" AS ENUM ('black', 'white')") ~name:"create_type_color" ~kind:Sqlgg_traits.Query.(CreateType "color") ())
   
     let create_shirt db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE \"shirt\" (\"id\" INTEGER NOT NULL, \"color\" \"color\" NOT NULL)") ~name:"create_shirt" ~kind:Sqlgg_traits.Query.(Create "shirt") ())
   
     let select_4 db  callback =
       let invoke_callback stmt =

--- a/test/cram/dynamic_subquery.t
+++ b/test/cram/dynamic_subquery.t
@@ -176,7 +176,7 @@ Full generated code:
   
   
     let create_products db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price INT)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ())
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/enum_literals.compare.ml
+++ b/test/cram/enum_literals.compare.ml
@@ -15,9 +15,9 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     end)
 
   let create_test_status db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_status (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_status (\n\
   status ENUM('Failed','Skipped','Passed') NOT NULL\n\
-)") ~name:"create_test_status" ~kind:Sqlgg_traits.Query.(Create "test_status") ()) T.no_params
+)") ~name:"create_test_status" ~kind:Sqlgg_traits.Query.(Create "test_status") ())
 
   let test1 db ~status_list callback =
     let invoke_callback stmt =
@@ -31,13 +31,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT * FROM test_status WHERE " ^ (match status_list with [] -> "FALSE" | _ :: _ -> "status IN " ^  "(" ^ String.concat ", " (List.map Enum_0.to_literal status_list) ^ ")")) ~name:"test1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
   id INT NOT NULL,\n\
   status ENUM('Active','Inactive','Pending') NOT NULL\n\
-)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let test2 db ~rows =
-    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"test2" ~kind:Sqlgg_traits.Query.(Insert "users") ()) T.no_params )
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO users (id, status) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, status) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (Enum_1.to_literal status); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"test2" ~kind:Sqlgg_traits.Query.(Insert "users") ()))
 
   module Fold = struct
     let test1 db ~status_list callback acc =

--- a/test/cram/json_functions.compare.ml
+++ b/test/cram/json_functions.compare.ml
@@ -3,25 +3,25 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_people db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") ~name:"create_people" ~kind:Sqlgg_traits.Query.(Create "people") ()) T.no_params
+)") ~name:"create_people" ~kind:Sqlgg_traits.Query.(Create "people") ())
 
   let create_people_data_json_kind_never_null_but_col_nullable db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_but_col_nullable (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON\n\
-)") ~name:"create_people_data_json_kind_never_null_but_col_nullable" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_but_col_nullable") ()) T.no_params
+)") ~name:"create_people_data_json_kind_never_null_but_col_nullable" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_but_col_nullable") ())
 
   let create_people_data_json_kind_never_null_and_col_strict db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE people_data_json_kind_never_null_and_col_strict (\n\
   id INT AUTO_INCREMENT PRIMARY KEY,\n\
   data JSON NOT NULL\n\
-)") ~name:"create_people_data_json_kind_never_null_and_col_strict" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_and_col_strict") ()) T.no_params
+)") ~name:"create_people_data_json_kind_never_null_and_col_strict" ~kind:Sqlgg_traits.Query.(Create "people_data_json_kind_never_null_and_col_strict") ())
 
   let one db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO people (data) VALUES\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO people (data) VALUES\n\
   (JSON_OBJECT(\n\
     'name', 'Alice',\n\
     'age', 30,\n\
@@ -43,7 +43,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   (JSON_OBJECT(\n\
     'name', NULL,\n\
     'age', NULL\n\
-  ))") ~name:"one" ~kind:Sqlgg_traits.Query.(Insert "people") ()) T.no_params
+  ))") ~name:"one" ~kind:Sqlgg_traits.Query.(Insert "people") ())
 
   let two db  callback =
     let invoke_callback stmt =

--- a/test/cram/not_null_refine.compare.ml
+++ b/test/cram/not_null_refine.compare.ml
@@ -145,11 +145,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_items db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (\n\
   id INT NOT NULL,\n\
   name TEXT NULL,\n\
   descr TEXT NULL\n\
-)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
 
   let static_not_null db  callback =
     let invoke_callback stmt =

--- a/test/cram/print_impl.ml
+++ b/test/cram/print_impl.ml
@@ -591,6 +591,9 @@ let execute (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) (set_params : 
   | MockError msg -> raise (Oops msg)
   | _ -> failwith "Expected MockExecute response"
 
+let execute_unprepared (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) : execute_response =
+  execute db q no_params
+
 let select_one_maybe (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
   printf "[MOCK SELECT_ONE_MAYBE] Connection type: [> `RO ]\n";
   let stmt = prepare db q.Sqlgg_traits.Query.sql in

--- a/test/cram/print_ocaml_impl.ml
+++ b/test/cram/print_ocaml_impl.ml
@@ -462,6 +462,9 @@ let execute (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) (set_params : 
     { affected_rows; insert_id }
   | _ -> failwith "Expected MockExecute response"
 
+let execute_unprepared (db : [> `WR ] connection) (q : Sqlgg_traits.Query.t) : execute_response =
+  execute db q no_params
+
 let select_one_maybe (db : [> `RO ] connection) (q : Sqlgg_traits.Query.t) (set_params : statement -> result) (convert : row -> 'a) : 'a option =
   printf "[MOCK SELECT_ONE_MAYBE] Connection type: [> `RO ]\n";
   let stmt = (q.Sqlgg_traits.Query.sql, 0) in

--- a/test/cram/registration_feedbacks.compare.ml
+++ b/test/cram/registration_feedbacks.compare.ml
@@ -3,12 +3,12 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_registration_feedbacks db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   `user_message_2` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ()) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ())
 
   let test_name db ~id ~search =
     let get_row stmt =

--- a/test/cram/reusable_queries_as_ctes.compare.ml
+++ b/test/cram/reusable_queries_as_ctes.compare.ml
@@ -3,19 +3,19 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_categories db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE categories (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE categories (\n\
     id SERIAL PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL\n\
-)") ~name:"create_categories" ~kind:Sqlgg_traits.Query.(Create "categories") ()) T.no_params
+)") ~name:"create_categories" ~kind:Sqlgg_traits.Query.(Create "categories") ())
 
   let create_products db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
     id SERIAL PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL,\n\
     category_id INTEGER,\n\
     price NUMERIC(10, 2) NOT NULL,\n\
     FOREIGN KEY (category_id) REFERENCES categories(id)\n\
-)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ())
 
   let test2 db ~five ~param ~test ~test2 ~test5 callback =
     let invoke_callback stmt =

--- a/test/cram/set_default_syntax.compare.ml
+++ b/test/cram/set_default_syntax.compare.ml
@@ -3,12 +3,12 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_registration_feedbacks db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS registration_feedbacks (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `user_message` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT(''),\n\
   `grant_types` varchar(80) COLLATE utf8_bin NOT NULL DEFAULT 'implicit authorization_code',\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ()) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_registration_feedbacks" ~kind:Sqlgg_traits.Query.(Create "registration_feedbacks") ())
 
   let insert_registration_feedbacks_1 db ~user_message ~grant_types =
     let set_params stmt =

--- a/test/cram/test.t
+++ b/test/cram/test.t
@@ -919,7 +919,7 @@ Test Single style for SELECT 1/0..1 and hide empty modules:
     module IO = Sqlgg_io.Blocking
   
     let create_test20250902 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") ~name:"create_test20250902" ~kind:Sqlgg_traits.Query.(Create "test20250902") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test20250902 (id INT PRIMARY KEY, name TEXT)") ~name:"create_test20250902" ~kind:Sqlgg_traits.Query.(Create "test20250902") ())
   
     let select_1 db  =
       let get_row stmt =
@@ -969,11 +969,11 @@ Test non_nullifiable when update:
     module IO = Sqlgg_io.Blocking
   
     let create_non_nullifiable db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE non_nullifiable (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE non_nullifiable (\n\
       name TEXT,\n\
           updated_at DATETIME NULL,\n\
       updated_at_not_nullable DATETIME NOT NULL\n\
-  )") ~name:"create_non_nullifiable" ~kind:Sqlgg_traits.Query.(Create "non_nullifiable") ()) T.no_params
+  )") ~name:"create_non_nullifiable" ~kind:Sqlgg_traits.Query.(Create "non_nullifiable") ())
   
     let update_non_nullifiable_1 db ~updated_at =
       let set_params stmt =
@@ -1067,14 +1067,14 @@ Test non_nullifiable with multi-row INSERT (NULL allowed on insert):
     module IO = Sqlgg_io.Blocking
   
     let create_nn_insert_multi db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_multi (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_multi (\n\
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_insert_multi" ~kind:Sqlgg_traits.Query.(Create "nn_insert_multi") ()) T.no_params
+  )") ~name:"create_nn_insert_multi" ~kind:Sqlgg_traits.Query.(Create "nn_insert_multi") ())
   
     let insert_nn_insert_multi_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") ~name:"insert_nn_insert_multi_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_multi") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_multi (id, name, published_at) VALUES (1, 'a', NULL), (2, 'b', NULL)") ~name:"insert_nn_insert_multi_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_multi") ())
   
   end (* module Sqlgg *)
 
@@ -1121,11 +1121,11 @@ Test non_nullifiable with INSERT ... ON DUPLICATE KEY UPDATE (values nullable, N
     module IO = Sqlgg_io.Blocking
   
     let create_nn_upsert db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_upsert (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_upsert (\n\
       id INT PRIMARY KEY,\n\
           column1 INT NULL,\n\
           column2 VARCHAR(255) NULL\n\
-  )") ~name:"create_nn_upsert" ~kind:Sqlgg_traits.Query.(Create "nn_upsert") ()) T.no_params
+  )") ~name:"create_nn_upsert" ~kind:Sqlgg_traits.Query.(Create "nn_upsert") ())
   
     let insert_nn_upsert_1 db ~v1 ~v2 =
       let set_params stmt =
@@ -1162,20 +1162,20 @@ Test non_nullifiable with INSERT ... SELECT (source may produce NULLs):
     module IO = Sqlgg_io.Blocking
   
     let create_nn_src db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_src (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_src (\n\
       id INT PRIMARY KEY,\n\
       ts DATETIME\n\
-  )") ~name:"create_nn_src" ~kind:Sqlgg_traits.Query.(Create "nn_src") ()) T.no_params
+  )") ~name:"create_nn_src" ~kind:Sqlgg_traits.Query.(Create "nn_src") ())
   
     let create_nn_dst db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_dst (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_dst (\n\
       id INT PRIMARY KEY,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_dst" ~kind:Sqlgg_traits.Query.(Create "nn_dst") ()) T.no_params
+  )") ~name:"create_nn_dst" ~kind:Sqlgg_traits.Query.(Create "nn_dst") ())
   
     let insert_nn_dst_2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_dst (id, published_at)\n\
-  SELECT id, ts FROM nn_src") ~name:"insert_nn_dst_2" ~kind:Sqlgg_traits.Query.(Insert "nn_dst") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_dst (id, published_at)\n\
+  SELECT id, ts FROM nn_src") ~name:"insert_nn_dst_2" ~kind:Sqlgg_traits.Query.(Insert "nn_dst") ())
   
   end (* module Sqlgg *)
 
@@ -1194,14 +1194,14 @@ Test INSERT (.. ) VALUES @rows with non_nullifiable column (NULL allowed on inse
     module IO = Sqlgg_io.Blocking
   
     let create_nn_insert_param db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_param (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE nn_insert_param (\n\
       id INT PRIMARY KEY,\n\
       name TEXT,\n\
           published_at DATETIME\n\
-  )") ~name:"create_nn_insert_param" ~kind:Sqlgg_traits.Query.(Create "nn_insert_param") ()) T.no_params
+  )") ~name:"create_nn_insert_param" ~kind:Sqlgg_traits.Query.(Create "nn_insert_param") ())
   
     let insert_nn_insert_param_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_nn_insert_param_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_param") ()) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO nn_insert_param (id, name, published_at) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name, published_at) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match name with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match published_at with None -> "NULL" | Some v -> T.Types.Datetime.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_nn_insert_param_1" ~kind:Sqlgg_traits.Query.(Insert "nn_insert_param") ()))
   
   end (* module Sqlgg *)
 
@@ -1215,10 +1215,10 @@ Test INSERT (..) VALUES @rows with columns whose names are OCaml keywords (must 
     module IO = Sqlgg_io.Blocking
   
     let create_kw_rows db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw_rows (type INTEGER, val TEXT)") ~name:"create_kw_rows" ~kind:Sqlgg_traits.Query.(Create "kw_rows") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw_rows (type INTEGER, val TEXT)") ~name:"create_kw_rows" ~kind:Sqlgg_traits.Query.(Create "kw_rows") ())
   
     let insert_kw_rows_1 db ~rows =
-      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_kw_rows_1" ~kind:Sqlgg_traits.Query.(Insert "kw_rows") ()) T.no_params )
+      ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO kw_rows (type, val) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (type_, val_) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (match type_ with None -> "NULL" | Some v -> T.Types.Int.to_literal v); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (match val_ with None -> "NULL" | Some v -> T.Types.Text.to_literal v); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"insert_kw_rows_1" ~kind:Sqlgg_traits.Query.(Insert "kw_rows") ()))
   
   end (* module Sqlgg *)
 
@@ -1352,10 +1352,10 @@ order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let update_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None) ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("UPDATE test t SET t.column_a = 'value' ORDER BY t.id DESC LIMIT 10") ~name:"update_1" ~kind:Sqlgg_traits.Query.(Update None) ())
   
   end (* module Sqlgg *)
 
@@ -1369,7 +1369,7 @@ parametrized order by and limit are supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let update_1 db ~order ~direction ~limit =
       let set_params stmt =
@@ -1391,7 +1391,7 @@ limit is supported with update stmt + table alias:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let update_1 db ~limit =
       let set_params stmt =
@@ -1414,10 +1414,10 @@ order by and limit are supported with update stmt + table alias + join:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT PRIMARY KEY, column_a TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let create_test2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") ~name:"create_test2" ~kind:Sqlgg_traits.Query.(Create "test2") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test2 (id INT PRIMARY KEY, column_a TEXT, test_id INT NOT NULL)") ~name:"create_test2" ~kind:Sqlgg_traits.Query.(Create "test2") ())
   
     let update_2 db ~value ~order ~direction ~limit =
       let set_params stmt =
@@ -1467,18 +1467,18 @@ Test GROUP_CONCAT with ORDER BY expressions and join:
     module IO = Sqlgg_io.Blocking
   
     let create_table_1_2025_09_26 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_1_2025_09_26 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_1_2025_09_26 (\n\
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_1 DATE,\n\
       table_no INT\n\
-  )") ~name:"create_table_1_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_1_2025_09_26") ()) T.no_params
+  )") ~name:"create_table_1_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_1_2025_09_26") ())
   
     let create_table_2_2025_09_26 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_2_2025_09_26 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_2_2025_09_26 (\n\
       id INT PRIMARY KEY AUTO_INCREMENT,\n\
       date_2 DATE,\n\
       table_no INT\n\
-  )") ~name:"create_table_2_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_2_2025_09_26") ()) T.no_params
+  )") ~name:"create_table_2_2025_09_26" ~kind:Sqlgg_traits.Query.(Create "table_2_2025_09_26") ())
   
     let select_2 db ~order_kind ~par callback =
       let invoke_callback stmt =
@@ -1605,9 +1605,9 @@ INSERT ... SELECT with UNION ALL and enum meta propagation (short):
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum_union db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_union (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_union (\n\
       pending_type ENUM('downgrade','upgrade') NOT NULL\n\
-  )") ~name:"create_t_enum_union" ~kind:Sqlgg_traits.Query.(Create "t_enum_union") ()) T.no_params
+  )") ~name:"create_t_enum_union" ~kind:Sqlgg_traits.Query.(Create "t_enum_union") ())
   
     let insert_t_enum_union_1 db ~p =
       let set_params stmt =
@@ -1644,9 +1644,9 @@ INSERT ... SELECT with meta propagation:
       end)
   
     let create_t_dst db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_dst (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_dst (\n\
     status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_dst" ~kind:Sqlgg_traits.Query.(Create "t_dst") ()) T.no_params
+  )") ~name:"create_t_dst" ~kind:Sqlgg_traits.Query.(Create "t_dst") ())
   
     let insert_t_dst_1 db ~s =
       let set_params stmt =
@@ -1717,7 +1717,7 @@ Test UINT64 mapping for UNSIGNED INT:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1783,10 +1783,10 @@ Test UINT64 mapping for UNSIGNED INT with mapping:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (\n\
    id BIGINT UNSIGNED,\n\
    v INT\n\
-  )") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
+  )") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1849,7 +1849,7 @@ Test UINT64 in type spec:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id BIGINT UNSIGNED NOT NULL, v INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ())
   
     let insert_t1_1 db ~id =
       let set_params stmt =
@@ -1893,7 +1893,7 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1944,7 +1944,7 @@ Enum generation without custom module (should generate open variants):
       end)
   
     let create_t_enum1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum1 (status ENUM('a','b') NOT NULL)") ~name:"create_t_enum1" ~kind:Sqlgg_traits.Query.(Create "t_enum1") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -1993,9 +1993,9 @@ Enum generation with custom module (should not generate open variants, should us
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ()) T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2043,9 +2043,9 @@ Enum generation with custom module (should not generate open variants, should us
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum2 (\n\
       status ENUM('a','b') NOT NULL\n\
-  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ()) T.no_params
+  )") ~name:"create_t_enum2" ~kind:Sqlgg_traits.Query.(Create "t_enum2") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2102,10 +2102,10 @@ Enum mixed: one enum without module (generate 1 Enum_), one with module (skip):
       end)
   
     let create_t_enum_mix db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_mix (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_mix (\n\
     col_a ENUM('a','b') NOT NULL,\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") ~name:"create_t_enum_mix" ~kind:Sqlgg_traits.Query.(Create "t_enum_mix") ()) T.no_params
+  )") ~name:"create_t_enum_mix" ~kind:Sqlgg_traits.Query.(Create "t_enum_mix") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2155,9 +2155,9 @@ Enum only with custom module, including WHERE IN tuple param (should generate 0 
     module IO = Sqlgg_io.Blocking
   
     let create_t_enum_tuple db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_tuple (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t_enum_tuple (\n\
       col_b ENUM('x','y') NOT NULL\n\
-  )") ~name:"create_t_enum_tuple" ~kind:Sqlgg_traits.Query.(Create "t_enum_tuple") ()) T.no_params
+  )") ~name:"create_t_enum_tuple" ~kind:Sqlgg_traits.Query.(Create "t_enum_tuple") ())
   
     let select_1 db ~vals callback =
       let invoke_callback stmt =
@@ -2216,9 +2216,9 @@ Test meta propagation: IFNULL with ENUM column should propagate metadata to resu
     module IO = Sqlgg_io.Blocking
   
     let create_test_ifnull_enum db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_ifnull_enum (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_ifnull_enum (\n\
       priority ENUM('low','medium','high') NULL\n\
-  )") ~name:"create_test_ifnull_enum" ~kind:Sqlgg_traits.Query.(Create "test_ifnull_enum") ()) T.no_params
+  )") ~name:"create_test_ifnull_enum" ~kind:Sqlgg_traits.Query.(Create "test_ifnull_enum") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2265,9 +2265,9 @@ Test meta propagation: INSERT with Choices should propagate ENUM metadata to cho
     module IO = Sqlgg_io.Blocking
   
     let create_test_insert_choices db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_insert_choices (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_insert_choices (\n\
       status ENUM('pending','completed') NOT NULL\n\
-  )") ~name:"create_test_insert_choices" ~kind:Sqlgg_traits.Query.(Create "test_insert_choices") ()) T.no_params
+  )") ~name:"create_test_insert_choices" ~kind:Sqlgg_traits.Query.(Create "test_insert_choices") ())
   
     let insert_test_insert_choices_1 db ~x =
       let set_params stmt =
@@ -2324,10 +2324,10 @@ Test numeric literals and decimal types:
     module IO = Sqlgg_io.Blocking
   
     let create_shop_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shop_items (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shop_items (\n\
    id INT PRIMARY KEY,\n\
    pending_price DECIMAL(12,3)\n\
-  )") ~name:"create_shop_items" ~kind:Sqlgg_traits.Query.(Create "shop_items") ()) T.no_params
+  )") ~name:"create_shop_items" ~kind:Sqlgg_traits.Query.(Create "shop_items") ())
   
     let select_1 db ~pending_price callback =
       let invoke_callback stmt =
@@ -2392,10 +2392,10 @@ Test numeric literal to float:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ())
   
   end (* module Sqlgg *)
 
@@ -2409,10 +2409,10 @@ Test numeric literal to decimal - valid:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.99)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ())
   
   end (* module Sqlgg *)
 
@@ -2435,10 +2435,10 @@ Test numeric literal to decimal - invalid (too many decimals):
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(5,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.999)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (99.999)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ())
   
   end (* module Sqlgg *)
 
@@ -2470,7 +2470,7 @@ Test decimal to float - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2), price_float FLOAT)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -2517,10 +2517,10 @@ Test int to decimal - allowed:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let insert_items_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (100)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("INSERT INTO items VALUES (100)") ~name:"insert_items_1" ~kind:Sqlgg_traits.Query.(Insert "items") ())
   
   end (* module Sqlgg *)
 
@@ -2535,10 +2535,10 @@ Test decimal arithmetic preserves scale:
     module IO = Sqlgg_io.Blocking
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (col1 DECIMAL(10,2))") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (col1 DECIMAL(10,2))") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ())
   
     let create_t2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t2 (col2 DECIMAL(12,3))") ~name:"create_t2" ~kind:Sqlgg_traits.Query.(Create "t2") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t2 (col2 DECIMAL(12,3))") ~name:"create_t2" ~kind:Sqlgg_traits.Query.(Create "t2") ())
   
     let select_2 db  callback =
       let invoke_callback stmt =
@@ -2582,7 +2582,7 @@ Test parameter with decimal cast:
     module IO = Sqlgg_io.Blocking
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(12,3))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (price DECIMAL(12,3))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     let select_1 db ~price callback =
       let invoke_callback stmt =
@@ -2641,10 +2641,10 @@ Test REPLACE function for string substitution:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ())
   
     let update_table_24_10_2025_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") ~name:"update_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Update (Some "table_24_10_2025")) ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("UPDATE table_24_10_2025 SET col_1 = REPLACE(col_1, ',', ' ') WHERE col_2 = 'test'") ~name:"update_table_24_10_2025_1" ~kind:Sqlgg_traits.Query.(Update (Some "table_24_10_2025")) ())
   
   end (* module Sqlgg *)
 
@@ -2658,7 +2658,7 @@ Test REPLACE function with INSERT REPLACE in same query:
     module IO = Sqlgg_io.Blocking
   
     let create_table_24_10_2025 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_24_10_2025 (col_1 TEXT PRIMARY KEY, col_2 TEXT)") ~name:"create_table_24_10_2025" ~kind:Sqlgg_traits.Query.(Create "table_24_10_2025") ())
   
     let insert_table_24_10_2025_1 db ~value =
       let set_params stmt =
@@ -2688,12 +2688,12 @@ Test BIGINT(20) UNSIGNED with module annotation:
     module IO = Sqlgg_io.Blocking
   
     let create_test_table db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_table (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test_table (\n\
     id BIGINT(20) UNSIGNED NOT NULL,\n\
     counter INT(10) UNSIGNED NOT NULL,\n\
     counter2 BIGINT(10) UNSIGNED NOT NULL DEFAULT 0,\n\
     name TEXT\n\
-  )") ~name:"create_test_table" ~kind:Sqlgg_traits.Query.(Create "test_table") ()) T.no_params
+  )") ~name:"create_test_table" ~kind:Sqlgg_traits.Query.(Create "test_table") ())
   
     let select_1 db ~id callback =
       let invoke_callback stmt =
@@ -2834,14 +2834,14 @@ Test GROUP_CONCAT with multiple expressions and JSON_ARRAYAGG:
     module IO = Sqlgg_io.Blocking
   
     let create_orders db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
     id INT PRIMARY KEY,\n\
     customer_id INT NOT NULL,\n\
     product TEXT NOT NULL,\n\
     quantity INT NOT NULL,\n\
     price DECIMAL(10,2) NOT NULL,\n\
     description TEXT\n\
-  )") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
+  )") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3271,19 +3271,19 @@ Test DEFAULT dialect feature valid for mysql:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_ts_interval db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_interval (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_interval (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") ~name:"create_ok_ts_interval" ~kind:Sqlgg_traits.Query.(Create "ok_ts_interval") ()) T.no_params
+  )") ~name:"create_ok_ts_interval" ~kind:Sqlgg_traits.Query.(Create "ok_ts_interval") ())
   
     let create_ok_ts_func db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_func (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_ts_func (\n\
     ts DATETIME DEFAULT (DATE_ADD(CURRENT_TIMESTAMP, INTERVAL 1 DAY))\n\
-  )") ~name:"create_ok_ts_func" ~kind:Sqlgg_traits.Query.(Create "ok_ts_func") ()) T.no_params
+  )") ~name:"create_ok_ts_func" ~kind:Sqlgg_traits.Query.(Create "ok_ts_func") ())
   
     let create_ok_tidb_ts db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT (CURRENT_TIMESTAMP + INTERVAL 12 HOUR)\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ())
   
   end (* module Sqlgg *)
 
@@ -3319,9 +3319,9 @@ Test DEFAULT dialect feature valid for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_tidb_ts db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ())
   
   end (* module Sqlgg *)
 
@@ -3346,9 +3346,9 @@ Test DEFAULT dialect feature valid for sqlite:
     module IO = Sqlgg_io.Blocking
   
     let create_ok_tidb_ts db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE ok_tidb_ts (\n\
     ts DATETIME DEFAULT NOW()\n\
-  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ()) T.no_params
+  )") ~name:"create_ok_tidb_ts" ~kind:Sqlgg_traits.Query.(Create "ok_tidb_ts") ())
   
   end (* module Sqlgg *)
 
@@ -3364,10 +3364,10 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_t4 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t4 (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t4 (\n\
     id bigint PRIMARY KEY,\n\
     j json DEFAULT (JSON_OBJECT(\"a\", 1, \"b\", 2))\n\
-  )") ~name:"create_t4" ~kind:Sqlgg_traits.Query.(Create "t4") ()) T.no_params
+  )") ~name:"create_t4" ~kind:Sqlgg_traits.Query.(Create "t4") ())
   
   end (* module Sqlgg *)
 
@@ -3394,9 +3394,9 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_user_status db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE user_status (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE user_status (\n\
    status ENUM('active', 'inactive', 'banned') NOT NULL DEFAULT 'active'\n\
-  )") ~name:"create_user_status" ~kind:Sqlgg_traits.Query.(Create "user_status") ()) T.no_params
+  )") ~name:"create_user_status" ~kind:Sqlgg_traits.Query.(Create "user_status") ())
   
   end (* module Sqlgg *)
 
@@ -3412,9 +3412,9 @@ Test DEFAULT dialect feature valid json for tidb:
     module IO = Sqlgg_io.Blocking
   
     let create_tbl db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE tbl (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE tbl (\n\
    f1 INT NOT NULL DEFAULT 1\n\
-  )") ~name:"create_tbl" ~kind:Sqlgg_traits.Query.(Create "tbl") ()) T.no_params
+  )") ~name:"create_tbl" ~kind:Sqlgg_traits.Query.(Create "tbl") ())
   
   end (* module Sqlgg *)
 
@@ -3439,7 +3439,7 @@ Test IS NOT NULL type refinement:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3486,7 +3486,7 @@ Test IS NOT NULL type refinement with explicit NULL column:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT NULL)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =
@@ -3533,7 +3533,7 @@ Test IS NOT NULL type refinement with IS NULL:
     module IO = Sqlgg_io.Blocking
   
     let create_test db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE test (id INT, str TEXT, name TEXT)") ~name:"create_test" ~kind:Sqlgg_traits.Query.(Create "test") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =

--- a/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
+++ b/test/cram/test_build_dynamic_join/basic.t/basic.compare.ml
@@ -234,13 +234,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_orders db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (id INT PRIMARY KEY, user_id INT, total INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
+++ b/test/cram/test_build_dynamic_join/chain_bad.t/chain_bad.compare.ml
@@ -86,13 +86,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (id INT PRIMARY KEY, user_id INT, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, profile_id INT, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
+++ b/test/cram/test_build_dynamic_join/chains.t/chains.compare.ml
@@ -353,16 +353,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT, avatar_id INT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT, badge_id INT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ())
 
   let create_badges db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") ~name:"create_badges" ~kind:Sqlgg_traits.Query.(Create "badges") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE badges (id INT PRIMARY KEY, label TEXT)") ~name:"create_badges" ~kind:Sqlgg_traits.Query.(Create "badges") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/example.t/example.compare.ml
+++ b/test/cram/test_build_dynamic_join/example.t/example.compare.ml
@@ -164,31 +164,31 @@ WHERE u.org_id = ? AND u.deleted = FALSE") ~name:"user_info" ~kind:Sqlgg_traits.
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (\n\
   id INT PRIMARY KEY,\n\
   org_id INT NOT NULL,\n\
   name TEXT NOT NULL,\n\
   email TEXT NOT NULL,\n\
   created_at TIMESTAMP NOT NULL,\n\
   deleted BOOLEAN NOT NULL\n\
-)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (\n\
   user_id INT PRIMARY KEY,\n\
   bio TEXT,\n\
   avatar_url TEXT,\n\
   location TEXT,\n\
   website TEXT\n\
-)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_billing db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (\n\
   user_id INT PRIMARY KEY,\n\
   plan TEXT NOT NULL,\n\
   paid_until DATETIME,\n\
   balance INT NOT NULL\n\
-)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ()) T.no_params
+)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
+++ b/test/cram/test_build_dynamic_join/join_kinds.t/join_kinds.compare.ml
@@ -622,16 +622,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, user_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_orders db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (bio TEXT, amount INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (bio TEXT, amount INT)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ())
 
   let create_shipments db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shipments (user_id INT, status TEXT)") ~name:"create_shipments" ~kind:Sqlgg_traits.Query.(Create "shipments") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE shipments (user_id INT, status TEXT)") ~name:"create_shipments" ~kind:Sqlgg_traits.Query.(Create "shipments") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/key_shapes.t/key_shapes.compare.ml
@@ -225,13 +225,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, email TEXT, org INT, dept INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_accounts db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, label TEXT)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ())
 
   let create_memberships db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") ~name:"create_memberships" ~kind:Sqlgg_traits.Query.(Create "memberships") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE memberships (org INT, dept INT, title TEXT, PRIMARY KEY (org, dept))") ~name:"create_memberships" ~kind:Sqlgg_traits.Query.(Create "memberships") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
+++ b/test/cram/test_build_dynamic_join/multi.t/multi.compare.ml
@@ -252,13 +252,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, mentor_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_avatars db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE avatars (id INT PRIMARY KEY, url TEXT)") ~name:"create_avatars" ~kind:Sqlgg_traits.Query.(Create "avatars") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
+++ b/test/cram/test_build_dynamic_join/on_shapes.t/on_shapes.compare.ml
@@ -598,10 +598,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
+++ b/test/cram/test_build_dynamic_join/outside_refs.t/outside_refs.compare.ml
@@ -506,10 +506,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
+++ b/test/cram/test_build_dynamic_join/self_join.t/self_join.compare.ml
@@ -145,7 +145,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, manager_id INT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
+++ b/test/cram/test_build_dynamic_join/subquery_sources.t/subquery_sources.compare.ml
@@ -296,10 +296,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
+++ b/test/cram/test_build_dynamic_join/whitespace.t/whitespace.compare.ml
@@ -101,13 +101,13 @@ WHERE u.note = '  two  spaces  inside  ' AND u.id = ?") ~name:"ws" ~kind:Sqlgg_t
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT PRIMARY KEY, name TEXT, note TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let create_profiles db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE profiles (user_id INT PRIMARY KEY, bio TEXT)") ~name:"create_profiles" ~kind:Sqlgg_traits.Query.(Create "profiles") ())
 
   let create_billing db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE billing (user_id INT PRIMARY KEY, plan TEXT)") ~name:"create_billing" ~kind:Sqlgg_traits.Query.(Create "billing") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_dynamic_select/run.t
+++ b/test/cram/test_dynamic_select/run.t
@@ -503,7 +503,7 @@ Test DynamicSelect edge: single column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -595,7 +595,7 @@ DynamicSelect: SELECT * remains static select:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -696,7 +696,7 @@ DynamicSelect: SELECT * with expression in same list:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -797,7 +797,7 @@ DynamicSelect: auto names for expressions without alias:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -880,7 +880,7 @@ Test DynamicSelect edge: expression at first position:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -972,7 +972,7 @@ Test DynamicSelect edge: literal only:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1091,7 +1091,7 @@ Test DynamicSelect edge: many columns:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT, c DECIMAL(10,2), d INT, e TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1192,7 +1192,7 @@ Test DynamicSelect edge: no space after commas:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1284,7 +1284,7 @@ Test DynamicSelect edge: minimal spacing:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1367,7 +1367,7 @@ Test DynamicSelect edge: column without alias gets auto name:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1488,7 +1488,7 @@ Test DynamicSelect with dynamic_select flag:
   
   
     let create_accounts db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (id INT PRIMARY KEY, balance DECIMAL(10,2))") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1598,7 +1598,7 @@ Test DynamicSelect with two dynamic columns:
   
   
     let create_items db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1699,7 +1699,7 @@ Test DynamicSelect with Verbatim branches:
   
   
     let create_users db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT, status TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT, status TEXT)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1791,7 +1791,7 @@ Test DynamicSelect at beginning of SELECT:
   
   
     let create_data db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE data (a INT, b TEXT)") ~name:"create_data" ~kind:Sqlgg_traits.Query.(Create "data") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE data (a INT, b TEXT)") ~name:"create_data" ~kind:Sqlgg_traits.Query.(Create "data") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1883,7 +1883,7 @@ Test DynamicSelect disabled in subquery (fallback to Choice):
   
   
     let create_t1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t1 (id INT)") ~name:"create_t1" ~kind:Sqlgg_traits.Query.(Create "t1") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -1958,11 +1958,11 @@ Test DynamicSelect with module annotation:
   
   
     let create_wrapped db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE wrapped (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE wrapped (\n\
           id INT PRIMARY KEY,\n\
       name TEXT,\n\
       price DECIMAL(10,2)\n\
-  )") ~name:"create_wrapped" ~kind:Sqlgg_traits.Query.(Create "wrapped") ()) T.no_params
+  )") ~name:"create_wrapped" ~kind:Sqlgg_traits.Query.(Create "wrapped") ())
   
     module Single = struct
     end (* module Single *)
@@ -2020,7 +2020,7 @@ Test DynamicSelect with LIMIT 1 (select_one):
   
   
     let create_products db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (id INT PRIMARY KEY, name TEXT, price DECIMAL(10,2))") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ())
   
     module Single = struct
     end (* module Single *)
@@ -2157,13 +2157,13 @@ Test DynamicSelect comprehensive list:
   
   
     let create_products db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
    id INT PRIMARY KEY,\n\
    name TEXT,\n\
    price DECIMAL(10,2),\n\
    category TEXT,\n\
    stock INT\n\
-  )") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
+  )") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2262,7 +2262,7 @@ Virtual select: param as bare column expression (spacing at ctor boundary):
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, val TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, val TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2362,7 +2362,7 @@ Virtual select: consecutive params as columns:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2479,7 +2479,7 @@ Virtual select: mixed columns and params without spaces after commas:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2571,7 +2571,7 @@ Virtual select: subquery expression as dynamic column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2669,7 +2669,7 @@ Virtual select: CASE WHEN as dynamic column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, status INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, status INT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2761,7 +2761,7 @@ Virtual select: function call with multiple args as column:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, first_name TEXT, last_name TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2860,7 +2860,7 @@ Virtual select: arithmetic with param at expression start:
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (id INT, price DECIMAL(10,2))") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)
@@ -2959,7 +2959,7 @@ Virtual select: tab-separated columns (non-space whitespace):
   
   
     let create_t db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (a INT, b TEXT)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
   
     module Fold = struct
     end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/compose.compare.ml
+++ b/test/cram/test_dynamic_select_compose/compose.compare.ml
@@ -703,10 +703,10 @@ ORDER BY " ^ ((match sort with `I -> " ( id ) " | `N -> " ( name ) "))) ~name:"k
 
 
   let create_t db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT,\n\
     name TEXT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_dynamic_select_compose/cte.compare.ml
+++ b/test/cram/test_dynamic_select_compose/cte.compare.ml
@@ -612,11 +612,11 @@ WHERE id IN (SELECT id FROM t WHERE status = ? AND " ^ ((match names with [] -> 
 
 
   let create_t db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT,\n\
     name TEXT,\n\
     status INT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_meta/meta.compare.ml
+++ b/test/cram/test_meta/meta.compare.ml
@@ -3,93 +3,93 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_accounts db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE accounts (\n\
   id BIGINT NOT NULL,\n\
     cid BIGINT NOT NULL,\n\
     status TEXT NOT NULL,\n\
   plain TEXT NOT NULL\n\
-)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ()) T.no_params
+)") ~name:"create_accounts" ~kind:Sqlgg_traits.Query.(Create "accounts") ())
 
   let create_orders db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE orders (\n\
     id BIGINT NOT NULL,\n\
     amount DECIMAL(10,2) NOT NULL\n\
-)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ()) T.no_params
+)") ~name:"create_orders" ~kind:Sqlgg_traits.Query.(Create "orders") ())
 
   let create_events db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE events (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE events (\n\
   order_ref BIGINT NOT NULL,\n\
   amount BIGINT NOT NULL\n\
-)") ~name:"create_events" ~kind:Sqlgg_traits.Query.(Create "events") ()) T.no_params
+)") ~name:"create_events" ~kind:Sqlgg_traits.Query.(Create "events") ())
 
   let create_named_owners db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owners (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owners (\n\
     id BIGINT NOT NULL,\n\
   title TEXT NOT NULL\n\
-)") ~name:"create_named_owners" ~kind:Sqlgg_traits.Query.(Create "named_owners") ()) T.no_params
+)") ~name:"create_named_owners" ~kind:Sqlgg_traits.Query.(Create "named_owners") ())
 
   let create_named_owned db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owned (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE named_owned (\n\
   id BIGINT NOT NULL,\n\
   note TEXT NOT NULL\n\
-)") ~name:"create_named_owned" ~kind:Sqlgg_traits.Query.(Create "named_owned") ()) T.no_params
+)") ~name:"create_named_owned" ~kind:Sqlgg_traits.Query.(Create "named_owned") ())
 
   let create_other_domain db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE other_domain (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE other_domain (\n\
     id BIGINT NOT NULL\n\
-)") ~name:"create_other_domain" ~kind:Sqlgg_traits.Query.(Create "other_domain") ()) T.no_params
+)") ~name:"create_other_domain" ~kind:Sqlgg_traits.Query.(Create "other_domain") ())
 
   let create_owners db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owners (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owners (\n\
     id BIGINT NOT NULL PRIMARY KEY\n\
-)") ~name:"create_owners" ~kind:Sqlgg_traits.Query.(Create "owners") ()) T.no_params
+)") ~name:"create_owners" ~kind:Sqlgg_traits.Query.(Create "owners") ())
 
   let create_owned db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owned (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE owned (\n\
   owner_ref BIGINT NOT NULL,\n\
   loose BIGINT NOT NULL,\n\
   FOREIGN KEY (owner_ref) REFERENCES owners(id)\n\
-)") ~name:"create_owned" ~kind:Sqlgg_traits.Query.(Create "owned") ()) T.no_params
+)") ~name:"create_owned" ~kind:Sqlgg_traits.Query.(Create "owned") ())
 
   let create_unrelated db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE unrelated (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE unrelated (\n\
   owner_ref BIGINT NOT NULL\n\
-)") ~name:"create_unrelated" ~kind:Sqlgg_traits.Query.(Create "unrelated") ()) T.no_params
+)") ~name:"create_unrelated" ~kind:Sqlgg_traits.Query.(Create "unrelated") ())
 
   let create_projects db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE projects (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE projects (\n\
   id BIGINT NOT NULL,\n\
     company_id BIGINT NOT NULL\n\
-)") ~name:"create_projects" ~kind:Sqlgg_traits.Query.(Create "projects") ()) T.no_params
+)") ~name:"create_projects" ~kind:Sqlgg_traits.Query.(Create "projects") ())
 
   let create_alerts db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE alerts (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE alerts (\n\
   dashboard_id BIGINT NOT NULL,\n\
   company_id BIGINT NOT NULL\n\
-)") ~name:"create_alerts" ~kind:Sqlgg_traits.Query.(Create "alerts") ()) T.no_params
+)") ~name:"create_alerts" ~kind:Sqlgg_traits.Query.(Create "alerts") ())
 
   let create_courses db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE courses (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE courses (\n\
     slug TEXT NOT NULL,\n\
     seconds BIGINT NOT NULL\n\
-)") ~name:"create_courses" ~kind:Sqlgg_traits.Query.(Create "courses") ()) T.no_params
+)") ~name:"create_courses" ~kind:Sqlgg_traits.Query.(Create "courses") ())
 
   let create_left_rows db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE left_rows (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE left_rows (\n\
     id BIGINT NOT NULL\n\
-)") ~name:"create_left_rows" ~kind:Sqlgg_traits.Query.(Create "left_rows") ()) T.no_params
+)") ~name:"create_left_rows" ~kind:Sqlgg_traits.Query.(Create "left_rows") ())
 
   let create_right_rows db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE right_rows (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE right_rows (\n\
     id BIGINT NOT NULL,\n\
     status ENUM('draft','published','failed') NOT NULL\n\
-)") ~name:"create_right_rows" ~kind:Sqlgg_traits.Query.(Create "right_rows") ()) T.no_params
+)") ~name:"create_right_rows" ~kind:Sqlgg_traits.Query.(Create "right_rows") ())
 
   let create_codec_rows db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE codec_rows (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE codec_rows (\n\
   id INT NOT NULL,\n\
       status ENUM('new','paid','shipped') NOT NULL\n\
-)") ~name:"create_codec_rows" ~kind:Sqlgg_traits.Query.(Create "codec_rows") ()) T.no_params
+)") ~name:"create_codec_rows" ~kind:Sqlgg_traits.Query.(Create "codec_rows") ())
 
   let shared_by_equality db  callback =
     let invoke_callback stmt =

--- a/test/cram/test_migrations/closed-loop-5tables.t/run.t
+++ b/test/cram/test_migrations/closed-loop-5tables.t/run.t
@@ -17,10 +17,10 @@ Step 2 - day-to-day change: target.sql adds `posts.views`.
     module IO = T.IO
   
     let apply_20260101000000_alter_posts_add_col_views db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") ~name:"apply_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `views` INT NOT NULL DEFAULT 0") ~name:"apply_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_posts_add_col_views db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `views`") ~name:"revert_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `views`") ~name:"revert_20260101000000_alter_posts_add_col_views" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("20260101000000_alter_posts_add_col_views", apply_20260101000000_alter_posts_add_col_views, revert_20260101000000_alter_posts_add_col_views);

--- a/test/cram/test_migrations/diff-add-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101000000_alter_users_add_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/diff-add-index.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-index.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") ~name:"apply_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD UNIQUE INDEX `email_idx` (`email`)") ~name:"apply_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101000000_alter_users_add_unique_email_idx db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP INDEX `email_idx`") ~name:"revert_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP INDEX `email_idx`") ~name:"revert_20260101000000_alter_users_add_unique_email_idx" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101000000_alter_users_add_unique_email_idx", apply_20260101000000_alter_users_add_unique_email_idx, revert_20260101000000_alter_users_add_unique_email_idx);

--- a/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
+++ b/test/cram/test_migrations/diff-add-primary-key.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_add_pk db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") ~name:"apply_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD PRIMARY KEY (`id`)") ~name:"apply_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101000000_alter_users_add_pk db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP PRIMARY KEY") ~name:"revert_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP PRIMARY KEY") ~name:"revert_20260101000000_alter_users_add_pk" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101000000_alter_users_add_pk", apply_20260101000000_alter_users_add_pk, revert_20260101000000_alter_users_add_pk);

--- a/test/cram/test_migrations/diff-change-type.t/migrations.ml
+++ b/test/cram/test_migrations/diff-change-type.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101000000_alter_users_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101000000_alter_users_change_col_id" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101000000_alter_users_change_col_id", apply_20260101000000_alter_users_change_col_id, revert_20260101000000_alter_users_change_col_id);

--- a/test/cram/test_migrations/diff-create-unique-index.t/run.t
+++ b/test/cram/test_migrations/diff-create-unique-index.t/run.t
@@ -14,11 +14,11 @@ the whole apply string, so it shows the result.)
     module IO = T.IO
   
     let apply_20260101000000_create_u db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE `u` (`id` INT, `email` VARCHAR(255), PRIMARY KEY (`id`));\n\
-  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") ~name:"apply_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE `u` (`id` INT, `email` VARCHAR(255), PRIMARY KEY (`id`));\n\
+  ALTER TABLE `u` ADD UNIQUE INDEX `uniq_email` (`email`)") ~name:"apply_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_create_u db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("DROP TABLE `u`") ~name:"revert_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("DROP TABLE `u`") ~name:"revert_20260101000000_create_u" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("20260101000000_create_u", apply_20260101000000_create_u, revert_20260101000000_create_u);

--- a/test/cram/test_migrations/diff-drop-column.t/migrations.ml
+++ b/test/cram/test_migrations/diff-drop-column.t/migrations.ml
@@ -3,10 +3,10 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101000000_alter_users_drop_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"apply_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"apply_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101000000_alter_users_drop_col_age db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"revert_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"revert_20260101000000_alter_users_drop_col_age" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101000000_alter_users_drop_col_age", apply_20260101000000_alter_users_drop_col_age, revert_20260101000000_alter_users_drop_col_age);

--- a/test/cram/test_migrations/diff-three-changes.t/migrations.ml
+++ b/test/cram/test_migrations/diff-three-changes.t/migrations.ml
@@ -3,22 +3,22 @@ module Mig (T : Sqlgg_traits.M_io) = struct
   module IO = T.IO
 
   let apply_20260101120000_alter_c_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` BIGINT NOT NULL") ~name:"apply_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101120000_alter_c_change_col_id db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `c` CHANGE COLUMN `id` `id` INT NOT NULL") ~name:"revert_20260101120000_alter_c_change_col_id" ~kind:Sqlgg_traits.Query.Other ())
 
   let apply_20260101120000_alter_b_drop_col_old db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` DROP COLUMN `old`") ~name:"apply_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` DROP COLUMN `old`") ~name:"apply_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101120000_alter_b_drop_col_old db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") ~name:"revert_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `b` ADD COLUMN `old` INT NOT NULL") ~name:"revert_20260101120000_alter_b_drop_col_old" ~kind:Sqlgg_traits.Query.Other ())
 
   let apply_20260101120000_alter_a_add_col_x db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") ~name:"apply_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` ADD COLUMN `x` INT NOT NULL") ~name:"apply_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ())
 
   let revert_20260101120000_alter_a_add_col_x db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` DROP COLUMN `x`") ~name:"revert_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `a` DROP COLUMN `x`") ~name:"revert_20260101120000_alter_a_add_col_x" ~kind:Sqlgg_traits.Query.Other ())
 
   let migrations = [
     ("20260101120000_alter_c_change_col_id", apply_20260101120000_alter_c_change_col_id, revert_20260101120000_alter_c_change_col_id);

--- a/test/cram/test_migrations/diff-ttl.t/run.t
+++ b/test/cram/test_migrations/diff-ttl.t/run.t
@@ -57,10 +57,10 @@ The full -migrate cycle generates apply/revert code for the TTL change:
     module IO = T.IO
   
     let apply_20260101000000_alter_foo_set_ttl db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") ~name:"apply_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` TTL = `created_at` + INTERVAL 6 MONTH TTL_ENABLE = 'ON'") ~name:"apply_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_foo_set_ttl db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` REMOVE TTL") ~name:"revert_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `foo` REMOVE TTL") ~name:"revert_20260101000000_alter_foo_set_ttl" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("20260101000000_alter_foo_set_ttl", apply_20260101000000_alter_foo_set_ttl, revert_20260101000000_alter_foo_set_ttl);

--- a/test/cram/test_migrations/dune-codegen.t/run.t
+++ b/test/cram/test_migrations/dune-codegen.t/run.t
@@ -35,16 +35,16 @@ current, so -migrate only regenerates and prints the human note to stderr:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-irreversible.t
+++ b/test/cram/test_migrations/migrate-irreversible.t
@@ -30,17 +30,17 @@ delta keeps a real one:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN legacy") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN legacy") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_0 db  =
       ignore db;
       IO.return { T.affected_rows = 0L; insert_id = None }
   
     let apply_20260101000000_alter_users_add_col_name db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `name` TEXT") ~name:"apply_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `name` TEXT") ~name:"apply_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_users_add_col_name db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `name`") ~name:"revert_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `name`") ~name:"revert_20260101000000_alter_users_add_col_name" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
+++ b/test/cram/test_migrations/migrate-long-mixed-sequence.t/run.t
@@ -76,40 +76,40 @@ The generated code merges everything by id: manual (day-pinned) and generated
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `email` TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `email` TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `email`") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `email`") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_alter_posts_2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") ~name:"apply_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `author_id` INT NOT NULL") ~name:"apply_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_posts_2 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `author_id`") ~name:"revert_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `author_id`") ~name:"revert_alter_posts_2" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_alter_posts_3 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts ADD COLUMN body TEXT") ~name:"apply_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts ADD COLUMN body TEXT") ~name:"apply_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_posts_3 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts DROP COLUMN body") ~name:"revert_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE posts DROP COLUMN body") ~name:"revert_alter_posts_3" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_20260101000000_alter_posts_add_col_published db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") ~name:"apply_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` ADD COLUMN `published` INT NOT NULL") ~name:"apply_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_posts_add_col_published db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `published`") ~name:"revert_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `posts` DROP COLUMN `published`") ~name:"revert_20260101000000_alter_posts_add_col_published" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `created_at` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_users_add_col_created_at db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `created_at`") ~name:"revert_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `created_at`") ~name:"revert_20260101000000_alter_users_add_col_created_at" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-loop.t/run.t
+++ b/test/cram/test_migrations/migrate-loop.t/run.t
@@ -24,10 +24,10 @@ The code is regenerated from the migration SQL:
     module IO = T.IO
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("20260101000000_alter_users_add_col_age", apply_20260101000000_alter_users_add_col_age, revert_20260101000000_alter_users_add_col_age);

--- a/test/cram/test_migrations/migrate-manual-mix.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-mix.t/run.t
@@ -34,16 +34,16 @@ The code merges both by id (manual day 20251231 first, generated 20260101000000_
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN bio TEXT") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN bio") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101000000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101000000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-manual-only.t/run.t
+++ b/test/cram/test_migrations/migrate-manual-only.t/run.t
@@ -26,10 +26,10 @@ But the code is regenerated and contains the hand-written rename:
     module IO = T.IO
   
     let apply_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email TO email_address") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email TO email_address") ~name:"apply_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_0 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email_address TO email") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users RENAME COLUMN email_address TO email") ~name:"revert_alter_users_0" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("alter_users_0", apply_alter_users_0, revert_alter_users_0);

--- a/test/cram/test_migrations/migrate-timestamp.t/run.t
+++ b/test/cram/test_migrations/migrate-timestamp.t/run.t
@@ -42,22 +42,22 @@ The code merges all three by id, so the manual `status` sits between `age` and
     module IO = T.IO
   
     let apply_20260101120000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `age` INT NOT NULL") ~name:"apply_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260101120000_alter_users_add_col_age db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `age`") ~name:"revert_20260101120000_alter_users_add_col_age" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users ADD COLUMN status INT NOT NULL DEFAULT 1") ~name:"apply_alter_users_1" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_alter_users_1 db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN status") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE users DROP COLUMN status") ~name:"revert_alter_users_1" ~kind:Sqlgg_traits.Query.Other ())
   
     let apply_20260102000000_alter_users_add_col_city db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `city` TEXT") ~name:"apply_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` ADD COLUMN `city` TEXT") ~name:"apply_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ())
   
     let revert_20260102000000_alter_users_add_col_city db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `city`") ~name:"revert_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("ALTER TABLE `users` DROP COLUMN `city`") ~name:"revert_20260102000000_alter_users_add_col_city" ~kind:Sqlgg_traits.Query.Other ())
   
     let migrations = [
       ("20260101120000_alter_users_add_col_age", apply_20260101120000_alter_users_add_col_age, revert_20260101120000_alter_users_add_col_age);

--- a/test/cram/test_query_meta/app.ml
+++ b/test/cram/test_query_meta/app.ml
@@ -38,6 +38,7 @@ module Annotating_impl = struct
   let select_one db q = Print_ocaml_impl.select_one db (annotate q)
   let select_one_maybe db q = Print_ocaml_impl.select_one_maybe db (annotate q)
   let execute db q = Print_ocaml_impl.execute db (annotate q)
+  let execute_unprepared db q = Print_ocaml_impl.execute_unprepared db (annotate q)
 
 end
 

--- a/test/cram/test_query_meta/queries.compare.ml
+++ b/test/cram/test_query_meta/queries.compare.ml
@@ -3,7 +3,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NOT NULL, email TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let find_user db ~id callback =
     let invoke_callback stmt =
@@ -37,7 +37,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.select db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("SELECT id, name FROM users WHERE " ^ (match ids with [] -> "FALSE" | _ :: _ -> "id IN " ^  "(" ^ String.concat ", " (List.map T.Types.Int.to_literal ids) ^ ")")) ~name:"find_users" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let add_users db ~rows =
-    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("INSERT INTO users (id, name) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal name); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users") ()) T.no_params )
+    ( match rows with [] -> IO.return { T.affected_rows = 0L; insert_id = None } | _ :: _ -> T.execute_unprepared db (Sqlgg_traits.Query.make ~filename:"queries.sql" ~sql:("INSERT INTO users (id, name) VALUES " ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (id, name) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b (T.Types.Int.to_literal id); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b (T.Types.Text.to_literal name); Buffer.add_char _sqlgg_b ')') rows; Buffer.contents _sqlgg_b)) ~name:"add_users" ~kind:Sqlgg_traits.Query.(Insert "users") ()))
 
   let rename_user db ~name ~id =
     let set_params stmt =

--- a/test/cram/test_query_meta/routing_app.ml
+++ b/test/cram/test_query_meta/routing_app.ml
@@ -37,6 +37,10 @@ module Routed_db = struct
     if per_request q then Print_impl.execute db.Cache.original (annotate_per_request q) set_params
     else Cache.execute db (annotate_static q) set_params
 
+  let execute_unprepared db q =
+    if per_request q then Print_impl.execute_unprepared db.Cache.original (annotate_per_request q)
+    else Cache.execute_unprepared db (annotate_static q)
+
 end
 
 module Naive_db = struct
@@ -47,6 +51,7 @@ module Naive_db = struct
   let select_one db q set_params conv = Cache.select_one db (annotate_per_request q) set_params conv
   let select_one_maybe db q set_params conv = Cache.select_one_maybe db (annotate_per_request q) set_params conv
   let execute db q set_params = Cache.execute db (annotate_per_request q) set_params
+  let execute_unprepared db q = Cache.execute_unprepared db (annotate_per_request q)
 
 end
 

--- a/test/cram/test_scoped_select/scope.expected.ml
+++ b/test/cram/test_scoped_select/scope.expected.ml
@@ -144,13 +144,13 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_products db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE products (\n\
     id INT PRIMARY KEY,\n\
     name TEXT,\n\
     price DECIMAL(10,2),\n\
     category TEXT,\n\
     stock INT\n\
-)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ()) T.no_params
+)") ~name:"create_products" ~kind:Sqlgg_traits.Query.(Create "products") ())
 
   module Single = struct
   end (* module Single *)

--- a/test/cram/test_shared_choice/shared.compare.ml
+++ b/test/cram/test_shared_choice/shared.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_t db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE t (\n\
     id INT NOT NULL,\n\
     name TEXT,\n\
     status INT\n\
-)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ()) T.no_params
+)") ~name:"create_t" ~kind:Sqlgg_traits.Query.(Create "t") ())
 
   let shared_const db ~x callback =
     let invoke_callback stmt =

--- a/test/cram/test_static_flags/both.t/both.compare.ml
+++ b/test/cram/test_static_flags/both.t/both.compare.ml
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =

--- a/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
+++ b/test/cram/test_static_flags/dynamic_only.t/dynamic_only.compare.ml
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   module Fold = struct
   end (* module Fold *)

--- a/test/cram/test_static_flags/global.t/global.compare.ml
+++ b/test/cram/test_static_flags/global.t/global.compare.ml
@@ -148,7 +148,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =

--- a/test/cram/test_static_flags/je_static.t/je_static.compare.ml
+++ b/test/cram/test_static_flags/je_static.t/je_static.compare.ml
@@ -92,10 +92,10 @@ WHERE i.id > ?") ~name:"wide" ~kind:Sqlgg_traits.Query.(Select Nat) ())
 
 
   let create_items db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE items (id INT NOT NULL PRIMARY KEY, name TEXT NULL)") ~name:"create_items" ~kind:Sqlgg_traits.Query.(Create "items") ())
 
   let create_stats db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") ~name:"create_stats" ~kind:Sqlgg_traits.Query.(Create "stats") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE stats (item_id INT NOT NULL PRIMARY KEY, sold INT NULL)") ~name:"create_stats" ~kind:Sqlgg_traits.Query.(Create "stats") ())
 
   let wide_static db ~min_id callback =
     let invoke_callback stmt =

--- a/test/cram/test_static_flags/override.t/override.compare.ml
+++ b/test/cram/test_static_flags/override.t/override.compare.ml
@@ -77,7 +77,7 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
 
 
   let create_users db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ()) T.no_params
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE users (id INT NOT NULL, name TEXT NULL)") ~name:"create_users" ~kind:Sqlgg_traits.Query.(Create "users") ())
 
   let get_user_static db ~id callback =
     let invoke_callback stmt =

--- a/test/cram/type_mappings.compare.ml
+++ b/test/cram/type_mappings.compare.ml
@@ -3,16 +3,16 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_table_37 db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_37 (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_37 (\n\
                 col_1 INT PRIMARY KEY,\n\
                         col_2 INT NOT NULL\n\
-      )") ~name:"create_table_37" ~kind:Sqlgg_traits.Query.(Create "table_37") ()) T.no_params
+      )") ~name:"create_table_37" ~kind:Sqlgg_traits.Query.(Create "table_37") ())
 
   let create_table_38 db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_38 (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE table_38 (\n\
                 col_3 INT PRIMARY KEY,\n\
         col_4 TEXT NOT NULL\n\
-      )") ~name:"create_table_38" ~kind:Sqlgg_traits.Query.(Create "table_38") ()) T.no_params
+      )") ~name:"create_table_38" ~kind:Sqlgg_traits.Query.(Create "table_38") ())
 
   let select_2 db  callback =
     let invoke_callback stmt =

--- a/test/cram/type_mappings_params.compare.ml
+++ b/test/cram/type_mappings_params.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_example db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example (\n\
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name VARCHAR(255) NOT NULL,\n\
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP\n\
-)") ~name:"create_example" ~kind:Sqlgg_traits.Query.(Create "example") ()) T.no_params
+)") ~name:"create_example" ~kind:Sqlgg_traits.Query.(Create "example") ())
 
   let select_1 db ~x callback =
     let invoke_callback stmt =
@@ -21,10 +21,10 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
     T.select db (Sqlgg_traits.Query.make ~sql:("SELECT id FROM example WHERE " ^ (match x with [] -> "FALSE" | _ :: _ -> "(name, id) IN " ^ "(" ^ (let _sqlgg_b = Buffer.create 13 in List.iteri (fun _sqlgg_idx (x_0n, x_1n) -> Buffer.add_string _sqlgg_b (if _sqlgg_idx = 0 then "(" else ", ("); Buffer.add_string _sqlgg_b ((fun v -> T.Types.Text.string_to_literal (Name.set_param v)) x_0n); Buffer.add_string _sqlgg_b ", "; Buffer.add_string _sqlgg_b ((fun v -> T.Types.Int.int64_to_literal (ExampleId.set_param v)) x_1n); Buffer.add_char _sqlgg_b ')') x; Buffer.contents _sqlgg_b) ^ ")")) ~name:"select_1" ~kind:Sqlgg_traits.Query.(Select Nat) ()) set_params invoke_callback
 
   let create_example2 db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example2 (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE example2 (\n\
     id INT AUTO_INCREMENT PRIMARY KEY,\n\
     name_2 VARCHAR(255) NOT NULL\n\
-)") ~name:"create_example2" ~kind:Sqlgg_traits.Query.(Create "example2") ()) T.no_params
+)") ~name:"create_example2" ~kind:Sqlgg_traits.Query.(Create "example2") ())
 
   let select_3 db ~name ~name_2 ~id callback =
     let invoke_callback stmt =

--- a/test/cram/type_unreserved.t
+++ b/test/cram/type_unreserved.t
@@ -129,7 +129,7 @@ produce a bare `type` keyword clash):
     module IO = Sqlgg_io.Blocking
   
     let create_kw db  =
-      T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw (type INT NOT NULL)") ~name:"create_kw" ~kind:Sqlgg_traits.Query.(Create "kw") ()) T.no_params
+      T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE kw (type INT NOT NULL)") ~name:"create_kw" ~kind:Sqlgg_traits.Query.(Create "kw") ())
   
     let select_1 db  callback =
       let invoke_callback stmt =

--- a/test/cram/where_in_composable.compare.ml
+++ b/test/cram/where_in_composable.compare.ml
@@ -3,11 +3,11 @@ module Sqlgg (T : Sqlgg_traits.M) = struct
   module IO = Sqlgg_io.Blocking
 
   let create_random_table_1 db  =
-    T.execute db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS random_table_1 (\n\
+    T.execute_unprepared db (Sqlgg_traits.Query.make ~sql:("CREATE TABLE IF NOT EXISTS random_table_1 (\n\
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   `id2` int(10) unsigned NOT NULL AUTO_INCREMENT,\n\
   PRIMARY KEY (`id`)\n\
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_random_table_1" ~kind:Sqlgg_traits.Query.(Create "random_table_1") ()) T.no_params
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin") ~name:"create_random_table_1" ~kind:Sqlgg_traits.Query.(Create "random_table_1") ())
 
   let select_1 db ~id ~ids2 callback =
     let invoke_callback stmt =


### PR DESCRIPTION
### Description

This PR bumps ocaml-mariadb to >= 2.1.0, and adds a trait function `execute_unprepared` for statements with
no parameters and no result set (DDL, plain INSERT/UPDATE/DELETE, migrations): one `COM_QUERY` round trip instead of `prepare/execute/close`, and no slot in the statement cache. 

