### PR TITLE
Add foreign keys to xml

### DIFF
--- a/lib/sql.ml
+++ b/lib/sql.ml
@@ -901,8 +901,14 @@ type insert_action =
   on_conflict_clause : conflict_clause located option;
 } [@@deriving show {with_path=false}]
 
+type foreign_key = {
+  fk_cols : string list;
+  fk_ref_table : table_name;
+  fk_ref_cols : string list;
+} [@@deriving show {with_path=false}]
+
 type table_constraints = [ `Ignore | `Primary of string list | `Unique of string option * string list
-  | `Foreign of string list * table_name * string list ] [@@deriving show {with_path=false}]
+  | `Foreign of foreign_key ] [@@deriving show {with_path=false}]
 
 type index_kind  = 
   | Regular_idx

--- a/lib/sql_parser.mly
+++ b/lib/sql_parser.mly
@@ -446,7 +446,7 @@ table_constraint_1:
       | UNIQUE index_or_key? name=ident? l=sequence(key_part) { `Unique (name, l) }
       | FOREIGN KEY ident? cols=sequence(ident) REFERENCES t=table_name refs=sequence(ident)?
         reference_action_clause*
-          { `Foreign (cols, t, Option.default [] refs) }
+          { `Foreign { fk_cols = cols; fk_ref_table = t; fk_ref_cols = Option.default [] refs } }
       | CHECK LPAREN expr RPAREN { `Ignore }
 
 reference_action_clause:

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -1498,7 +1498,7 @@ let with_constraints attrs constraints : Schema.t =
   let constraints_table : (string, Constraints.t) Hashtbl.t = Hashtbl.create (List.length attrs) in
   let inherited : (string, Meta.t option) Hashtbl.t = Hashtbl.create (List.length attrs) in
   constraints |> List.iter begin function
-    | `Foreign (cols, table, refs) ->
+    | `Foreign { Sql.fk_cols = cols; fk_ref_table = table; fk_ref_cols = refs } ->
       let referenced = Tables.with_stored table [] (fun t -> t.columns) in
       let refs = match refs with [] -> Tables.get_primary_key_columns referenced | refs -> refs in
       if List.compare_lengths cols refs = 0 then
@@ -1574,8 +1574,7 @@ let rec eval (stmt:Sql.stmt) =
           default_sql = Alter_action_attr.default_sql col;
         }
       ) schema attrs in
-      Tables.add_columns (name, columns);
-      Tables.add_inline_indexes name ~indexes ~constraints;
+      Tables.create name ~columns ~indexes ~constraints;
       ([],[],Create name)
   | Create (name, Select { value=select; _ }) ->
       let (schema,params,_) = eval_select_full empty_env select in

--- a/lib/tables.ml
+++ b/lib/tables.ml
@@ -26,6 +26,7 @@ type stored_table = {
   tbl_charset : table_charset option;
   tbl_ttl : table_ttl option;
   tbl_indexes : stored_index SMap.t;
+  tbl_foreign_keys : Sql.foreign_key list;
 }
 
 let store : stored_table list ref = ref []
@@ -72,7 +73,11 @@ let check name = ignore (get_stored name)
 
 let add_columns (name, cols) =
   match find_stored name with
-  | None -> store := { name; columns = cols; tbl_charset = None; tbl_ttl = None; tbl_indexes = SMap.empty } :: !store
+  | None ->
+    store :=
+      { name; columns = cols; tbl_charset = None; tbl_ttl = None;
+        tbl_indexes = SMap.empty; tbl_foreign_keys = [] }
+      :: !store
   | Some _ -> table_exists name
 
 let add (name, schema) =
@@ -136,7 +141,11 @@ let index_add_auto name ~kind ~cols =
   alter name (fun t ->
     add_index_record t ~index_name:(synth_index_name t.tbl_indexes cols) ~kind ~cols)
 
-let add_inline_indexes name ~indexes ~constraints =
+let get_foreign_keys name =
+  with_stored name [] (fun table -> table.tbl_foreign_keys)
+
+let create name ~columns ~indexes ~constraints =
+  add_columns (name, columns);
   List.iter (fun (idx : Sql.table_inline_index Sql.located) ->
     let { Sql.idx_name; idx_kind; idx_cols = cols; idx_unique } = idx.value in
     let kind = match idx_kind with
@@ -153,7 +162,9 @@ let add_inline_indexes name ~indexes ~constraints =
       index_add name ~index_name ~kind:Sql.Unique_idx ~cols
     | `Unique (None, (_ :: _ as cols)) ->
       index_add_auto name ~kind:Sql.Unique_idx ~cols
-    | _ -> ()
+    | `Foreign foreign_key ->
+      alter name (fun t -> { t with tbl_foreign_keys = t.tbl_foreign_keys @ [ foreign_key ] })
+    | `Unique (_, []) | `Primary _ | `Ignore -> ()
   ) constraints
 
 let singleton_unique_col (i : stored_index) =

--- a/src/gen_xml.ml
+++ b/src/gen_xml.ml
@@ -142,8 +142,27 @@ let generate_code (x,_) index stmt =
   let nodes = [ input; output] in
   x := Node ("stmt", ("name",name)::("sql",sql)::("category",show_category @@ category_of_stmt_kind stmt.kind)::attrs, nodes) :: !x
 
+let foreign_key_node { Sql.fk_cols; fk_ref_table; fk_ref_cols } =
+  let referenced_columns =
+    match fk_ref_cols with
+    | [] -> []
+    | cols -> [ "referenced_columns", String.concat "," cols ]
+  in
+  let attrs =
+    [ "columns", String.concat "," fk_cols;
+      "references", Sql.show_table_name fk_ref_table ]
+    @ referenced_columns
+  in
+  Node ("foreign_key", attrs, [])
+
+let foreign_keys_nodes name =
+  match Tables.get_foreign_keys name with
+  | [] -> []
+  | foreign_keys -> [ Node ("foreign_keys", [], List.map foreign_key_node foreign_keys) ]
+
 let generate_table (x,_) (name,schema) =
-  x := Node ("table", ["name",Sql.show_table_name name], [Node ("schema",[],schema_to_values schema)]) :: !x
+  let schema_node = Node ("schema", [], schema_to_values schema) in
+  x := Node ("table", ["name",Sql.show_table_name name], schema_node :: foreign_keys_nodes name) :: !x
 
 let start_output (x,pre) = pre := !x; x := []
 

--- a/test/out/left_join.xml
+++ b/test/out/left_join.xml
@@ -25,6 +25,9 @@
    <value name="email" type="Text" nullable="true"/>
    <value name="account_type_id" type="Int" nullable="true"/>
   </schema>
+  <foreign_keys>
+   <foreign_key columns="account_type_id" references="account_types" referenced_columns="type_id"/>
+  </foreign_keys>
  </table>
  <table name="account_types">
   <schema>

--- a/test/out/reusable.xml
+++ b/test/out/reusable.xml
@@ -45,6 +45,9 @@
    <value name="price" type="Decimal"/>
    <value name="category_id" type="Int" nullable="true"/>
   </schema>
+  <foreign_keys>
+   <foreign_key columns="category_id" references="categories" referenced_columns="id"/>
+  </foreign_keys>
  </table>
  <table name="categories">
   <schema>

--- a/test/out/subquery.xml
+++ b/test/out/subquery.xml
@@ -54,6 +54,9 @@
    <value name="master_id" type="Int" nullable="true"/>
    <value name="at" type="Datetime" nullable="true"/>
   </schema>
+  <foreign_keys>
+   <foreign_key columns="master_id" references="master" referenced_columns="id"/>
+  </foreign_keys>
  </table>
  <table name="master">
   <schema>

--- a/test/out/subquery_res_expr.xml
+++ b/test/out/subquery_res_expr.xml
@@ -52,6 +52,10 @@
    <value name="col_3_4" type="Int" nullable="true"/>
    <value name="col_3_5" type="Float" nullable="true"/>
   </schema>
+  <foreign_keys>
+   <foreign_key columns="col_3_2" references="tbl_2" referenced_columns="col_2_1"/>
+   <foreign_key columns="col_3_3" references="tbl_1" referenced_columns="col_1_1"/>
+  </foreign_keys>
  </table>
  <table name="tbl_2">
   <schema>


### PR DESCRIPTION
Foreign keys declared in `CREATE TABLE` are now kept in `Tables` and emitted in the XML output as a `<foreign_keys>` block inside `<table>`.

```sql
CREATE TABLE users (id INT PRIMARY KEY);
CREATE TABLE orders (
  id INT PRIMARY KEY,
  user_id INT,
  FOREIGN KEY (user_id) REFERENCES users(id)
);
```

```xml
<table name="orders">
 <schema>
  <value name="id" type="Int"/>
  <value name="user_id" type="Int" nullable="true"/>
 </schema>
 <foreign_keys>
  <foreign_key columns="user_id" references="users" referenced_columns="id"/>
 </foreign_keys>
</table>
```
